### PR TITLE
Add contribution guide, README, and CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,39 @@
+---
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        # Explicitly specifying the testenvs shouldn't really be
+        # necessary here, but for some reason tox invokes no testenvs
+        # at all if invoked as just "tox" from the GitHub Actions
+        # workflow. Until that is fixed, name the testenvs.
+        run: tox -e gitlint,yamllint,build
+      - name: Upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-${{ matrix.python-version }}
+          path: site/
+    strategy:
+      matrix:
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+
+name: Python package
+
+'on':
+  - push
+  - pull_request

--- a/.yamllint
+++ b/.yamllint
@@ -12,5 +12,8 @@ rules:
   document-start:
     level: error
   key-ordering: enable
+  line-length:
+    allow-non-breakable-words: true
+    max: 90
   truthy:
     level: error

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Experimental documentation repository
+
+For the time being, please do not mistake this for anything official
+or supported.

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -1,0 +1,112 @@
+# Contribution Guide
+
+See something on this site that is inaccurate, missing, or that could
+simply be improved? There are multiple ways for you to help make this
+site better, and we welcome all of them.
+
+
+## Markdown
+
+The documentation on this site uses
+[Markdown](https://en.wikipedia.org/wiki/Markdown). Markdown is a
+documentation format that is rich enough to be useful for good
+technical documentation, and yet simpler and easier to learn than
+other formats like
+[reStructuredText](https://en.wikipedia.org/wiki/ReStructuredText) or
+[DocBook](https://en.wikipedia.org/wiki/DocBook) XML.
+
+If you’re unfamiliar with Markdown, you can read up on its basics in
+[this classic article by John
+Gruber](https://daringfireball.net/projects/markdown/) if you’re
+interested, but chances are that you’ll also find all the information
+you’ll need in [this cheat sheet by Adam
+Pritchard](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet),
+or the [Start Writing guide from
+GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+Or you simply look at the source of one of the pages on this site (try
+the Edit button on this one!) and figure it out as you go along — it’s
+really pretty straightforward.
+
+## Modifications to content on this site
+
+You have two options for editing content: directly in your browser
+using GitHub, or using a Git-based workflow from your local work
+environment.
+
+
+### Making contributions from your browser
+
+Every page on this site has an Edit button 🖍️. If you click it, it’ll
+take you straight to the corresponding source page in GitHub. Then,
+you can follow [GitHub’s
+documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository)
+on how to propose changes to another user’s repository.
+
+
+### Making contributions using Git
+
+The Git repository for this site lives at <{{ config.repo_url }}>. You
+can fork that repository, make the proposed changes in your fork, and
+then send us a standard [GitHub pull
+request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
+If you would like to see your changes as you are working on them, you
+can do that with [tox](https://tox.wiki/en/latest/):
+
+```bash
+tox -e serve
+```
+
+A local copy of the documentation will then run on your local machine
+and be accessible from <http://localhost:8000> in your browser.
+
+
+## Quality checks
+
+<!-- GitHub Actions workflows cannot run until the repo is made public. -->
+
+There are a few checks that we apply to the configuration. They run
+automatically via GitHub Actions workflows when you send your PR:
+
+* We check the commit message with
+  [gitlint](https://jorisroovers.com/gitlint/), and enforce the
+  [Conventional
+  Commits](https://www.conventionalcommits.org/en/v1.0.0/) commit
+  message style.
+* We check whether the documentation still builds correctly, with your
+  change applied.
+* We check to make sure that no internal or external links in the
+  documentation are dead. This is one example where the checks might
+  fail through no fault of yours at all — some external link may have
+  disappeared between the most recent change and your contribution, by
+  pure coincidence. When that happens, we’ll fix it together.
+* We check some YAML conventions with
+  [yamllint](https://yamllint.readthedocs.io/en/stable/). However,
+  most contributions would probably only touch Markdown files and not
+  YAML, so you’re unlikely to trip over this.
+
+If you’re working in your local Git repository and your work
+environment has [tox](https://tox.wiki/en/latest/) installed, you can
+also run the checks locally:
+
+```bash
+tox
+```
+
+You can also configure your local checkout to run quality checks on
+each commit. To do that, run:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## License
+
+The content on this site is available under the [Creative Commons
+Attribution-ShareAlike 4.0 International
+license](https://creativecommons.org/licenses/by-sa/4.0/), as you can
+see from the
+![CC BY-SA](https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg)
+icon at the bottom of each page. Please keep in mind that you are
+making your contribution under those terms.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,10 @@
-# Welcome to MkDocs
+# Start Here
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+This is an **experimental** documentation repository.
 
-## Commands
+!!! warning
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+    For the time being, please do not mistake this for anything official
+    or supported.
 
-## Project layout
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ copyright: >
   <a href="https://creativecommons.org/licenses/by-sa/4.0/">
   <img src="https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg"/>
   </a>
+edit_uri: ./edit/main/docs
 plugins:
   - git-authors:
       enabled: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ copyright: >
   <img src="https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg"/>
   </a>
 edit_uri: ./edit/main/docs
+markdown_extensions:
+  - admonition
 plugins:
   - git-authors:
       enabled: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,10 @@
 # Configuration settings in this file should be ordered
 # alphabetically.
 ---
+copyright: >
+  <a href="https://creativecommons.org/licenses/by-sa/4.0/">
+  <img src="https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg"/>
+  </a>
 plugins:
   - git-authors:
       enabled: true


### PR DESCRIPTION
Add information about where the documentation is hosted, and how one can contribute to it.

Also, add a README for those who just stumble upon this repo, and include a GitHub Actions workflow that runs the `tox` tests, so we can enable branch protection.