### PR TITLE
feat: enable PDF output

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,10 +11,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install packages
+        run: |
+          sudo apt-get install weasyprint
+      - name: Install Python dependencies
         run: |
           pip install tox tox-gh-actions
-      - name: Test with tox
+      - env:
+          DOCS_ENABLE_PDF_EXPORT: 1
+        name: Test with tox
         # Explicitly specifying the testenvs shouldn't really be
         # necessary here, but for some reason tox invokes no testenvs
         # at all if invoked as just "tox" from the GitHub Actions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ plugins:
       raise_error: true
       validate_external_urls: true
   - macros
+  - pdf-export:
+      enabled_if_env: DOCS_ENABLE_PDF_EXPORT
   - search
 repo_url: https://github.com/citynetwork/docs
 site_name: "Replace This Placeholder Before Making This Public"

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = yamllint,build
 [testenv]
 envdir = {toxworkdir}/mkdocs
 skip_install = True
+passenv = DOCS_*
 deps =
   mkdocs
   mkdocs-htmlproofer-plugin
@@ -11,6 +12,7 @@ deps =
   mkdocs-git-revision-date-localized-plugin
   mkdocs-macros-plugin
   mkdocs-material
+  mkdocs-pdf-export-plugin
 commands =
   mkdocs {posargs}
 


### PR DESCRIPTION
Add mkdocs-pdf-export-plugin, which (if Mkdocs is running with the `DOCS_ENABLE_PDF_EXPORT` environment variable set to `1`) renders PDF versions of all pages, and adds a download button right next to the edit button on every page.