### PR TITLE
Add merge SHA into build artifact

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload build
         uses: actions/upload-artifact@v2
         with:
-          name: build-${{ matrix.python-version }}
+          name: build-${{ matrix.python-version }}-${{ github.sha }}
           path: site/
     strategy:
       matrix:


### PR DESCRIPTION
When building artifact, by default the name is always build-version.
This is a problem if you're working on multiple PRs for which
you download the artifact: It's now harder to know who is who.

This fixes it by adding the SHA of the virtual merge commit into
the filename of the artifact.

Closes: #6 