### PR TITLE
feat: Add how-to guides for Barbican

### DIFF
--- a/docs/How-To_Guides/Object_storage/s3-credentials.md
+++ b/docs/How-To_Guides/Object_storage/s3-credentials.md
@@ -1,0 +1,53 @@
+# Working with S3-compatible credentials
+
+When you want to interact with object storage in {{extra.brand}} using
+tools that support an Amazon S3 compatible API (such as `s3cmd`,
+`rclone`, the `aws` CLI, or the Python `boto3` library), you need an
+S3-compatible access key ID and secret key.
+
+
+## Creating credentials
+
+You can create a set of S3-compatible credentials with the following
+command:
+
+```bash
+openstack ec2 credentials create
+```
+
+This will return an `Access` and `Secret` key that you can use to
+populate the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+environment variables (or whichever configuration options your
+application requires).
+
+!!! note
+    Your S3-compatible credentials are always scoped to your
+    {{extra.brand}} *region* and *project*. You cannot reuse an access
+    and secret key across multiple regions or projects.
+
+    Also, your credentials are only “S3-compatible” in the sense that
+    they use the same *format* as AWS S3 does. They are never valid against
+    AWS S3 itself.
+
+
+## Listing credentials
+
+You can list any previously-created credentials with:
+
+```bash
+openstack ec2 credentials list
+```
+
+## Deleting credentials
+
+If at any time you need to delete a set of AWS-compatible credentials,
+you can do so with the following command:
+
+```bash
+openstack ec2 credentials delete <access-key-id>
+```
+
+!!! warning
+
+    Deleting a set of S3-compatible credentials will *immediately*
+    revoke access for any applications that were using it.

--- a/docs/How-To_Guides/Object_storage/sse-c.md
+++ b/docs/How-To_Guides/Object_storage/sse-c.md
@@ -1,0 +1,91 @@
+# Client-side encryption with S3 API (SSE-C)
+
+You can use objects encryption via S3 API, according to the[Amazon
+SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+specification. This means that you need to provide an encryption/decryption key
+with each request to the object.
+
+You can store the encryption key in Barbican, and provide it to the S3
+client at runtime. Below we will provide more detailed explanation
+regarding how to use this in your workloads.
+
+
+## Requirements
+
+This guide assumes familiarity with the following tools:
+
+* `python-openstackclient` (with the `python-barbicanclient` plugin),
+* `pwgen`,
+* `rclone` version 1.54 or later.
+
+
+## Create encryption details
+
+According to SSE-C specification, in order to use server-side
+encryption, any S3 client needs to provide three pieces of
+information, which it includes in the request headers for each S3
+request being made:
+
+* Encryption algorithm: the only valid option here is AES256.
+* Encryption key: a generated random key that we will store in
+  Barbican. It should be valid AES key, which means that key length
+  must be 32 bytes.
+* Encryption key checksum: MD5 checksum of the encryption key. It's
+  used for integrity checks.
+
+In order to generate encryption key and store it in Barbican, proceed
+as follows.
+
+1.  Generate secret:
+
+        secret_raw=$(pwgen 32 1)
+
+2.  Store secret in Barbican:
+
+        barbican_secret_url=$(openstack secret store --name objectSecret --algorithm aes --bit-length 256 --payload ${secret_raw} -f value -c 'Secret href')
+
+3.  Retrieve secret from Barbican:
+
+        secret=$(openstack secret get ${barbican_secret_url} -p -c Payload -f value)
+
+
+## Managing encrypted objects in S3 (with `rclone`)
+
+SSE-C encryption has been implemented/fixed with version 1.54. Prior
+rclone versions won't work here.
+
+1. Download and install the latest rclone for your distribution:
+   <https://rclone.org/downloads/>
+2. Create or retrieve your [access key ID and secret
+   key](s3-credentials.md).
+3. Create a configuration file named `~/.rclone.conf`, with the
+   following content:
+
+        [{{extra.brand|lower|replace(' ','')}}]
+        type = s3
+        provider = Ceph
+        env_auth = false
+        access_key_id = <access key id>
+        secret_access_key = <secret key>
+        endpoint = <region>.{{extra.brand_domain}}:8080
+        acl = private
+        sse_customer_algorithm = AES256
+
+4. Create an S3 bucket:
+
+        rclone mkdir {{extra.brand|lower|replace(' ','')}}:encrypted
+
+5. Sync a directory to the S3 bucket, encrypting the files it
+   contains on upload:
+
+        rclone sync ~/media/ {{extra.brand|lower|replace(' ','')}}:encrypted \
+          --s3-sse-customer-key=${secret}
+
+6. Retrieve a file from S3 and decrypt it:
+
+        rclone copy {{extra.brand|lower|replace(' ','')}}:encrypted/file.png \
+          --s3-sse-customer-key=${secret}
+
+
+For more examples on how to use rclone, please use its reference
+documentation: <https://rclone.org/docs/#subcommands>

--- a/docs/How-To_Guides/OpenStack/Barbican/generic-secret.md
+++ b/docs/How-To_Guides/OpenStack/Barbican/generic-secret.md
@@ -1,0 +1,91 @@
+# Generic secret storage
+
+The simplest way to use Barbican is to create and retrieve a securely
+stored, generic secret.
+
+## How to store a generic secret
+
+It is possible to store any secret data with Barbican. The command
+below will create a secret of the type `passphrase`, named `mysecret`,
+which contains the passphrase `my very secret passphrase`.
+
+```bash
+openstack secret store \
+  --secret-type passphrase \
+  -p "my very secret passphrase" \
+  -n mysecret
+```
+
+!!! note
+
+    The example output below uses {{extra.brand}}’s `Fra1` region. In other
+	regions, the secret 
+	[URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+	will differ.
+
+
+```
++---------------+--------------------------------------------------------------------------------+
+| Field         | Value                                                                          |
++---------------+--------------------------------------------------------------------------------+
+| Secret href   | https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba |
+| Name          | mysecret                                                                       |
+| Created       | None                                                                           |
+| Status        | None                                                                           |
+| Content types | None                                                                           |
+| Algorithm     | aes                                                                            |
+| Bit length    | 256                                                                            |
+| Secret type   | passphrase                                                                     |
+| Mode          | cbc                                                                            |
+| Expiration    | None                                                                           |
++---------------+--------------------------------------------------------------------------------+
+```
+
+Note that `passphrase` type secrets are symmetrically encrypted, using
+the [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
+encryption algorithm with a 256-bit key length. You can select other
+bit lengths and algorithms with the `-b` and `-a` command line
+options, if desired.
+
+## How to retrieve secrets
+
+Secrets are stored in Barbican in an encrypted format. You can see
+a list of secrets created for your user with the following command:
+
+```bash
+openstack secret list
+```
+
+```
++--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
+| Secret href                                                                    | Name     | Created                   | Status | Content types                           | Algorithm | Bit length | Secret type | Mode | Expiration |
++--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
+| https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba | mysecret | 2021-04-29T10:33:18+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | passphrase  | cbc  | None       |
+| https://fra1.{{extra.brand_domain}}:9311/v1/secrets/ad628532-53b8-4d2f-91e5-0097b51da4e | None     | 2021-04-27T13:52:10+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | symmetric   | None | None       |
++--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
+```
+
+You can retrieve the decrypted secret with the `openstack secret get`
+command, adding the `-p` (or `--payload`) option:
+
+```bash
+$ openstack secret get -p \
+  https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba
+```
+
+```
++---------+---------------------------+
+| Field   | Value                     |
++---------+---------------------------+
+| Payload | my very secret passphrase |
++---------+---------------------------+
+```
+
+!!! note
+
+    Unlike many other OpenStack services, which allow you to retrieve
+    object references by name or UUID, Barbican only lets you retrieve
+    secrets by their full
+	[URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
+	That URI must include the
+	`https://<region>.{{extra.brand_domain}}:9311/v1/secrets/` prefix.

--- a/docs/How-To_Guides/OpenStack/Barbican/index.md
+++ b/docs/How-To_Guides/OpenStack/Barbican/index.md
@@ -1,0 +1,25 @@
+# Using Barbican for secret storage
+
+**[Barbican](https://docs.openstack.org/barbican/latest/)** is
+OpenStack's secret storage facility. In {{extra.brand}}, Barbican is
+supported for the following purposes:
+
+* [Generic secret storage](generic-secret.md),
+* [encryption for persistent volumes](../Cinder/encrypted-volumes.md),
+* [certificate storage for HTTPS load balancers](../Octavia/tls-lb.md).
+
+To manage secrets with Barbican, you will need the `openstack` command
+line interface (CLI), and its Barbican plugin. You can install them
+both with the following commands:
+
+```bash
+pip install python-openstackclient python-barbicanclient
+```
+
+On Debian/Ubuntu platforms, you may also install these utilities via
+their APT packages:
+
+```bash
+apt install python3-openstackclient python3-barbicanclient
+```
+

--- a/docs/How-To_Guides/OpenStack/Barbican/share-secret.md
+++ b/docs/How-To_Guides/OpenStack/Barbican/share-secret.md
@@ -1,0 +1,41 @@
+# Sharing secrets via ACLs
+
+Normally, a Barbican secret is only available to the OpenStack API
+user that created it. However, under some circumstances it may be
+desirable to make a secret available to another user.
+
+To do so, you will need
+
+* the secret’s
+  [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier),
+* the other user’s OpenStack API user ID.
+
+!!! hint
+
+    Any {{extra.brand}} user can always retrieve their own user ID
+	with the following command:
+
+	```
+	openstack token issue -f value -c user_id
+	```
+
+Once you have assembled this information, you can proceed with the
+`openstack acl user add` command:
+
+```bash
+openstack acl user add \
+  --user <user_id> \
+  --operation-type read \
+  https://region.{{extra.brand_domain}}:9311/v1/secrets/<secret_id>
+```
+
+If you want to unshare the secret again, you simply use the
+corresponding `openstack acl user remove` command:
+
+```bash
+openstack acl user remove \
+  --user <user_id> \
+  --operation-type read \
+  https://region.{{extra.brand_domain}}:9311/v1/secrets/<secret_id>
+```
+

--- a/docs/How-To_Guides/OpenStack/Cinder/encrypted-volumes.md
+++ b/docs/How-To_Guides/OpenStack/Cinder/encrypted-volumes.md
@@ -1,0 +1,157 @@
+# Encrypted volumes
+
+When using Barbican for block storage encryption, you ensure that data
+in persistent storage volumes is stored in an encrypted fashion.
+
+That encryption is transparent to virtual machines (instances) that
+you attach the volume to.
+
+
+## Creating an encrypted volume
+
+For the creation of an encrypted volume, you need to provide a
+specific *volume type.* You can retrieve the list of available volume
+types with the following command:
+
+```bash
+openstack volume type list
+```
+```
++--------------------------------------+-----------------------+-----------+
+| ID                                   | Name                  | Is Public |
++--------------------------------------+-----------------------+-----------+
+| a479a6b0-b283-41a5-b38b-5b08e7f902ca | volumes_hdd_encrypted | True      |
+| d9dfa98a-238d-4ca0-9abf-701fceb05623 | __DEFAULT__           | True      |
+| 86796611-fb12-4628-b6b1-e09469e301d7 | volumes_hdd           | True      |
++--------------------------------------+-----------------------+-----------+
+```
+
+!!! hint
+
+	In {{extra.brand}}, all volume types that support encryption use
+	the suffix `_encrypted`.
+
+To create a volume with encryption, you need to explicitly specify the
+`--type` option to the `openstack volume create` command. The
+following example creates a volume using the `volumes_hdd_encrypted`
+type, naming it `enc_drive` and setting its size to 10 GiB:
+
+```bash
+openstack volume create \
+  --type volumes_hdd_encrypted \
+  --size 10 \
+  enc_drive
+```
+```
++---------------------+--------------------------------------+
+| Field               | Value                                |
++---------------------+--------------------------------------+
+| attachments         | []                                   |
+| availability_zone   | nova                                 |
+| bootable            | false                                |
+| consistencygroup_id | None                                 |
+| created_at          | 2021-04-27T13:52:10.000000           |
+| description         | None                                 |
+| encrypted           | True                                 |
+| id                  | 33211b21-8d4f-48e9-b76f-ec73ffd19def |
+| multiattach         | False                                |
+| name                | enc_drive                            |
+| properties          |                                      |
+| replication_status  | None                                 |
+| size                | 10                                   |
+| snapshot_id         | None                                 |
+| source_volid        | None                                 |
+| status              | creating                             |
+| type                | volumes_hdd_encrypted                |
+| updated_at          | None                                 |
+| user_id             | 966ad341f4e14920b5f589f900246ccc     |
++---------------------+--------------------------------------+
+```
+
+Upon volume creation, this will create a one-off encryption key, which
+is stored in Barbican and applies to this one volume only. In other
+words, the key created for this volume will be unable to decrypt any
+other volumes except the one it was created for.
+
+
+## Retrieving a volume’s encryption key
+
+Once you have created an encrypted volume, you may retrieve a
+reference to the Barbican secret that represents its encryption
+key. You do this with the following command:
+
+```bash
+openstack volume show \
+  --os-volume-api-version 3.66 \
+  -f value \
+  -c encryption_key_id \
+  enc_drive
+```
+
+Instead of the volume name, you can of course also specify its UUID:
+
+```bash
+openstack volume show \
+  --os-volume-api-version 3.66 \
+  -f value \
+  -c encryption_key_id \
+  33211b21-8d4f-48e9-b76f-ec73ffd19def
+```
+
+
+## Deleting an encrypted volume
+
+When you decide you no longer need an encrypted volume and want to
+delete it, you can do so with the `openstack volume delete`
+command. As long as you do this with the same user account as the one
+that created the volume, this will succeed without further
+intervention.
+
+However, if you are trying to delete a volume that was created by a
+different user, you’ll run into the limitation that the *secret*
+associated with the volume is owned by that user. As a result, the
+deletion of the encrypted volume using your own user credentials will
+fail.
+
+There are two options to work around this limitation:
+
+1. You can switch to the user credentials of the user that created the
+   volume (if you have access to them), and proceed with the deletion.
+2. You can ask the user that created the volume to [add you to the
+   Access Control List (ACL) for the
+   secret](../Barbican/share-secret.md). This will enable you to read
+   the secret, and to delete the volume using your own credentials.
+
+
+## Block device encryption caveats
+
+Once a volume is configured to use encryption and is also attached to
+an instance in {{extra.brand}}, some caveats apply that you might want
+to keep in mind.
+
+Sometimes, automatically or through administrator intervention, we
+move one of your instances to another physical machine. This process
+is known as *live migration,* and it normally does not interrupt the
+instance’s functionality at all — typically, neither you nor the
+application users notice that live migration has even happened. This
+is a very common occurrence when we do routine upgrades of the
+{{extra.brand}} platform, during our pre-announced maintenance windows.
+
+The same considerations apply to physical node failure. If the
+physical machine running your instance fails, we can automatically
+recover it onto another machine — an action known as *evacuation.*
+
+Live migration or evacuation *including encrypted volumes* does,
+however, require that whoever does the migration also has at least
+read access to the volume’s encryption secret.
+
+This means that you have two options:
+
+1. If you *do* trust us to include your instances in live migrations
+   and evacuations, even if they attach encrypted volumes, then you
+   can [add our administrative account to the Access Control List
+   (ACL) for your secrets](../Barbican/share-secret.md).
+2. If you *don’t* want to share your secrets but you still want to use
+   encrypted volumes, you should build your own mechanism or process
+   (preferably automated) so that your instances recover in case they
+   become non-functional.

--- a/docs/How-To_Guides/OpenStack/Octavia/tls-lb.md
+++ b/docs/How-To_Guides/OpenStack/Octavia/tls-lb.md
@@ -1,0 +1,117 @@
+# HTTPS-terminating load balancers
+
+In {{extra.brand}}’s load balancing service, [OpenStack
+Octavia](https://docs.openstack.org/octavia), you can configure load
+balancers so that they manage HTTPS termination. That is to say that
+the load balancer encrypts and decrypts HTTPS traffic, and forwards
+HTTP to and from a backend web server.
+
+To do so, the load balancer must have access to encryption credentials
+(such as certificates and private keys), which it stores in Barbican.
+
+
+## PKCS #12 Certificate Bundles
+
+The [PKCS #12](https://en.wikipedia.org/wiki/PKCS_12) archive format
+includes SSL certificates, certificate chains, and private keys all in
+one bundle. Most certificate providers give you the option of
+downloading certificate credentials using the PKCS #12 format.
+
+In case your certificate provider has made your certificate chain and
+key available seperately, using the PEM format, you can easily convert
+it to PKCS #12 using the following `openssl` command:
+
+```
+openssl pkcs12 -export -inkey key.pem -in fullchain.pem -out bundle.p12
+```
+
+When prompted for an export password, use a blank one.
+
+
+## Creating Barbican secrets from PKCS #12 bundles
+
+To create a secret from a stored PKCS #12 bundle, you need pass in the
+contents of the bundle, *pre-encoded with
+[Base64](https://en.wikipedia.org/wiki/Base64)*, as the secret’s
+payload.
+
+```bash
+openstack secret store \
+  --name='tls_secret1' \
+  -t 'application/octet-stream' \
+  -e 'base64' \
+  --payload="$(base64 < server.p12)"
+```
+```
++---------------+---------------------------------------------------------------------------------+
+| Field         | Value                                                                           |
++---------------+---------------------------------------------------------------------------------+
+| Secret href   | https://kna1.citycloud.com:9311/v1/secrets/69bd82f5-60c9-4764-99ec-7a3dff05d2aa |
+| Name          | tls_secret1                                                                     |
+| Created       | None                                                                            |
+| Status        | None                                                                            |
+| Content types | {'default': 'application/octet-stream'}                                         |
+| Algorithm     | aes                                                                             |
+| Bit length    | 256                                                                             |
+| Secret type   | opaque                                                                          |
+| Mode          | cbc                                                                             |
+| Expiration    | None                                                                            |
++---------------+---------------------------------------------------------------------------------+
+```
+
+## Creating HTTPS-enabled load balancer listeners
+
+Once you have created your secret containing your certificate data,
+you can create a load balancer *listener* with the following
+properties:
+
+* It uses the `TERMINATED_HTTPS` protocol,
+* It sets its “default TLS container” to the Barbican secret
+  containing the PKCS #12 bundle,
+* It listens on the standard HTTPS port, 443.
+
+
+You create such a listener with the following command:
+
+```bash
+openstack loadbalancer listener create \
+  --protocol-port 443 \
+  --protocol TERMINATED_HTTPS \
+  --name listener1 \
+  --default-tls-container=https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae  \
+  <loadbalancer-name-or-id>
+```
+```
++-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Field                       | Value                                                                                                                                                                                                                                                                              |
++-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| admin_state_up              | True                                                                                                                                                                                                                                                                               |
+| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
+| created_at                  | 2021-01-20T11:51:46                                                                                                                                                                                                                                                                |
+| default_pool_id             | None                                                                                                                                                                                                                                                                               |
+| default_tls_container_ref   | https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae                                                                                                                                                                                                    |
+| description                 |                                                                                                                                                                                                                                                                                    |
+| id                          | 4ec6b23d-d08a-4de0-9e12-54ac690ee1ec                                                                                                                                                                                                                                               |
+| insert_headers              | None                                                                                                                                                                                                                                                                               |
+| l7policies                  |                                                                                                                                                                                                                                                                                    |
+| loadbalancers               | 2c2a0760-c3a8-48d2-bdd0-288c3d33a43f                                                                                                                                                                                                                                               |
+| name                        | listener1                                                                                                                                                                                                                                                                          |
+| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
+| project_id                  | 4a9484063d4c40d29301ad745c0e2c69                                                                                                                                                                                                                                                   |
+| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
+| protocol_port               | 443                                                                                                                                                                                                                                                                                |
+| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
+| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
+| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
+| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
+| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
+| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
+| updated_at                  | None                                                                                                                                                                                                                                                                               |
+| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
+| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
+| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
+| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
+| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
+| tls_versions                |                                                                                                                                                                                                                                                                                    |
++-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```


### PR DESCRIPTION
Expand the how-to guides section with information on

* How to use Barbican for generic secret storage
* How to share and unshare Barbican secrets
* How to use Barbican for encrypted volumes
* How to use Barbican for HTTPS termination in Octavia
* How to use Barbican for SSE-C against Ceph-backed S3