### PR TITLE
feat: Add facility to convert documents with pandoc

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
         # necessary here, but for some reason tox invokes no testenvs
         # at all if invoked as just "tox" from the GitHub Actions
         # workflow. Until that is fixed, name the testenvs.
-        run: tox -e gitlint,yamllint,build
+        run: tox -e gitlint,yamllint,bashate,build
       - name: Upload build
         uses: actions/upload-artifact@v2
         with:

--- a/docs/How-To_Guides/Object_storage/s3-credentials.md
+++ b/docs/How-To_Guides/Object_storage/s3-credentials.md
@@ -20,14 +20,13 @@ populate the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 environment variables (or whichever configuration options your
 application requires).
 
-!!! note
-    Your S3-compatible credentials are always scoped to your
-    {{extra.brand}} *region* and *project*. You cannot reuse an access
-    and secret key across multiple regions or projects.
-
-    Also, your credentials are only “S3-compatible” in the sense that
-    they use the same *format* as AWS S3 does. They are never valid against
-    AWS S3 itself.
+> Your S3-compatible credentials are always scoped to your
+> {{extra.brand}} *region* and *project*. You cannot reuse an access
+> and secret key across multiple regions or projects.
+>
+> Also, your credentials are only “S3-compatible” in the sense that
+> they use the same *format* as AWS S3 does. They are never valid against
+> AWS S3 itself.
 
 
 ## Listing credentials
@@ -47,7 +46,5 @@ you can do so with the following command:
 openstack ec2 credentials delete <access-key-id>
 ```
 
-!!! warning
-
-    Deleting a set of S3-compatible credentials will *immediately*
-    revoke access for any applications that were using it.
+> Deleting a set of S3-compatible credentials will *immediately*
+> revoke access for any applications that were using it.

--- a/docs/How-To_Guides/OpenStack/Barbican/generic-secret.md
+++ b/docs/How-To_Guides/OpenStack/Barbican/generic-secret.md
@@ -16,12 +16,10 @@ openstack secret store \
   -n mysecret
 ```
 
-!!! note
-
-    The example output below uses {{extra.brand}}’s `Fra1` region. In other
-	regions, the secret 
-	[URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-	will differ.
+> The example output below uses {{extra.brand}}’s `Fra1` region. In
+> other regions, the secret
+> [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+> will differ.
 
 
 ```
@@ -81,11 +79,9 @@ $ openstack secret get -p \
 +---------+---------------------------+
 ```
 
-!!! note
-
-    Unlike many other OpenStack services, which allow you to retrieve
-    object references by name or UUID, Barbican only lets you retrieve
-    secrets by their full
-	[URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
-	That URI must include the
-	`https://<region>.{{extra.brand_domain}}:9311/v1/secrets/` prefix.
+> Unlike many other OpenStack services, which allow you to retrieve
+> object references by name or UUID, Barbican only lets you retrieve
+> secrets by their full
+> [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
+> That URI must include the
+> `https://<region>.{{extra.brand_domain}}:9311/v1/secrets/` prefix.

--- a/docs/How-To_Guides/OpenStack/Barbican/share-secret.md
+++ b/docs/How-To_Guides/OpenStack/Barbican/share-secret.md
@@ -10,14 +10,12 @@ To do so, you will need
   [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier),
 * the other user’s OpenStack API user ID.
 
-!!! hint
-
-    Any {{extra.brand}} user can always retrieve their own user ID
-	with the following command:
-
-	```
-	openstack token issue -f value -c user_id
-	```
+> Any {{extra.brand}} user can always retrieve their own user ID
+> with the following command:
+>
+> ```
+> openstack token issue -f value -c user_id
+> ```
 
 Once you have assembled this information, you can proceed with the
 `openstack acl user add` command:
@@ -38,4 +36,3 @@ openstack acl user remove \
   --operation-type read \
   https://region.{{extra.brand_domain}}:9311/v1/secrets/<secret_id>
 ```
-

--- a/docs/How-To_Guides/OpenStack/Cinder/encrypted-volumes.md
+++ b/docs/How-To_Guides/OpenStack/Cinder/encrypted-volumes.md
@@ -26,10 +26,8 @@ openstack volume type list
 +--------------------------------------+-----------------------+-----------+
 ```
 
-!!! hint
-
-	In {{extra.brand}}, all volume types that support encryption use
-	the suffix `_encrypted`.
+> In {{extra.brand}}, all volume types that support encryption use the
+> suffix `_encrypted`.
 
 To create a volume with encryption, you need to explicitly specify the
 `--type` option to the `openstack volume create` command. The

--- a/docs/Tutorials/index.md
+++ b/docs/Tutorials/index.md
@@ -19,8 +19,6 @@ This section does *not* include detailed walkthroughs of specific
 technical tasks. For those, please see our [How-To
 Guides](../How-To_Guides/index.md) section.
 
-!!! note
-
-    If you find our tutorials helpful, you might also be interested in our
-	self-paced online training courses, available from
-	[our course booking site](https://shop.{{config.extra.company_domain}}).
+> If you find our tutorials helpful, you might also be interested in
+> our self-paced online training courses, available from [our course
+> booking site](https://shop.{{config.extra.company_domain}}).

--- a/docs/You_Can_Help!/index.md
+++ b/docs/You_Can_Help!/index.md
@@ -1,10 +1,8 @@
 # Contribution Guide
 
-!!! question
-
-    See something on this site that is inaccurate, missing, or that could
-	simply be improved? There are multiple ways for you to help make this
-	site better, and we welcome all of them.
+See something on this site that is inaccurate, missing, or that could
+simply be improved? There are multiple ways for you to help make this
+site better, and we welcome all of them.
 
 
 ## Markdown

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,7 @@
 
 This is an **experimental** documentation repository.
 
-!!! warning
-
-    For the time being, please do not mistake this for anything official
-    or supported.
+> For the time being, please do not mistake this for anything official
+> or supported.
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,7 @@ extra:
   brand_domain: "citycloud.com"
   company: "City Network"
   company_domain: "citynetwork.eu"
-markdown_extensions:
-  - admonition
+markdown_extensions: []
 plugins:
   - git-authors:
       enabled: true

--- a/pandoc/README.md
+++ b/pandoc/README.md
@@ -1,0 +1,9 @@
+This directory is meant to be used as a Pandoc user data directory,
+i.e. something to be referenced with `pandoc`’s `--data-dir` option.
+
+This directory can include, among others,
+
+* a `reference.odt` template for use with `pandoc -t odt` (for
+  OpenDocument Text output, as used by LibreOffice),
+* a `reference.docx` template for use with `pandoc -t docx` (for
+  Microsoft Word documents).

--- a/scripts/from-markdown.sh
+++ b/scripts/from-markdown.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# from-markdown.sh — a wrapper script to convert Markdown to
+# Pandoc-supported output formats
+
+set -e
+
+usage() {
+    echo "Usage: $0 [-t format] [-o outfile] infile..." >&2
+}
+
+output="-"
+format="docx"
+
+while getopts "o:t:h" opt; do
+    case "${opt}" in
+        o)
+            output=${OPTARG}
+            ;;
+        t)
+            format=${OPTARG}
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Concatenate all input files and preprocess them with Jinja2, then
+# feed the result to pandoc on stdin
+tempmd=`mktemp --suffix .md`
+cat $* > $tempmd
+jinja2 $tempmd mkdocs.yml \
+    | pandoc \
+        --data-dir=pandoc \
+        --no-highlight \
+        -f gfm \
+        -t ${format} \
+        -o ${output} \
+        -i -
+
+# Clean up
+rm $tempmd

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = yamllint,build
+envlist = yamllint,bashate,build
 
 [testenv]
 envdir = {toxworkdir}/mkdocs
@@ -32,6 +32,27 @@ commands =
 [testenv:build]
 commands =
   mkdocs build --strict
+
+[testenv:bashate]
+envdir = {toxworkdir}/bashate
+deps =
+  bashate
+commands =
+  bashate {toxinidir}/scripts/from-markdown.sh
+
+[testenv:to-odt]
+envdir = {toxworkdir}/pandoc
+deps =
+  jinja2-cli[yaml]
+commands =
+  {toxinidir}/scripts/from-markdown.sh -t odt {posargs}
+
+[testenv:to-docx]
+envdir = {toxworkdir}/pandoc
+deps =
+  jinja2-cli[yaml]
+commands =
+  {toxinidir}/scripts/from-markdown.sh -t docx {posargs}
 
 [testenv:gitlint]
 envdir = {toxworkdir}/gitlint


### PR DESCRIPTION
Add a facility to, with relative ease, create OpenDocument Text and Word documents from the original Markdown. To use, run

```
tox -e to-odt -- -o output.odt input1.md input2.md input3.md
```

or

```
tox -e to-docx -- -o output.docx input1.md input2.md input3.md
```

To achieve this, a simple script concatenates the input files, processes them against `mkdocs.yml` using the Jinja2 CLI, and feeds the result to `pandoc` with appropriate command-line options.

For branding, `reference.docx` and `reference.odt` files can be placed into the `pandoc` subdirectory.

Also, add `bashate` testing for the script itself.