### PR TITLE
build: Pass positional arguments into "tox -e serve"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 
 [testenv:serve]
 commands =
-  mkdocs serve
+  mkdocs serve {posargs}
 
 [testenv:test-theme]
 deps =


### PR DESCRIPTION
It's usually helpful to be able to set a non-standard `-a` option to `mkdocs serve`, in order to listen on a different port if port 8000 is
already in use. Thus, pass positional arguments into the `serve` testenv.