### PR TITLE
Upgrade the site from "experimental" to "beta", disable blank content, simplify deployment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           name: build-${{ matrix.python-version }}-${{ github.sha }}
           path: site/
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-
     strategy:
       matrix:
         python-version:
@@ -44,8 +37,14 @@ jobs:
           - '3.9'
           - '3.10'
 
-name: Python package
+name: Build
 
+# We want to run this workflow on each push to a topic branch, and on
+# each pull request. Once we merge to main, we want to run the
+# "deploy" workflow instead.
 'on':
-  - push
-  - pull_request
+  pull_request: {}
+  push:
+    branches:
+      - '!main'
+      - '!gh-pages'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+---
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install Python dependencies
+        run: |
+          pip install tox
+      - env:
+          DOCS_ENABLE_PDF_EXPORT: 1
+        name: Deploy to gh-pages
+        run: tox -e deploy-github
+
+name: Deploy
+
+'on':
+  push:
+    branches:
+      - main

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,7 +1,9 @@
+# TODO: We'll enable the disabled sections as we migrate/create
+# content.
 nav:
   - index.md
-  - concepts
+#  - concepts
   - howto
-  - tutorials
-  - reference
+#  - tutorials
+#  - reference
   - contrib

--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -71,7 +71,8 @@ then send us a standard [GitHub pull
 request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 If you would like to see your changes as you are working on them, you
-can do that with [tox](https://tox.wiki/en/latest/):
+can do that with [tox](https://tox.wiki/en/latest/). Having checked
+out the topic branch with your modifications, run:
 
 ```bash
 tox -e serve

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -13,6 +13,8 @@ focused on a specific cloud technology.
   credentials, the `openstack` client, and/or the native OpenStack
   APIs.
 
+<!-- TODO: we’ll enable these as we migrate content.
+
 * **Kubernetes** How-Tos cover what you can do with a Kubernetes
   cluster on {{config.extra.brand}}.
 
@@ -23,6 +25,7 @@ focused on a specific cloud technology.
   and
   [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
   providers.
+-->
 
 * **Object storage** How-Tos deal with the S3 and Swift object storage
   APIs, and how you can use them for object storage in

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
 # Start Here
 
-This is an **experimental** documentation repository.
+This is the {{extra.brand}} **Beta** documentation web site.
 
-> For the time being, please do not mistake this for anything official
-> or supported.
+> We are currently in the process of migrating our Knowledge Base and
+> other documentation to this site. If you want to help, [here’s
+> how!](contrib/index.md)
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ plugins:
       enabled_if_env: DOCS_ENABLE_PDF_EXPORT
   - search
 repo_url: https://github.com/citynetwork/docs
-site_name: "Docs"
+site_name: "Docs (Beta)"
 theme:
   custom_dir: theme
   favicon: assets/favicon.ico

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,21 @@ commands =
 commands =
   mkdocs build --strict
 
+[testenv:deploy-github]
+passenv =
+  {[testenv]passenv}
+  GITHUB_*
+commands =
+  {[testenv:build]commands}
+  mkdocs gh-deploy {posargs}
+
+[testenv:deploy-gitlab]
+passenv =
+  {[testenv]passenv}
+  CI_*
+commands =
+  mkdocs build --strict --site-dir=public
+
 [testenv:bashate]
 envdir = {toxworkdir}/bashate
 deps =


### PR DESCRIPTION
As we're getting ready to publish this content, throw in a few updates to better reflect its current state:

* It's no longer "experimental" (a moniker that implies that the content might go away any moment), but it's far from complete. So call it "beta".
* Simplify the deployment workflow: rather than relying on a heavyweight external GitHub action, just use `mkdocs gh-deploy` (via a tox testenv).
* Comment out some content that isn't yet ready for general consumption, so it isn't visible in the rendered web site. But leave it in-tree so that interested partners can dive into it.