### PR TITLE
feat: Enable light and dark mode, and detect system setting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,4 +46,13 @@ theme:
   logo: assets/logo.png
   name: material
   palette:
-    scheme: cleura
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/lightbulb-outline
+        name: "Switch to dark mode"
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/lightbulb
+        name: "Switch to light mode"

--- a/theme/assets/stylesheets/cleura-palette.css
+++ b/theme/assets/stylesheets/cleura-palette.css
@@ -1,4 +1,9 @@
-[data-md-color-scheme="cleura"] {
+[data-md-color-scheme="default"] {
+    --md-primary-fg-color: #FF6600;
+    --md-accent-fg-color:  #2643FF;
+}
+
+[data-md-color-scheme="slate"] {
     --md-primary-fg-color: #FF6600;
     --md-accent-fg-color:  #2643FF;
 }


### PR DESCRIPTION
Being able to switch between light and dark mode is not a gimmick; it's an accessibility issue: people living with migraines often find it extremely uncomfortable and/or painful to look at large bright white areas on their screen.

Thus, add a light/dark mode switch, and also detect the global system or browser setting to provide a reasonable default.