### PR TITLE
build: Add CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.cleura.cloud


### PR DESCRIPTION
GitHub Pages custom domains are meant to be enabled in one of two ways: via the repository settings (Settings → Code and automation → Pages → Custom domain), or via a `CNAME` file in the root of the repository's `gh-pages` branch.

It appears that the former option is not working, in the sense that it gets cleared on every deployment run. This, then, results in the site effectively disappearing (i.e. producing HTTP 404s).

Thus, opt for the latter option and do use the `CNAME` file.