### PR TITLE
fix: IPv6 in compliant

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -40,7 +40,7 @@
 |                      | Sto1HS           | Sto2HS           |
 | -------------------- | ---------------- | ---------------- |
 | IPv4 (with NAT)      | :material-check: | :material-check: |
-| IPv6                 | :material-check: | :material-check: |
+| IPv6                 | :material-close: | :material-close: |
 | VPN (IPsec with PSK) | :material-check: | :material-check: |
 
 


### PR DESCRIPTION
sto1hs and sto2hs have no IPv6 support yet
this work is not prioritized as of today