### PR TITLE
feat: Add Kubernetes cluster management to feature support matrix

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -51,3 +51,9 @@
 | Application layer (HTTPS, with secrets management for TLS certificates) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
+## Kubernetes management
+
+|                   | Kna1                  | Sto2                  | Fra1                  | Dx1              | Tky1             |
+| ----------------- | ----------------      | ----------------      | ----------------      | ---------------- | ---------------- |
+| OpenStack Magnum  | :material-check:      | :material-check:      | :material-check:      | :material-check: | :material-check: |
+| Gardener          | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: |


### PR DESCRIPTION
Since the closed beta for Gardener in Public Cloud is now underway, mention it as a feature that is in deployment, but not yet supported.

Simultaneously, also add Magnum to the feature matrix, which has been officially supported since 2018.

Reference:
https://cleura.com/press-releases/city-network-launches-container-service-in-city-cloud-with-kubernetes-in-focus/