### PR TITLE
feat: Enable the Python-Markdown SmartyPants extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+  - smarty
   - tables
 plugins:
   - awesome-pages


### PR DESCRIPTION
SmartyPants adds a few clever typography features to Markdown, such as intelligently turning "straight quotes" into “curly quotes”, three dashes (---) into one em dash (—), and three dots (...) into ellipsis (…).

Reference:
https://python-markdown.github.io/extensions/smarty/