### PR TITLE
fix: Add missing word in contribution guide heading

### DIFF
--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -14,7 +14,7 @@ documentation](https://docs.github.com/en/repositories/working-with-files/managi
 on how to propose changes to another user’s repository.
 
 
-## Modifying using Git
+## Modifying content using Git
 
 The Git repository for this site lives at <{{ config.repo_url }}>. You
 can [fork that


### PR DESCRIPTION
In the review for PR #39, we missed a missing word ("content") in a
section heading. Add it.
