### PR TITLE
chore: Update .mailmap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install packages
         run: |
-          sudo apt-get install weasyprint
+          sudo apt-get update
+          sudo apt-get -y install weasyprint
       - name: Install Python dependencies
         run: |
           pip install tox tox-gh-actions

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,15 @@
 # For the purpose of this file, see:
 # https://timvink.github.io/mkdocs-git-authors-plugin/mailmap.html
-Florian Haas <florian@cleura.com> <florian@citynetwork.eu>
+Christos Varelas <christos.varelas@citynetwork.eu>
+Christos Varelas <christos.varelas@cleura.com>
+Dmitriy Rabotyagov <dmitriy.rabotyagov@citynetwork.eu>
+Dmitriy Rabotyagov <dmitriy.rabotyagov@cleura.com>
+Eliott Trouillet <53047591+packettoobig@users.noreply.github.com>
+Florian Haas <florian@citynetwork.eu>
+Florian Haas <florian@cleura.com>
+Foad Lind <foad.lind@citynetwork.eu>
+Foad Lind <foad.lind@cleura.com>
+Mateusz Guziak <mateusz.guziak@cleura.com>
+Mateusz Guziak <skipper126@interia.pl>
+Namrata Sitlani <namrata.sitlani@citynetwork.eu>
+Namrata Sitlani <namrata.sitlani@cleura.com>


### PR DESCRIPTION
Having added a few more contributors as of late, all of whom have both cleura.com and citynetwork.eu addresses, update the .mailmap file so as to keep the mkdocs-git-authors plugin happy.

Also, fix the GitHub Actions workflow definition to more reliably install the `weasyprint` package, by running `apt-get update` before `apt-get install`.
