### PR TITLE
build: Use environment variable for toggling htmlproofer

### DIFF
--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -85,4 +85,13 @@ tox -e serve
 A local copy of the documentation will then run on your local machine
 and be accessible from <http://localhost:8000> in your browser.
 
+When you are planning to make several changes in rapid succession, you
+may want to speed up rendering the site after each change. You may do
+so by disabling a plugin that checks all links (including external
+links) for accessibility:
 
+```bash
+cd {{ config.extra.brand | lower }}-docs
+export DOCS_ENABLE_HTMLPROOFER=false
+tox -e serve
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ plugins:
       type: iso_date
   - glightbox
   - htmlproofer:
+      # yamllint disable-line rule:truthy
+      enabled: !ENV [DOCS_ENABLE_HTMLPROOFER, True]
       raise_error: true
       validate_external_urls: true
   - macros


### PR DESCRIPTION
The htmlproofer plugin increases documentation build times nearly tenfold. This may be undesirable when making quick changes while running `tox -e serve`. Thus, introduce an environment variable, `DOCS_ENABLE_HTMLPROOFER`, and disable the plugin if it is set to `false`.[^1]

Since this means that `mkdocs.yml` no longer contains `true` or `false` for a boolean variable, disable the yamllint `truthy` check for that line.[^2]

Also, update the contribution guide to that effect.

[^1]: https://www.mkdocs.org/user-guide/configuration/#environment-variables
[^2]: https://yamllint.readthedocs.io/en/stable/disable_with_comments.html#disabling-checks-for-a-specific-line
