### PR TITLE
feat: Update feature support matrix with links to encryption howtos

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -20,19 +20,20 @@
 
 ## Block storage
 
-|                                | Sto1HS           | Sto2HS           |
-| ------------------------------ | ---------------- | ---------------- |
-| Highly available storage       | :material-check: | :material-check: |
-| High-performance local storage | :material-close: | :material-close: |
+|                                                                 | Sto1HS           | Sto2HS           |
+| ------------------------------                                  | ---------------- | ---------------- |
+| Highly available storage                                        | :material-check: | :material-check: |
+| High-performance local storage                                  | :material-close: | :material-close: |
+| [Volume encryption](/howto/openstack/cinder/encrypted-volumes/) | :material-check: | :material-check: |
 
 
 ## Object storage
 
-|                                | Sto1HS           | Sto2HS           |
-| ------------------------------ | ---------------- | ---------------- |
-| S3 API                         | :material-check: | :material-check: |
-| S3 SSE-C                       | :material-check: | :material-check: |
-| Swift API                      | :material-check: | :material-check: |
+|                                                         | Sto1HS           | Sto2HS           |
+| ------------------------------                          | ---------------- | ---------------- |
+| S3 API                                                  | :material-check: | :material-check: |
+| S3 [SSE-C](S3 [SSE-C](/howto/object-storage/s3/sse-c/)) | :material-check: | :material-check: |
+| Swift API                                               | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)
@@ -46,8 +47,8 @@
 
 ## Load Balancers 
 
-|                                                                         | Sto1HS           | Sto2HS           |
-| --------------------------------------------------------------------    | ---------------- | ---------------- |
-| Transport layer (TCP/UDP)                                               | :material-check: | :material-check: |
-| Application layer (HTTP)                                                | :material-check: | :material-check: |
-| Application layer (HTTPS, with secrets management for TLS certificates) | :material-check: | :material-check: |
+|                                                                                                             | Sto1HS           | Sto2HS           |
+| --------------------------------------------------------------------                                        | ---------------- | ---------------- |
+| Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: |
+| Application layer (HTTP)                                                                                    | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](/howto/openstack/octavia/tls-lb/)) | :material-check: | :material-check: |

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -18,19 +18,21 @@
 
 ## Block storage
 
-|                                | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| ------------------------------ | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| Highly available storage       | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| High-performance local storage | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: |
+|                                                                 | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
+| ------------------------------                                  | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| Highly available storage                                        | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| High-performance local storage                                  | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: |
+| [Volume encryption](/howto/openstack/cinder/encrypted-volumes/) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+
 
 
 ## Object storage
 
-|                                | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| ------------------------------ | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| S3 API                         | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
-| S3 SSE-C                       | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
-| Swift API                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
+|                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
+| ------------------------------              | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| S3 API                                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
+| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
+| Swift API                                   | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
 
 
 ## Networking (Layer 2/3)
@@ -44,11 +46,11 @@
 
 ## Load Balancers 
 
-|                                                                         | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| --------------------------------------------------------------------    | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| Transport layer (TCP/UDP)                                               | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer (HTTP)                                                | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer (HTTPS, with secrets management for TLS certificates) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+|                                                                                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
+| --------------------------------------------------------------------                                        | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| Application layer (HTTP)                                                                                    | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](/howto/openstack/octavia/tls-lb/)) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Kubernetes management


### PR DESCRIPTION
Update the feature support matrix in the reference section with links
to Barbican-related how-to guides (for volume encryption, S3 SSE-C,
and HTTPS termination in Octavia).
