### PR TITLE
build: Don't show email addresses for authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,15 +1,12 @@
 # For the purpose of this file, see:
 # https://timvink.github.io/mkdocs-git-authors-plugin/mailmap.html
-Christos Varelas <christos.varelas@citynetwork.eu>
+Christos Varelas <christos.varelas@cleura.com> <christos.varelas@citynetwork.eu>
 Christos Varelas <christos.varelas@cleura.com>
-Dmitriy Rabotyagov <dmitriy.rabotyagov@citynetwork.eu>
-Dmitriy Rabotyagov <dmitriy.rabotyagov@cleura.com>
+Dmitriy Rabotyagov <dmitriy.rabotyagov@cleura.com> <dmitriy.rabotyagov@citynetwork.eu>
 Eliott Trouillet <53047591+packettoobig@users.noreply.github.com>
-Florian Haas <florian@citynetwork.eu>
-Florian Haas <florian@cleura.com>
-Foad Lind <foad.lind@citynetwork.eu>
-Foad Lind <foad.lind@cleura.com>
-Mateusz Guziak <mateusz.guziak@cleura.com>
-Mateusz Guziak <skipper126@interia.pl>
-Namrata Sitlani <namrata.sitlani@citynetwork.eu>
-Namrata Sitlani <namrata.sitlani@cleura.com>
+Florian Haas <florian@cleura.com> <florian@citynetwork.eu>
+Florian Haas <florian@cleura.com> <florian.haas@cleura.com>
+Foad Lind <foad.lind@cleura.com> <foad.lind@citynetwork.eu>
+Jean-Philippe Evrard <evrardjp@users.noreply.github.com> <open-source@a.spamming.party>
+Mateusz Guziak <mateusz.guziak@cleura.com> <skipper126@interia.pl>
+Namrata Sitlani <namrata.sitlani@cleura.com> <namrata.sitlani@citynetwork.eu>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ plugins:
   - awesome-pages
   - git-authors:
       enabled: true
+      show_email_address: false
   - git-revision-date-localized:
       enable_creation_date: true
       enabled: true

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = DOCS_*
 deps =
   mkdocs
   mkdocs-awesome-pages-plugin
-  mkdocs-git-authors-plugin
+  mkdocs-git-authors-plugin>=0.6.5
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox
   mkdocs-htmlproofer-plugin


### PR DESCRIPTION
Since version 0.6.5, the git-authors plugin has the option of only showing the author's name(s), rather than rendering them as a
`mailto:` link. Since we want to list contributors but don't want to open them to spam, set the `show_email_address` option to `false`.

Also, fix up the `.mailmap` file so author identities are properly merged, and every person shows up as an author only once for every page (in other words, we avoid listings like "John Doe, Emily Example, John Doe" under a page).
