### PR TITLE
Add beta disclaimer and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/functional_bug.md
+++ b/.github/ISSUE_TEMPLATE/functional_bug.md
@@ -1,0 +1,63 @@
+---
+name: Functional Bug
+about: Use this template to report functionally incorrect or misleading documentation.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Summary
+
+Replace this with a short summary (one sentence or short paragraph) of
+the issue you are describing.
+
+## Affected paths
+
+List the URL(s) where you found inaccurate information. You can use
+URLs from [the rendered site](https://docs.cleura.cloud) or from [the
+sources on GitHub](https://github.com/citynetwork/docs), either is
+fine.
+
+## What I did
+
+Explain the steps you undertook that produced results that are
+inconsistent with the documentation, or that led to errors when you
+followed the documentation.
+
+It’s OK to remove or mask credentials, but otherwise try to err on the
+side of sharing more rather than less information.
+
+## What I expected to observe
+
+Explain how you expected a service to behave, based on the
+documentation you used.
+
+## What I actually observed
+
+Explain how the service behaved differently.
+
+## My environment
+
+Please add some information about the environment that you’re working
+in. At a minimum, include these items:
+
+* Browser: (Insert the web browser name and version you are using.)
+* Operating system: (Insert the OS name and version you are using.)
+* CLI version: (Insert the output of `openstack --version`, `s3cmd
+  --version`, or the version number of whatever other command-line
+  interface you are using.)
+
+Additionally, you might also want to add any of the items below, if
+you think they might be relevant to the bug:
+
+* Screenshots from the Cleura Cloud Control Panel
+* Screen dumps from CLIs
+
+Make sure to redact any sensitive information regarding your own users
+and products.
+
+## Additional context
+
+If there’s any other context you’d like to share, please add it
+here. Otherwise, you can delete this section.

--- a/.github/ISSUE_TEMPLATE/textual_bug.md
+++ b/.github/ISSUE_TEMPLATE/textual_bug.md
@@ -1,0 +1,33 @@
+---
+name: Textual Bug
+about: Use this template to report grammar glitches, syntax errors, and typos.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Summary
+
+Replace this with a short summary (one sentence or short paragraph) of
+the issue you are describing.
+
+## Affected paths
+
+List the URL(s) where you found a problem. You can use URLs from [the
+rendered site](https://docs.cleura.cloud) or from [the sources on
+GitHub](https://github.com/citynetwork/docs), either is fine.
+
+## What the documentation says
+
+Quote the passage that you believe needs improvement.
+
+## What the documentation should say
+
+Make a suggestion on how to improve the passage and to make it more
+understandable, more accessible, or simply more correct.
+
+## Additional context
+
+If there’s any other context you’d like to share, please add it
+here. Otherwise, you can delete this section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,26 @@
 
 This is the {{extra.brand}} **Beta** documentation web site.
 
-> We are currently in the process of migrating our Knowledge Base and
-> other documentation to this site. If you want to help, [here’s
-> how!](contrib/index.md)
+## What does "Beta" mean?
+
+The fact that this site is in a Beta stage means that any information
+you find here should be reliable and accurate for {{extra.brand}}
+products and services. If you find any published documentation that is
+inaccurate or not in line with functionality as you observe it on
+{{extra.brand}}, we would very much appreciate if you filed
+[a documentation bug]({{config.repo_url}}/issues).
+
+However, the documentation on this site may be incomplete, meaning
+that it does not yet cover *all* functionality available in
+{{extra.brand}}.
+
+In addition, page paths (URLs) are not yet stable. In other words,
+content may move from one path to another between visits. If you are
+looking for content that may have moved, please use the _Search_
+function.
+
+We are currently in the process of migrating our Knowledge Base and
+other documentation to this site. If you want to help,
+[here’s how!](contrib/index.md)
 
 


### PR DESCRIPTION
Add a couple of patches to better explain what "beta" means for the site, and to enable people to file bugs if they see them:

- feat: Expand Beta disclaimer, add call to action for documentation bugs
- docs: Add GitHub issue templates
