### PR TITLE
fix: Unwrap long lines in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/functional_bug.md
+++ b/.github/ISSUE_TEMPLATE/functional_bug.md
@@ -9,29 +9,21 @@ assignees: ''
 
 # Summary
 
-Replace this with a short summary (one sentence or short paragraph) of
-the issue you are describing.
+Replace this with a short summary (one sentence or short paragraph) of the issue you are describing.
 
 ## Affected paths
 
-List the URL(s) where you found inaccurate information. You can use
-URLs from [the rendered site](https://docs.cleura.cloud) or from [the
-sources on GitHub](https://github.com/citynetwork/docs), either is
-fine.
+List the URL(s) where you found inaccurate information. You can use URLs from [the rendered site](https://docs.cleura.cloud) or from [the sources on GitHub](https://github.com/citynetwork/docs), either is fine.
 
 ## What I did
 
-Explain the steps you undertook that produced results that are
-inconsistent with the documentation, or that led to errors when you
-followed the documentation.
+Explain the steps you undertook that produced results that are inconsistent with the documentation, or that led to errors when you followed the documentation.
 
-It’s OK to remove or mask credentials, but otherwise try to err on the
-side of sharing more rather than less information.
+It’s OK to remove or mask credentials, but otherwise try to err on the side of sharing more rather than less information.
 
 ## What I expected to observe
 
-Explain how you expected a service to behave, based on the
-documentation you used.
+Explain how you expected a service to behave, based on the documentation you used.
 
 ## What I actually observed
 
@@ -39,25 +31,19 @@ Explain how the service behaved differently.
 
 ## My environment
 
-Please add some information about the environment that you’re working
-in. At a minimum, include these items:
+Please add some information about the environment that you’re working in. At a minimum, include these items:
 
 * Browser: (Insert the web browser name and version you are using.)
 * Operating system: (Insert the OS name and version you are using.)
-* CLI version: (Insert the output of `openstack --version`, `s3cmd
-  --version`, or the version number of whatever other command-line
-  interface you are using.)
+* CLI version: (Insert the output of `openstack --version`, `s3cmd --version`, or the version number of whatever other command-line interface you are using.)
 
-Additionally, you might also want to add any of the items below, if
-you think they might be relevant to the bug:
+Additionally, you might also want to add any of the items below, if you think they might be relevant to the bug:
 
 * Screenshots from the Cleura Cloud Control Panel
 * Screen dumps from CLIs
 
-Make sure to redact any sensitive information regarding your own users
-and products.
+Make sure to redact any sensitive information regarding your own users and products.
 
 ## Additional context
 
-If there’s any other context you’d like to share, please add it
-here. Otherwise, you can delete this section.
+If there’s any other context you’d like to share, please add it here. Otherwise, you can delete this section.

--- a/.github/ISSUE_TEMPLATE/textual_bug.md
+++ b/.github/ISSUE_TEMPLATE/textual_bug.md
@@ -9,14 +9,11 @@ assignees: ''
 
 # Summary
 
-Replace this with a short summary (one sentence or short paragraph) of
-the issue you are describing.
+Replace this with a short summary (one sentence or short paragraph) of the issue you are describing.
 
 ## Affected paths
 
-List the URL(s) where you found a problem. You can use URLs from [the
-rendered site](https://docs.cleura.cloud) or from [the sources on
-GitHub](https://github.com/citynetwork/docs), either is fine.
+List the URL(s) where you found a problem. You can use URLs from [the rendered site](https://docs.cleura.cloud) or from [the sources on GitHub](https://github.com/citynetwork/docs), either is fine.
 
 ## What the documentation says
 
@@ -24,10 +21,8 @@ Quote the passage that you believe needs improvement.
 
 ## What the documentation should say
 
-Make a suggestion on how to improve the passage and to make it more
-understandable, more accessible, or simply more correct.
+Make a suggestion on how to improve the passage and to make it more understandable, more accessible, or simply more correct.
 
 ## Additional context
 
-If there’s any other context you’d like to share, please add it
-here. Otherwise, you can delete this section.
+If there’s any other context you’d like to share, please add it here. Otherwise, you can delete this section.


### PR DESCRIPTION
Small follow-up to #49:

When creating an issue using the GitHub issue template, and entering preview mode, the issues look odd when they use pre-wrapped lines. To make the experience smoother for issue reporters, unwrap the templates so they use long lines instead.
