### PR TITLE
docs: Update contrib guide with suggestions for screen shots/dumps

### DIFF
--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -4,6 +4,26 @@ You have two options for editing content: directly in your browser
 using GitHub, or using a Git-based workflow from your local work
 environment.
 
+## Notes on specific content additions
+
+**Screen shots:** If you are contributing a change that contains
+screen shots from {{extra.gui}}, they should use a resolution of
+1920×1080 pixels (1080p). If your screen uses a larger resolution, use
+[Firefox Responsive Design
+Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
+or [Chrome/Chromium Device
+Mode](https://developer.chrome.com/docs/devtools/device-mode/) to
+configure your browser with 1080p.
+
+**CLI screen dumps:** If you are contributing a change that contains a
+screen dump from the `openstack` command-line client, please limit its
+width to 100 characters. You can do this by setting the following
+environment variable in your terminal, before you start work on your
+change.
+
+``` bash
+export CLIFF_MAX_TERM_WIDTH=100
+```
 
 ## Modifying content from your browser
 


### PR DESCRIPTION
Add a note recommending 1080p resolution for GUI screen shots, and a 100-character width limit for CLI screen dumps.
