### PR TITLE
chore: Update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,6 +6,7 @@ Dmitriy Rabotyagov <dmitriy.rabotyagov@cleura.com> <dmitriy.rabotyagov@citynetwo
 Eliott Trouillet <53047591+packettoobig@users.noreply.github.com>
 Florian Haas <florian@cleura.com> <florian@citynetwork.eu>
 Florian Haas <florian@cleura.com> <florian.haas@cleura.com>
+Florian Haas <florian@cleura.com> <610707+fghaas@users.noreply.github.com>
 Foad Lind <foad.lind@cleura.com> <foad.lind@citynetwork.eu>
 Jean-Philippe Evrard <evrardjp@users.noreply.github.com> <open-source@a.spamming.party>
 Mateusz Guziak <mateusz.guziak@cleura.com> <skipper126@interia.pl>


### PR DESCRIPTION
GitHub somehow ended up mangling the author email address in the the commit landing PR #51 (94bc25e5e89c3997490ffae6204be50a08062ae3).

Update `.mailmap` again so that the git-authors plugin does not include the same author name twice in the same page footer.
