### PR TITLE
fix: Remove residual mentions of OpenStack Victoria and Ceph Nautilus

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -22,7 +22,6 @@ means that we deploy every other OpenStack release and skip the
 intervening one.
 
 {{extra.brand}} Cloud currently runs OpenStack
-[Victoria](https://releases.openstack.org/victoria) and
 [Xena](https://releases.openstack.org/xena).
 
 
@@ -33,5 +32,4 @@ releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
 {{extra.brand}} Cloud currently runs Ceph
-[Nautilus](https://docs.ceph.com/en/latest/releases/nautilus/) and
 [Pacific](https://docs.ceph.com/en/latest/releases/pacific/).


### PR DESCRIPTION
In the Reference section, the version overview was still mentioning
OpenStack Victoria and Ceph Nautilus. Since these versions are no
longer in use anywhere in Cleura Cloud, remove those mentions.
