### PR TITLE
feat: Add Plausible analytics

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,9 @@ other documentation to this site. If you want to help,
 [here’s how!](contrib/index.md)
 
 
+## Site analytics and cookies
+
+This site does not set cookies, which is why we also don't need to
+annoy you with a cookie consent banner. We use
+[cookie-free](https://plausible.io/data-policy#how-we-count-unique-users-without-cookies)
+site analytics from [Plausible](https://plausible.io).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ copyright: >
   </a>
 edit_uri: ./edit/main/docs
 extra:
+  analytics:
+    domain: docs.cleura.cloud
+    provider: plausible
   brand: "Cleura"
   brand_domain: "citycloud.com"
   company: "Cleura"

--- a/theme/partials/integrations/analytics/plausible.html
+++ b/theme/partials/integrations/analytics/plausible.html
@@ -1,0 +1,1 @@
+<script defer data-domain="{{ config.extra.analytics.domain }}" src="https://plausible.io/js/plausible.js"></script>


### PR DESCRIPTION
Plausible is a cookieless, privacy-preserving, GDPR compliant site
analytics solution that is already in use on https://cleura.com.

Using a theme override, include the Plausible analytics snippet on
every page. Mention Plausible on the start page.

References:
https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#custom-site-analytics
https://squidfunk.github.io/mkdocs-material/customization/#extending-the-theme
https://plausible.io/data-policy#how-we-count-unique-users-without-cookies
