### PR TITLE
chore: Temporarily disable htmlproofer in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           pip install tox tox-gh-actions
       - env:
+          DOCS_ENABLE_HTMLPROOFER: false
           DOCS_ENABLE_PDF_EXPORT: 1
         name: Test with tox
         # Explicitly specifying the testenvs shouldn't really be

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           pip install tox
       - env:
+          DOCS_ENABLE_HTMLPROOFER: false
           DOCS_ENABLE_PDF_EXPORT: 1
         name: Deploy to gh-pages
         run: tox -e deploy-github


### PR DESCRIPTION
We are currently getting false positives from the htmlproofer plugin
when it runs from GitHub Actions workflows, in that it reports links
as dead that are evidently alive. This is probably due to bandwidth
throttling or DDOS protection misfiring on the target sites.

This patch should be reverted as soon as the issues subside.
