### PR TITLE
chore: Re-enable htmlproofer in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           pip install tox tox-gh-actions
       - env:
-          DOCS_ENABLE_HTMLPROOFER: false
           DOCS_ENABLE_PDF_EXPORT: 1
         name: Test with tox
         # Explicitly specifying the testenvs shouldn't really be

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ jobs:
         run: |
           pip install tox
       - env:
-          DOCS_ENABLE_HTMLPROOFER: false
           DOCS_ENABLE_PDF_EXPORT: 1
         name: Deploy to gh-pages
         run: tox -e deploy-github


### PR DESCRIPTION
We want to use the htmlproofer plugin for deployments, and only
disabled it in GitHub Actions because we were getting false positives
(presumably due to bandwidth throttling or DDOS protection on the
target sites).

This reverts commit 9454deec5081e74531fa37adbc7a23c39758c551.
