### PR TITLE
chore: Drop "extra." and "config.extra." prefixes from macros

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,9 +1,9 @@
 # Concepts and Background
 
 This section contains conceptual and background information about
-{{config.extra.brand}} and the services we support. This is not so
+{{brand}} and the services we support. This is not so
 much about **how** you do something (for that, please see our [How-To
 Guides](../howto/)), more about **why** things work in
 a certain way, or why we have implemented them in a particular way in
-{{config.extra.brand}}.
+{{brand}}.
 

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -7,7 +7,7 @@ environment.
 ## Notes on specific content additions
 
 **Screen shots:** If you are contributing a change that contains
-screen shots from {{extra.gui}}, they should use a resolution of
+screen shots from {{gui}}, they should use a resolution of
 1920×1080 pixels (1080p). If your screen uses a larger resolution, use
 [Firefox Responsive Design
 Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
@@ -55,13 +55,13 @@ First, create a fork of the documentation repository:
     
     Then, proceed to create a new local checkout of your fork:
     ```bash
-    git clone git@github.com:<yourusername>/<your-repo-fork> {{ config.extra.brand | lower }}-docs
-    cd {{ config.extra.brand | lower }}-docs
+    git clone git@github.com:<yourusername>/<your-repo-fork> {{ brand | lower }}-docs
+    cd {{ brand | lower }}-docs
     ```
 === "`gh` client"
     ```bash
-    gh repo fork --clone {{ config.repo_url }} -- {{ config.extra.brand | lower }}-docs
-    cd {{ config.extra.brand | lower }}-docs
+    gh repo fork --clone {{ config.repo_url }} -- {{ brand | lower }}-docs
+    cd {{ brand | lower }}-docs
     ```
     
 Next, create a local topic branch and make your modifications:
@@ -97,7 +97,7 @@ To see your changes as you work on them, you can use
 your modifications, run:
 
 ```bash
-cd {{ config.extra.brand | lower }}-docs
+cd {{ brand | lower }}-docs
 git checkout <your-topic-branch-name>
 tox -e serve
 ```
@@ -111,7 +111,7 @@ so by disabling a plugin that checks all links (including external
 links) for accessibility:
 
 ```bash
-cd {{ config.extra.brand | lower }}-docs
+cd {{ brand | lower }}-docs
 export DOCS_ENABLE_HTMLPROOFER=false
 tox -e serve
 ```
@@ -132,7 +132,7 @@ commit message subjects. Please make sure that your commit message
 starts with one of the following prefixes:
 
 * `feat:` denotes a content addition, such as adding documentation for
-  some {{extra.brand}} Cloud functionality that was not included in
+  some {{brand}} Cloud functionality that was not included in
   the documentation before.
 * `fix:` denotes a content correction, such as fixing a
   documentation bug.

--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -1,6 +1,6 @@
 # Creating a new account in Cleura Cloud
 
-To gain access to the {{extra.gui}}, you first
+To gain access to the {{gui}}, you first
 have to create a new account. For that, navigate to
 <https://cleura.cloud>. At the bottom right-hand side of the page,
 click on the _Create account_ button.
@@ -17,7 +17,7 @@ box, and then click on the _Create_ button.
 
 ![Type in necessary details](assets/02-type-email-country.png)
 
-This will redirect you to the {{extra.gui}}, and
+This will redirect you to the {{gui}}, and
 since you are logging in from a new account for the first time, you
 now have to take three simple steps.
 
@@ -57,7 +57,7 @@ now have to take three simple steps.
 ![Account verification](assets/06-step-3.png)
 
 After the account verification is complete, you are greeted by the
-{{extra.gui}}. Feel free to follow through the
+{{gui}}. Feel free to follow through the
 introductory guide to the environment --- that will not take long ---
 or skip it and start taking advantage of the Cleura Cloud without
 delay.

--- a/docs/howto/getting-started/enable-openstack-cli.md
+++ b/docs/howto/getting-started/enable-openstack-cli.md
@@ -7,7 +7,7 @@ create and manage the lifecycle of objects related, for example, to
 Compute, Networking, or Storage.
 
 Before installing `openstack` to your local laptop or workstation, you 
-first need to have an OpenStack user in your {{extra.brand}} account. 
+first need to have an OpenStack user in your {{brand}} account. 
 Next, you create and download a special RC file onto your computer, 
 modify it to reflect your OpenStack user's credentials, and source it. 
 Only then will you be able to use any installed `openstack` client.
@@ -15,16 +15,16 @@ Only then will you be able to use any installed `openstack` client.
 ## Creating an OpenStack user
 
 From your favorite web browser, navigate to the [Cleura 
-Cloud](https://{{extra.gui_domain}}) page, and login into your 
-{{extra.brand}} account.
+Cloud](https://{{gui_domain}}) page, and login into your 
+{{brand}} account.
 
-Please make sure the left-hand side pane on the {{extra.gui}} is fully 
+Please make sure the left-hand side pane on the {{gui}} is fully 
 visible, click the _Users_ category to expand it, and click on 
 _Openstack Users_.
 
 ![Add a new OpenStack user](assets/ostack-cli/shot-01.png)
 
-Then, at the top right-hand side of the {{extra.gui}}, click once more 
+Then, at the top right-hand side of the {{gui}}, click once more 
 the _Add new Openstack user_ option. A new pane will slide into view, 
 titled _Create Openstack User_.
 
@@ -54,14 +54,14 @@ _Description_ box.
 
 The new OpenStack user will be ready in just a few seconds. At any 
 time, you can view all available OpenStack users by going to the 
-left-hand side pane on the {{extra.gui}} and selecting _Users_ > 
+left-hand side pane on the {{gui}} and selecting _Users_ > 
 _Openstack Users_.
 
 ![All available OpenStack users](assets/ostack-cli/shot-06.png)
 
 ## Creating and downloading an RC file
 
-On the {{extra.gui}} expand the left-hand side pane, click _Users_ and 
+On the {{gui}} expand the left-hand side pane, click _Users_ and 
 then _Openstack Users_. You will then see, listed in the main pane 
 titled _Openstack Users_, all available users. Click on the 
 three-dotted round icon on the right of the user you want to create an 
@@ -148,7 +148,7 @@ examples follow.
 
 Provided you have already sourced your RC file, you can now use the 
 `openstack` command line tool to access various OpenStack APIs on the 
-{{extra.brand}} Cloud.
+{{brand}} Cloud.
 
 To make sure your local installation of `openstack` works as expected, 
 type:
@@ -157,7 +157,7 @@ type:
 openstack token issue
 ```
 
-If `openstack` can indeed connect to the {{extra.brand}} Cloud 
+If `openstack` can indeed connect to the {{brand}} Cloud 
 OpenStack APIs, then you will get information, in tabular format, 
 regarding the issuance of a new token.
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,7 +1,7 @@
 # About our How-To guides
 
 In this section you’ll find details about how you can accomplish
-specific tasks in {{config.extra.brand}} and the services we support.
+specific tasks in {{brand}} and the services we support.
 
 There are several categories of How-To guides, and they tend to be
 focused on a specific cloud technology.
@@ -10,22 +10,22 @@ focused on a specific cloud technology.
   Cloud, and start using our services.
 
 * **Kubernetes** How-Tos cover how you can create and manage your
-  Kubernetes deployments using {{config.extra.gui}}.
+  Kubernetes deployments using {{gui}}.
 
 * **Object storage** How-Tos deal with the S3 and Swift object storage
   APIs, and how you can use them for object storage in
-  {{config.extra.brand}}.
+  {{brand}}.
 
 * **OpenStack CLI/API** How-Tos cover tasks that you can accomplish
   with the OpenStack command line interfaces and application
   programming interfaces. They generally do not depend on any adjacent
-  services or tools, just your {{config.extra.brand}} OpenStack
+  services or tools, just your {{brand}} OpenStack
   credentials, the `openstack` client, and/or the native OpenStack
   APIs.
 
 <!-- TODO: we’ll enable these as we migrate content.
 * **Terraform** How-Tos deal with Terraform configurations and how you
-  can apply them in {{config.extra.brand}}. They build on the
+  can apply them in {{brand}}. They build on the
   `terraform` binary and the
   [OpenStack](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
   and

--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -1,7 +1,7 @@
 # Creating Kubernetes clusters with Gardener
 
 If you want to create a Kubernetes cluster, you can do it via
-{{config.extra.gui}} using Gardener. This how-to shows you how to do
+{{gui}} using Gardener. This how-to shows you how to do
 that, and how to deploy a sample application on such a cluster.
 
 ## Prerequisites
@@ -10,15 +10,15 @@ To access the cluster from your computer, you will need
 [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
 on your machine.
 
-## Creating a Kubernetes cluster in {{config.extra.gui}}
+## Creating a Kubernetes cluster in {{gui}}
 
-To get started, navigate to <https://{{config.extra.gui_domain}}>, and
+To get started, navigate to <https://{{gui_domain}}>, and
 in the side panel choose Kubernetes → [Managed
-Kubernetes](https://{{config.extra.gui_domain}}/containers/gardener).
+Kubernetes](https://{{gui_domain}}/containers/gardener).
 You will see a Gardener page, in which you can create and manage your
 clusters. Click `Create Kubernetes cluster`.
 
-![Gardener page in {{config.extra.gui}}](assets/gardener_page.png)
+![Gardener page in {{gui}}](assets/gardener_page.png)
 
 > In Gardener's terminology, a Kubernetes cluster is referred as a
 > **Shoot cluster**. You can see the name "Shoot" in various places
@@ -72,7 +72,7 @@ apiVersion: v1
 clusters:
   - cluster:
       certificate-authority-data: DATA+OMITTED
-      server: https://api.test-cluster.p40698.staging-k8s.{{config.extra.gui_domain}}
+      server: https://api.test-cluster.p40698.staging-k8s.{{gui_domain}}
     name: shoot--p40698--test-cluster
 contexts:
   - context:

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -2,8 +2,8 @@
 
 <!-- Config interpolation for the company name didn't work for the title here. -->
 
-In {{config.extra.company}} you can run Kubernetes in various
-ways. [{{config.extra.gui}}](https://{{config.extra.gui_domain}})
+In {{company}} you can run Kubernetes in various
+ways. [{{gui}}](https://{{gui_domain}})
 includes management interfaces for [Gardener](https://gardener.cloud/)
 and [OpenStack Magnum](https://docs.openstack.org/magnum/).
 
@@ -14,9 +14,9 @@ It allows you to create clusters and automatically handle their lifecycle operat
 hibernation schedules, and automatic updates to Kubernetes control plane and worker nodes.
 You can read more about Gardener and its capabilities on its [documentation website](https://gardener.cloud/docs/gardener/).
 
-To learn how to use Gardener in the {{config.extra.gui}}, refer to
+To learn how to use Gardener in the {{gui}}, refer to
 [Creating Kubernetes clusters using
-{{config.extra.gui}}](gardener/create-shoot-cluster.md).
+{{gui}}](gardener/create-shoot-cluster.md).
 
 ### Magnum
 

--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -1,6 +1,6 @@
 # Working with S3-compatible credentials
 
-When you want to interact with object storage in {{extra.brand}} using
+When you want to interact with object storage in {{brand}} using
 tools that support an Amazon S3 compatible API (such as `s3cmd`,
 `rclone`, the `aws` CLI, or the Python `boto3` library), you need an
 S3-compatible access key ID and secret key.
@@ -21,7 +21,7 @@ environment variables (or whichever configuration options your
 application requires).
 
 > Your S3-compatible credentials are always scoped to your
-> {{extra.brand}} *region* and *project*. You cannot reuse an access
+> {{brand}} *region* and *project*. You cannot reuse an access
 > and secret key across multiple regions or projects.
 >
 > Also, your credentials are only “S3-compatible” in the sense that
@@ -45,7 +45,7 @@ need to configure your S3 client with it.
 How exactly you do that depends on your preferred client:
 
 === "aws"
-    Create a new profile, named after your {{extra.brand}} region:
+    Create a new profile, named after your {{brand}} region:
     ```bash
     aws configure set \
       --profile <region> \
@@ -57,20 +57,20 @@ How exactly you do that depends on your preferred client:
 
     For the `aws` CLI, you cannot define a region's endpoint in the
     profile. As such, you must add the
-    `--endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080`
+    `--endpoint-url=https://s3-<region>.{{brand_domain}}:8080`
     option to each `aws s3api` call.
 === "mc"
-    Create a new alias, named after your {{extra.brand}} region:
+    Create a new alias, named after your {{brand}} region:
     ```bash
     mc alias set <region> \
-      https://s3-<region>.{{extra.brand_domain}}:8080 \
+      https://s3-<region>.{{brand_domain}}:8080 \
       <access-key> <secret-key>
     ```
 	Once you have configured an alias like this, you are able to
 	run bucket operations with `mc` using the `alias/bucket` syntax.
 === "s3cmd"
     `s3cmd` does not support configuration profiles, so you need to use
-    a separate configuration file for each {{extra.brand}} region you
+    a separate configuration file for each {{brand}} region you
     want to use:
     ```bash
     s3cmd -c ~/.s3cfg-<region> --configure
@@ -78,9 +78,9 @@ How exactly you do that depends on your preferred client:
 
     * Set your `Access Key` and `Secret Key` when prompted.
     * Leave `Default Region` unchanged.
-    * Set `S3 Endpoint` to `s3-<region>.{{extra.brand_domain}}:8080`.
+    * Set `S3 Endpoint` to `s3-<region>.{{brand_domain}}:8080`.
     * Set `DNS-style bucket+hostname:port template for accessing a bucket`
-      to `s3-<region>.{{extra.brand_domain}}:8080` as well.
+      to `s3-<region>.{{brand_domain}}:8080` as well.
     * Set `Use HTTPS protocol` to `Yes` (the default).
     * Configure GnuPG encryption and your HTTP proxy server, if needed.
     * Test access with your supplied credentials.

--- a/docs/howto/object-storage/s3/expiry.md
+++ b/docs/howto/object-storage/s3/expiry.md
@@ -30,7 +30,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api put-bucket-lifecycle-configuration \
 	  --lifecycle-configuration file://lifecycle.json \ 
 	  --bucket <bucket-name>

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -61,29 +61,29 @@ rclone versions won't work here.
 3. Create a configuration file named `~/.rclone.conf`, with the
    following content:
 
-        [{{extra.brand|lower|replace(' ','')}}]
+        [{{brand|lower|replace(' ','')}}]
         type = s3
         provider = Ceph
         env_auth = false
         access_key_id = <access key id>
         secret_access_key = <secret key>
-        endpoint = <region>.{{extra.brand_domain}}:8080
+        endpoint = <region>.{{brand_domain}}:8080
         acl = private
         sse_customer_algorithm = AES256
 
 4. Create an S3 bucket:
 
-        rclone mkdir {{extra.brand|lower|replace(' ','')}}:encrypted
+        rclone mkdir {{brand|lower|replace(' ','')}}:encrypted
 
 5. Sync a directory to the S3 bucket, encrypting the files it
    contains on upload:
 
-        rclone sync ~/media/ {{extra.brand|lower|replace(' ','')}}:encrypted \
+        rclone sync ~/media/ {{brand|lower|replace(' ','')}}:encrypted \
           --s3-sse-customer-key=${secret}
 
 6. Retrieve a file from S3 and decrypt it:
 
-        rclone copy {{extra.brand|lower|replace(' ','')}}:encrypted/file.png \
+        rclone copy {{brand|lower|replace(' ','')}}:encrypted/file.png \
           --s3-sse-customer-key=${secret}
 
 

--- a/docs/howto/object-storage/s3/versioning.md
+++ b/docs/howto/object-storage/s3/versioning.md
@@ -11,7 +11,7 @@ To enable versioning in a bucket, use one of the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api put-bucket-versioning \
       --versioning-configuration Status=Enabled \
       --bucket <bucket-name>
@@ -32,7 +32,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api get-bucket-versioning \
       --bucket <bucket-name>
     ```
@@ -58,7 +58,7 @@ that in unversioned buckets:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api put-object \
       --bucket <bucket-name> \
       --key <object-name> \
@@ -84,7 +84,7 @@ available for an object:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api list-object-versions \
       --bucket <bucket-name> \
       --key <object-name>
@@ -107,7 +107,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api get-object \
       --bucket <bucket-name> \
       --key <object-name> \
@@ -142,7 +142,7 @@ which case object removal does occur.
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api delete-object \
       --bucket <bucket-name> \
       --key <object-name>
@@ -163,7 +163,7 @@ specific object version:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{extra.brand_domain}}:8080 \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api delete-object \
       --version-id <versionid> \
       --bucket <bucket-name> \

--- a/docs/howto/openstack/barbican/generic-secret.md
+++ b/docs/howto/openstack/barbican/generic-secret.md
@@ -16,7 +16,7 @@ openstack secret store \
   -n mysecret
 ```
 
-> The example output below uses {{extra.brand}}’s `Fra1` region. In
+> The example output below uses {{brand}}’s `Fra1` region. In
 > other regions, the secret
 > [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
 > will differ.
@@ -26,7 +26,7 @@ openstack secret store \
 +---------------+--------------------------------------------------------------------------------+
 | Field         | Value                                                                          |
 +---------------+--------------------------------------------------------------------------------+
-| Secret href   | https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba |
+| Secret href   | https://fra1.{{brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba |
 | Name          | mysecret                                                                       |
 | Created       | None                                                                           |
 | Status        | None                                                                           |
@@ -58,8 +58,8 @@ openstack secret list
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 | Secret href                                                                    | Name     | Created                   | Status | Content types                           | Algorithm | Bit length | Secret type | Mode | Expiration |
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
-| https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba | mysecret | 2021-04-29T10:33:18+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | passphrase  | cbc  | None       |
-| https://fra1.{{extra.brand_domain}}:9311/v1/secrets/ad628532-53b8-4d2f-91e5-0097b51da4e | None     | 2021-04-27T13:52:10+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | symmetric   | None | None       |
+| https://fra1.{{brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba | mysecret | 2021-04-29T10:33:18+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | passphrase  | cbc  | None       |
+| https://fra1.{{brand_domain}}:9311/v1/secrets/ad628532-53b8-4d2f-91e5-0097b51da4e | None     | 2021-04-27T13:52:10+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | symmetric   | None | None       |
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 ```
 
@@ -68,7 +68,7 @@ command, adding the `-p` (or `--payload`) option:
 
 ```bash
 $ openstack secret get -p \
-  https://fra1.{{extra.brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba
+  https://fra1.{{brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba
 ```
 
 ```
@@ -84,4 +84,4 @@ $ openstack secret get -p \
 > secrets by their full
 > [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
 > That URI must include the
-> `https://<region>.{{extra.brand_domain}}:9311/v1/secrets/` prefix.
+> `https://<region>.{{brand_domain}}:9311/v1/secrets/` prefix.

--- a/docs/howto/openstack/barbican/index.md
+++ b/docs/howto/openstack/barbican/index.md
@@ -1,7 +1,7 @@
 # Using Barbican for secret storage
 
 **[Barbican](https://docs.openstack.org/barbican/latest/)** is
-OpenStack's secret storage facility. In {{extra.brand}}, Barbican is
+OpenStack's secret storage facility. In {{brand}}, Barbican is
 supported for the following purposes:
 
 * [Generic secret storage](generic-secret.md),

--- a/docs/howto/openstack/barbican/share-secret.md
+++ b/docs/howto/openstack/barbican/share-secret.md
@@ -10,7 +10,7 @@ To do so, you will need
   [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier),
 * the other user’s OpenStack API user ID.
 
-> Any {{extra.brand}} user can always retrieve their own user ID
+> Any {{brand}} user can always retrieve their own user ID
 > with the following command:
 >
 > ```
@@ -24,7 +24,7 @@ Once you have assembled this information, you can proceed with the
 openstack acl user add \
   --user <user_id> \
   --operation-type read \
-  https://region.{{extra.brand_domain}}:9311/v1/secrets/<secret_id>
+  https://region.{{brand_domain}}:9311/v1/secrets/<secret_id>
 ```
 
 If you want to unshare the secret again, you simply use the
@@ -34,5 +34,5 @@ corresponding `openstack acl user remove` command:
 openstack acl user remove \
   --user <user_id> \
   --operation-type read \
-  https://region.{{extra.brand_domain}}:9311/v1/secrets/<secret_id>
+  https://region.{{brand_domain}}:9311/v1/secrets/<secret_id>
 ```

--- a/docs/howto/openstack/cinder/encrypted-volumes.md
+++ b/docs/howto/openstack/cinder/encrypted-volumes.md
@@ -26,7 +26,7 @@ openstack volume type list
 +--------------------------------------+-----------------------+-----------+
 ```
 
-> In {{extra.brand}}, all volume types that support encryption use the
+> In {{brand}}, all volume types that support encryption use the
 > suffix `_encrypted`.
 
 To create a volume with encryption, you need to explicitly specify the
@@ -124,7 +124,7 @@ There are two options to work around this limitation:
 ## Block device encryption caveats
 
 Once a volume is configured to use encryption and is also attached to
-an instance in {{extra.brand}}, some caveats apply that you might want
+an instance in {{brand}}, some caveats apply that you might want
 to keep in mind.
 
 Sometimes, automatically or through administrator intervention, we
@@ -133,7 +133,7 @@ is known as *live migration,* and it normally does not interrupt the
 instance’s functionality at all — typically, neither you nor the
 application users notice that live migration has even happened. This
 is a very common occurrence when we do routine upgrades of the
-{{extra.brand}} platform, during our pre-announced maintenance windows.
+{{brand}} platform, during our pre-announced maintenance windows.
 
 The same considerations apply to physical node failure. If the
 physical machine running your instance fails, we can automatically

--- a/docs/howto/openstack/neutron/multiple-public-ips.md
+++ b/docs/howto/openstack/neutron/multiple-public-ips.md
@@ -1,6 +1,6 @@
 # Assigning multiple public (floating) IPs to a server
 
-In {{extra.brand}}, we do not pass external networks to the compute nodes. This means
+In {{brand}}, we do not pass external networks to the compute nodes. This means
 that you, as a user, can not directly attach a server to the public network.
 
 In order to provide connectivity to the public network (for IPv4), you need to use

--- a/docs/howto/openstack/neutron/new-network.md
+++ b/docs/howto/openstack/neutron/new-network.md
@@ -1,27 +1,27 @@
 # Creating new networks in Cleura Cloud
 
-Before creating a server in {{extra.brand}} Cloud, you need at least
+Before creating a server in {{brand}} Cloud, you need at least
 one network to make the new server a member of. Since you may have
 more than one network per region, let us now walk through creating
-a new network using the {{extra.gui}}, or using the OpenStack CLI.
+a new network using the {{gui}}, or using the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose to work from the {{extra.gui}} or with the
+Whether you choose to work from the {{gui}} or with the
 OpenStack CLI, you need to [have an account](/howto/getting-started/create-account)
-in {{extra.brand}} Cloud. Additionally, to use the OpenStack
+in {{brand}} Cloud. Additionally, to use the OpenStack
 CLI make sure to [enable it first](/howto/getting-started/enable-openstack-cli).
 
 ## Creating a network
 
-To create a network from the {{extra.gui}}, fire up your favorite web
-browser, navigate to the [Cleura Cloud](https://{{extra.gui_domain}})
-page, and login into your {{extra.brand}} account. On the other hand,
+To create a network from the {{gui}}, fire up your favorite web
+browser, navigate to the [Cleura Cloud](https://{{gui_domain}})
+page, and login into your {{brand}} account. On the other hand,
 if you prefer to work with OpenStack CLI, please do not forget to
 source the RC file first.
 
-=== "{{extra.gui}}"
-    On the top right-hand side of the {{extra.gui}}, click the _Create_
+=== "{{gui}}"
+    On the top right-hand side of the {{gui}}, click the _Create_
     button. A new pane will slide into view from the right-hand side of
     the browser window, titled _Create_.
 
@@ -29,7 +29,7 @@ source the RC file first.
 
     You will notice several rounded boxes prominently displayed on that
     pane, each for defining, configuring, and instantiating a different
-    {{extra.brand}} Cloud object. Go ahead and click the _Network_ box. A
+    {{brand}} Cloud object. Go ahead and click the _Network_ box. A
     new pane titled _Create Network_ will slide over. At the top, type
     in a name and select one of the available regions for the new
     network.
@@ -83,12 +83,12 @@ source the RC file first.
 
 Creating a new network does not necessarily mean it has all the
 features you most likely would expect. Unless you work from the
-{{extra.gui}}, where almost every component is activated for you with
+{{gui}}, where almost every component is activated for you with
 a few clicks here and there, when you use the OpenStack CLI there is
 some extra work you need to do before you get a network you would
 characterize as useful.
 
-=== "{{extra.gui}}"
+=== "{{gui}}"
     Expand the _Advanced Options_ section below, make sure _Port Security_
     is enabled, and leave the MTU parameter blank.
 
@@ -206,15 +206,15 @@ characterize as useful.
 
 ## Listing networks and getting information
 
-At any time, you may connect to the {{extra.gui}}, list all networks
+At any time, you may connect to the {{gui}}, list all networks
 you have already created, and get detailed information for any of
 these networks. Alternatively, you may get all that information using
 the OpenStack CLI.
 
-=== "{{extra.gui}}"
+=== "{{gui}}"
     You may see all defined networks, in all supported regions, by
     selecting _Networking_ > _Networks_ (see the left-hand side pane
-    on the {{extra.gui}}).
+    on the {{gui}}).
 
     ![All networks in all regions](assets/new-net-panel/shot-06.png)
 

--- a/docs/howto/openstack/nova/config-drive.md
+++ b/docs/howto/openstack/nova/config-drive.md
@@ -7,7 +7,7 @@ OpenStack Compute uses metadata to inject custom configurations to
 servers on boot. You can add custom scripts, install packages, and
 add SSH keys to the servers using metadata.
 
-By default, metadata discovery in {{extra.brand}} Cloud uses an HTTP
+By default, metadata discovery in {{brand}} Cloud uses an HTTP
 data source that booting servers connect to. Sometimes this is
 undesirable or — for specific server/networking configurations —
 unreliable. Under those circumstances, you can use an alternate

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -1,9 +1,9 @@
 # Creating new servers in Cleura Cloud
 
-Once you have an [account in {{extra.brand}} 
+Once you have an [account in {{brand}} 
 Cloud](/howto/getting-started/create-account), you can create virtual 
 machines --- henceforth simply _servers_ --- using either the 
-{{extra.gui}} or the OpenStack CLI. Let us demonstrate the creation of 
+{{gui}} or the OpenStack CLI. Let us demonstrate the creation of 
 a new server, following both approaches.
 
 ## Prerequisites
@@ -16,21 +16,21 @@ first](/howto/getting-started/enable-openstack-cli).
 
 ## Creating a server
 
-To create a server from the {{extra.gui}}, fire up your favorite web 
-browser, navigate to the [Cleura Cloud](https://{{extra.gui_domain}}) 
-page, and log into your {{extra.brand}} account. On the other hand, 
+To create a server from the {{gui}}, fire up your favorite web 
+browser, navigate to the [Cleura Cloud](https://{{gui_domain}}) 
+page, and log into your {{brand}} account. On the other hand, 
 if you prefer to work with the OpenStack CLI, please do not forget to 
 [source the RC file first](/howto/getting-started/enable-openstack-cli).
 
-=== "{{extra.gui}}"
-	On the top right-hand side of the {{extra.gui}}, click the 
+=== "{{gui}}"
+	On the top right-hand side of the {{gui}}, click the 
 	_Create_ button. A new pane titled _Create_ will slide into view from 
 	the right-hand side of the browser window.
 		
 	![Create new object](assets/new-server/shot-01.png)
 		
 	You will notice several rounded boxes on that pane, each for 
-	defining, configuring, and instantiating a different {{extra.brand}} 
+	defining, configuring, and instantiating a different {{brand}} 
 	Cloud object. Go ahead and click the _Server_ box. A new pane titled 
 	_Create a Server_ will slide over. At the top, type in a name for the 
 	new server and select one of the available regions.
@@ -87,7 +87,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	![Networking and security groups](assets/new-server/shot-05.png)
 		
 	If you already have one or more public keys in your 
-	{{extra.brand}} Cloud account, you can now select a key to be included 
+	{{brand}} Cloud account, you can now select a key to be included 
 	in the `~/.ssh/authorized_keys` file of the server's default user. That 
 	way, you can securely log into the remote user's account without typing 
 	a password. If there are no public keys to choose from, activate the 
@@ -104,7 +104,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 		
 	![User-data propagation method](assets/new-server/shot-07.png)
 		
-	It is now time to create your {{extra.brand}} Cloud server; 
+	It is now time to create your {{brand}} Cloud server; 
 	click the green _Create_ button, and the new server will be readily 
 	available in a few seconds.
 		
@@ -148,7 +148,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	```
 		
 	Your server should have an image to boot off of (`IMAGE_NAME`). 
-	For a list of all available images in {{extra.brand}} Cloud, type:
+	For a list of all available images in {{brand}} Cloud, type:
 		
 	```bash
 	openstack image list
@@ -219,14 +219,14 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 		
 	You most likely want a server you can remotely connect to via 
 	SSH without typing a password. Upload one of our public keys to your 
-	{{extra.brand}} Cloud account:
+	{{brand}} Cloud account:
 		
 	```bash
 	openstack keypair create --public-key ~/.ssh/id_ed25519.pub bahnhof
 	```
 		
 	In the example above, we uploaded the public key 
-	`~/.ssh/id_ed25519.pub` to our {{extra.brand}} Cloud account and named 
+	`~/.ssh/id_ed25519.pub` to our {{brand}} Cloud account and named 
 	it `bahnhof`. Follow our example and do not forget to set the 
 	`KEY_NAME`:
 		
@@ -271,10 +271,10 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	used the actual values and not the variables we so meticulously set.) 
 	The `--wait` parameter is optional. Whenever you choose to 
 	use it, you get back control of your terminal only after the server is 
-	readily available in {{extra.brand}} Cloud.
+	readily available in {{brand}} Cloud.
 	
 	To connect to your server remotely, you need to create a floating IP
-	for the external network in the {{extra.brand}} Cloud, and then assign
+	for the external network in the {{brand}} Cloud, and then assign
 	this IP to your server. First, create the floating IP: 
 	
 	```bash
@@ -302,8 +302,8 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	```
 
 ## Viewing information about the newly created server
-=== "{{extra.gui}}"
-	From the {{extra.gui}} you may, at any 
+=== "{{gui}}"
+	From the {{gui}} you may, at any 
 	time, see all servers and get detailed information regarding each one 
 	of them; expand the left-hand side vertical pane, click _Compute_, then 
 	_Servers_, and, in the central pane, select the region you want. 
@@ -322,7 +322,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	openstack server show zug
 	```
 ## Connecting to the server console
-=== "{{extra.gui}}"		
+=== "{{gui}}"		
 	While viewing information regarding your server, you may get 
 	its public IP  address (e.g., from the _Addresses_ tab) and connect to 
 	it remotely. Alternatively, you may launch a web console and log in; 
@@ -332,7 +332,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	![Launch remote console](assets/new-server/shot-10.png)
 		
 	A new window pops up, and that's your web console to your 
-	{{extra.brand}} Cloud server. Please note that this window cannot be 
+	{{brand}} Cloud server. Please note that this window cannot be 
 	resized but can be opened on a new browser window or tab.
 		
 	![Server console](assets/new-server/shot-11.png)

--- a/docs/howto/openstack/octavia/tls-lb.md
+++ b/docs/howto/openstack/octavia/tls-lb.md
@@ -1,6 +1,6 @@
 # HTTPS-terminating load balancers
 
-In {{extra.brand}}’s load balancing service, [OpenStack
+In {{brand}}’s load balancing service, [OpenStack
 Octavia](https://docs.openstack.org/octavia/latest/), you can
 configure load balancers so that they manage HTTPS termination. That
 is to say that the load balancer encrypts and decrypts HTTPS traffic,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,19 @@
 # Start Here
 
-This is the {{extra.brand}} **Beta** documentation web site.
+This is the {{brand}} **Beta** documentation web site.
 
 ## What does "Beta" mean?
 
 The fact that this site is in a Beta stage means that any information
-you find here should be reliable and accurate for {{extra.brand}}
+you find here should be reliable and accurate for {{brand}}
 products and services. If you find any published documentation that is
 inaccurate or not in line with functionality as you observe it on
-{{extra.brand}}, we would very much appreciate if you filed
+{{brand}}, we would very much appreciate if you filed
 [a documentation bug]({{config.repo_url}}/issues).
 
 However, the documentation on this site may be incomplete, meaning
 that it does not yet cover *all* functionality available in
-{{extra.brand}}.
+{{brand}}.
 
 In addition, page paths (URLs) are not yet stable. In other words,
 content may move from one path to another between visits. If you are

--- a/docs/reference/features/index.md
+++ b/docs/reference/features/index.md
@@ -1,13 +1,13 @@
 # Feature support matrix
 
-Services in {{extra.brand}} Cloud constantly evolve, and we gradually
+Services in {{brand}} Cloud constantly evolve, and we gradually
 add features to regions as they become available and mature.
 
-This page lists the cloud features available in each {{extra.brand}}
+This page lists the cloud features available in each {{brand}}
 Cloud region.
 
-* [Public Cloud](public.md): features supported in our {{extra.brand}}
+* [Public Cloud](public.md): features supported in our {{brand}}
   Public Cloud regions.
 
 * [Compliant Cloud](compliant.md): features supported in our
-  {{extra.brand}} Compliant Cloud regions.
+  {{brand}} Compliant Cloud regions.

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -1,13 +1,13 @@
 # Flavors
 
-Any server instance running in {{extra.brand}} Cloud has a **flavor**,
+Any server instance running in {{brand}} Cloud has a **flavor**,
 which defines the number of virtual CPU cores, the amount of virtual
 RAM, and other performance-related factors.
 
 
 ## Naming convention
 
-Flavor names in {{extra.brand}} follow a convention, which can be
+Flavor names in {{brand}} follow a convention, which can be
 summarized as `X.YcZgb`:
 
 * `X` stands for a lowercase letter identifying the [compute
@@ -25,12 +25,12 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
 
 ## Compute tiers
 
-{{extra.brand}} Cloud defines the following compute tiers:
+{{brand}} Cloud defines the following compute tiers:
 
 * `b`: General purpose. This is the default compute tier. Instances
   launched with matching flavors use highly available network-attached
   storage. This makes them flexible to migrate within the
-  {{extra.brand}} Cloud infrastructure, without interruption.
+  {{brand}} Cloud infrastructure, without interruption.
   Some
   [limitations](../../howto/openstack/cinder/encrypted-volumes/#block-device-encryption-caveats)
   apply to instances with attached [encrypted
@@ -49,10 +49,10 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
   access to a
   [GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit).
 
-Some tiers are only available in select {{extra.brand}} Cloud
+Some tiers are only available in select {{brand}} Cloud
 regions. For details on tier availability, see the [Feature support
 matrix](../features/index.md).
 
-The general-purpose tier is always available to all {{extra.brand}}
+The general-purpose tier is always available to all {{brand}}
 Cloud customers. For access to other tiers, contact our
-[{{extra.support}}](https://{{extra.support_domain}}/servicedesk).
+[{{support}}](https://{{support_domain}}/servicedesk).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,19 +1,19 @@
 # Reference
 
 This is our reference section. It serves to provide general reference
-information about {{config.extra.brand}} services.
+information about {{brand}} services.
 
 ## Feature and service availability
 
 * Our **[Feature Support Matrix](features/index.md)** lists cloud
-  features and their availability across {{config.extra.brand}}
+  features and their availability across {{brand}}
   regions.
 
 * The **[Flavors](flavors/index.md)** reference explains our naming
   convention for pre-defined CPU/RAM/disk configurations ("flavors")
   for server instances, and their availability across
-  {{config.extra.brand}} regions.
+  {{brand}} regions.
 
 * Our **[API Service Version Matrix](versions/index.md)** lists the
-  open source software versions running in our {{config.extra.brand}}
+  open source software versions running in our {{brand}}
   regions.

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -1,27 +1,27 @@
 # Service version matrix
 
-Services in {{extra.brand}} Cloud are updated on a regular basis and
+Services in {{brand}} Cloud are updated on a regular basis and
 on a rolling schedule.
 
 This section lists the cloud API service versions available in each
-{{extra.brand}} Cloud region.
+{{brand}} Cloud region.
 
-* [Public Cloud](public.md): versions running in our {{extra.brand}}
+* [Public Cloud](public.md): versions running in our {{brand}}
   Public Cloud regions.
 
 * [Compliant Cloud](compliant.md): versions running in our
-  {{extra.brand}} Compliant Cloud regions.
+  {{brand}} Compliant Cloud regions.
 
 
 ## OpenStack Services
 
 [OpenStack releases](https://releases.openstack.org/) are named, in
 alphabetical order, and occur on a six-month release schedule. In
-{{extra.brand}} Public Cloud we upgrade OpenStack releases annually; this
+{{brand}} Public Cloud we upgrade OpenStack releases annually; this
 means that we deploy every other OpenStack release and skip the
 intervening one.
 
-{{extra.brand}} Cloud currently runs OpenStack
+{{brand}} Cloud currently runs OpenStack
 [Xena](https://releases.openstack.org/xena).
 
 
@@ -31,5 +31,5 @@ intervening one.
 releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
-{{extra.brand}} Cloud currently runs Ceph
+{{brand}} Cloud currently runs Ceph
 [Pacific](https://docs.ceph.com/en/latest/releases/pacific/).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,18 +1,18 @@
 # About our tutorials
 
-Our tutorials are gentle introductions to {{config.extra.brand}}. They
+Our tutorials are gentle introductions to {{brand}}. They
 generally require very little prior knowledge and assume only that you
 have access to a browser, or to a terminal.
 
 We group these into two major categories:
 
 * **Browser-based tutorials** get you started on
-  {{config.extra.brand}} using the
-  [{{config.extra.gui}}](https://{{config.extra.gui_domain}}/).
+  {{brand}} using the
+  [{{gui}}](https://{{gui_domain}}/).
 
 * **Terminal-based tutorials** introduce you to command-line
   interfaces (CLIs) and their interaction with
-  {{config.extra.brand}}’s web-based Application Programming
+  {{brand}}’s web-based Application Programming
   Interfaces (APIs).
 
 This section does *not* include detailed walkthroughs of specific
@@ -21,4 +21,4 @@ Guides](../howto/) section.
 
 > If you find our tutorials helpful, you might also be interested in
 > our self-paced online training courses, available from [our course
-> booking site](https://shop.{{config.extra.company_domain}}).
+> booking site](https://shop.{{company_domain}}).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,10 @@ plugins:
       enabled: !ENV [DOCS_ENABLE_HTMLPROOFER, True]
       raise_error: true
       validate_external_urls: true
-  - macros
+  - macros:
+      # yamllint disable-line rule:truthy
+      on_error_fail: !ENV [DOCS_FAIL_ON_MACRO_ERROR, True]
+      on_undefined: strict
   - pdf-export:
       enabled_if_env: DOCS_ENABLE_PDF_EXPORT
   - search


### PR DESCRIPTION
Prior to this change, we referred to macros defined in the `extra` dictionary of `mkdocs.yml` either with the `extra.` or even the
`config.extra.` prefix.

As [the mkdocs-macros-plugin documentation](https://mkdocs-macros-plugin.readthedocs.io/en/latest/pages/#configuration-variables
) explains, this is actually not necessary: any variables defined in `extra` can be referred to without such a prefix, and it is only when we want to access other variables in `config` (such as `config.repo_url`) that we need to fully qualify them.

Since the documentation sources become much more concise that way, use the abbreviated (unqualified) syntax.

Note: referring to the variables in this manner obviously means that in the `extra` dictionary we cannot have any top-level keys named `config`, `page`, `navigation`, `environment`, `plugin`, `git`, or `files`, but we don't at this time, and avoiding those top-level keys should not be a big issue in the future.
