### PR TITLE
Small navigation updates

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -1,4 +1,4 @@
-# Creating a new account in Cleura Cloud
+# Creating a new account
 
 To gain access to the {{gui}}, you first
 have to create a new account. For that, navigate to

--- a/docs/howto/openstack/neutron/.pages
+++ b/docs/howto/openstack/neutron/.pages
@@ -1,1 +1,4 @@
 title: "Neutron (networking service)"
+nav:
+  - new-network.md
+  - multiple-public-ips.md

--- a/docs/howto/openstack/neutron/new-network.md
+++ b/docs/howto/openstack/neutron/new-network.md
@@ -1,4 +1,4 @@
-# Creating new networks in Cleura Cloud
+# Creating new networks
 
 Before creating a server in {{brand}} Cloud, you need at least
 one network to make the new server a member of. Since you may have

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -1,4 +1,4 @@
-# Creating new servers in Cleura Cloud
+# Creating new servers
 
 Once you have an [account in {{brand}} 
 Cloud](/howto/getting-started/create-account), you can create virtual 


### PR DESCRIPTION
* Remove "in Cleura Cloud" from section headings. It doesn’t make much
  sense to keep it, because it’s obvious and redundant.
* Reorder pages in OpenStack Neutron how-to section, so that we don’t
  talk about networking specifics before explaining how to create a
  network.
