### PR TITLE
docs: Updates to Contribution Guide

### DIFF
--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -4,16 +4,23 @@ You have two options for editing content: directly in your browser
 using GitHub, or using a Git-based workflow from your local work
 environment.
 
-## Notes on specific content additions
+## Notes on content additions
 
-**Screen shots:** If you are contributing a change that contains
-screen shots from {{gui}}, they should use a resolution of
+
+**Sections:** Generally, content additions should fit somewhere within
+the existing top-level and second-level sections. Try not to introduce
+a new top-level or second-level section.
+
+**Screenshots:** If you are contributing a change that contains
+screenshots from {{gui}}, they should use a resolution of
 1920×1080 pixels (1080p). If your screen uses a larger resolution, use
 [Firefox Responsive Design
 Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
 or [Chrome/Chromium Device
 Mode](https://developer.chrome.com/docs/devtools/device-mode/) to
 configure your browser with 1080p.
+Screenshots should be added to a directory named `assets`, located in
+the same directory as the Markdown file you are adding or editing.
 
 **CLI screen dumps:** If you are contributing a change that contains a
 screen dump from the `openstack` command-line client, please limit its
@@ -116,7 +123,7 @@ export DOCS_ENABLE_HTMLPROOFER=false
 tox -e serve
 ```
 
-## A note on commit messages
+## Commit messages
 
 When you submit a change, you will need to provide a commit message,
 which is very nearly as important as the change itself. Excellent


### PR DESCRIPTION
* Discourage contributors from conjuring up new top-level or
  second-level sections.
* Mention the "assets" directory for screen shots.
