### PR TITLE
fix: Correct information on Dedicated CPU and Virtual GPU availability

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -12,8 +12,8 @@
 
 |                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Dedicated CPU](../../flavors/#compute-tiers) | :material-close: | :material-close:      | :material-close: | :material-close: | :material-close: |
-| [Virtual GPU](../../flavors/#compute-tiers)   | :material-close: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
+| [Dedicated CPU](../../flavors/#compute-tiers) | :material-close: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
+| [Virtual GPU](../../flavors/#compute-tiers)   | :material-close: | :material-close:      | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage


### PR DESCRIPTION
In the Sto2 region, a feature that is currently rolling out is
Dedicated CPU, not Virtual GPU. Fix the reference information
accordingly.
