### PR TITLE
refactor: Slightly reorganize Kubernetes how-tos

### DIFF
--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -6,9 +6,12 @@ that, and how to deploy a sample application on such a cluster.
 
 ## Prerequisites
 
-To access the cluster from your computer, you will need
-[kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
-on your machine.
+* To access Gardener functionality from {{gui}}, you need to enroll in
+  our closed beta. For access to the closed beta, contact our
+  [{{support}}](https://{{support_domain}}/servicedesk).
+* To access the Kubernetes cluster from your computer, you will need
+  [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
+  on your machine.
 
 ## Creating a Kubernetes cluster in {{gui}}
 

--- a/docs/howto/kubernetes/gardener/index.md
+++ b/docs/howto/kubernetes/gardener/index.md
@@ -1,0 +1,18 @@
+# Gardener
+
+Gardener is a Kubernetes-native system that provides automated
+management and operation of Kubernetes clusters as a service.  It
+allows you to create clusters and automatically handle their lifecycle
+operations, including configurable maintenance windows, hibernation
+schedules, and automatic updates to Kubernetes control plane and
+worker nodes.
+
+You can read more about Gardener and its capabilities on its
+[documentation website](https://gardener.cloud/docs/gardener/).
+
+> Gardener in {{brand}} Cloud is currently in a **closed beta** stage.
+> For access to the closed beta, contact our
+> [{{support}}](https://{{support_domain}}/servicedesk).
+
+To learn how to use Gardener in the {{gui}}, refer to [Creating
+Kubernetes clusters with Gardener](create-shoot-cluster.md).

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -1,40 +1,9 @@
 # Kubernetes in Cleura
 
-<!-- Config interpolation for the company name didn't work for the 
-title here. -->
+In {{brand}} Cloud you have several options for deploying and managing
+Kubernetes clusters.
 
-In {{company}} you can run Kubernetes in various
-ways. [{{gui}}](https://{{gui_domain}}) includes management
-interfaces for [Gardener](https://gardener.cloud/) and
-[OpenStack Magnum](https://docs.openstack.org/magnum/).
-
-### Gardener
-
-Gardener is a Kubernetes-native system that provides automated 
-management and operation of Kubernetes clusters as a service.
-It allows you to create clusters and automatically handle their 
-lifecycle operations, including configurable maintenance windows,
-hibernation schedules, and automatic updates to Kubernetes control 
-plane and worker nodes.
-You can read more about Gardener and its capabilities on its 
-[documentation website](https://gardener.cloud/docs/gardener/).
-
-To learn how to use Gardener in the {{gui}}, refer to
-[Creating Kubernetes clusters using
-{{gui}}](gardener/create-shoot-cluster.md).
-
-### Magnum
-
-Magnum lets you create clusters via the OpenStack APIs. To do that,
-you base your configuration on a Cluster Template. The template
-defines parameters describing how the cluster will be constructed,
-such as worker flavors. In each region, we offer predefined public
-Cluster Templates with ready-to-use configurations.  To learn more
-about Cluster Templates, check out the
-[Magnum documentation](https://docs.openstack.org/magnum/latest/user/#clustertemplate).
-
-Once you have chosen your Cluster Template, you move on to 
-[create a cluster based on that template](/howto/openstack/magnum/new-k8s-cluster).
-When you create the cluster, you can define the number of nodes in
-your cluster, ask for multiple master nodes with a load balancer
-in front, etc.
+[{{gui}}](https://{{gui_domain}}) includes management interfaces for
+[Gardener](gardener/) and [OpenStack Magnum](magnum/). To manage
+Magnum clusters, you can also use the [OpenStack command-line
+interface](../getting-started/enable-openstack-cli/).

--- a/docs/howto/kubernetes/magnum/index.md
+++ b/docs/howto/kubernetes/magnum/index.md
@@ -1,0 +1,15 @@
+# Magnum
+
+Magnum lets you create clusters via the OpenStack APIs. To do that,
+you base your configuration on a Cluster Template. The template
+defines parameters describing how the cluster will be constructed,
+such as worker flavors. In each region, we offer predefined public
+Cluster Templates with ready-to-use configurations.  To learn more
+about Cluster Templates, check out the [Magnum
+documentation](https://docs.openstack.org/magnum/latest/user/#clustertemplate).
+
+Once you have chosen your Cluster Template, you move on to [create a
+cluster based on that
+template](/howto/openstack/magnum/new-k8s-cluster).  When you create
+the cluster, you can define the number of nodes in your cluster, ask
+for multiple master nodes with a load balancer in front, etc.


### PR DESCRIPTION
* Add `index.md` files in the `howto/kubernetes/magnum` and `howto/kubernetes/gardener` directories.
* Move generic information about Gardener and Magnum into those files.
* Clarify that Gardener is in closed beta, and add instructions on how to enroll in it.
