### PR TITLE
feat: Access the rescue mode and access the original server disk

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,7 +2,7 @@
 
 ## OpenStack Services
 
-|                                | Kna1  | Sto2   | Fra1  | Dx1   | Tky1   |
+|                                | KNA1  | STO2   | FRA1  | DX1   | TKY1   |
 | ------------------------------ | ----- | ------ | ----- | ----- | ------ |
 | Barbican (secret storage)      | Xena  | Xena   | Xena  | Xena  | Xena   |
 | Cinder (block storage)         | Xena  | Xena   | Xena  | Xena  | Xena   |
@@ -17,7 +17,7 @@
 
 ## Ceph Services
 
-|                               | Kna1      | Sto2             | Fra1     | Dx1      | Tky1             |
+|                               | KNA1      | STO2             | FRA1     | DX1      | TKY1             |
 | --------------------------    | --------- | ------           | -----    | -----    | ------           |
 | Block storage (for OpenStack) | Nautilus  | Nautilus         | Nautilus | Nautilus | Nautilus         |
 | Object storage (Swift API)    | Nautilus  | :material-close: | Nautilus | Pacific  | :material-close: |


### PR DESCRIPTION
This is the continue of [CLDENG-846](https://jira.citynetwork.se/browse/CLDENG-846) to have system-rescue image on all public regions and using it on server rescue mode access, [KB](https://kb.citynetwork.eu/kb/how-to-articles/windows/how-to-enter-rescue-mode-and-access-the-original-c-disk-in-windows) resource 