### PR TITLE
build: Bump version tags for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           # commit, so that gitlint lints the correct commit message.
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install packages
@@ -32,7 +32,7 @@ jobs:
         # workflow. Until that is fixed, name the testenvs.
         run: tox -e gitlint,yamllint,bashate,build
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-${{ matrix.python-version }}-${{ github.sha }}
           path: site/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install Python dependencies


### PR DESCRIPTION
GitHub advises against the use of actions using Node.js 12. This is true for the v2 releases of the `checkout` and `setup-python`
actions. Thus, bump those actions to their latest versions (v3 and v4, respectively).

While we're at it, bump the `upload-artifact` action to v3 as well.

Reference:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
