### PR TITLE
refactor: Set "company" to "Cleura", "brand" to "Cleura Cloud"

### DIFF
--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -53,8 +53,8 @@ really pretty straightforward.
 
 ## License
 
-With the sole exception of trademarks like “{{brand}}” and the
-{{brand}} logo, the content on this site is available under the
+With the sole exception of trademarks like “{{company}}” and the
+{{company}} logo, the content on this site is available under the
 [Creative Commons Attribution-ShareAlike 4.0 International
 license](https://creativecommons.org/licenses/by-sa/4.0/), as you can
 see from the ![CC

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -139,7 +139,7 @@ commit message subjects. Please make sure that your commit message
 starts with one of the following prefixes:
 
 * `feat:` denotes a content addition, such as adding documentation for
-  some {{brand}} Cloud functionality that was not included in
+  some {{brand}} functionality that was not included in
   the documentation before.
 * `fix:` denotes a content correction, such as fixing a
   documentation bug.

--- a/docs/howto/getting-started/enable-openstack-cli.md
+++ b/docs/howto/getting-started/enable-openstack-cli.md
@@ -14,8 +14,8 @@ Only then will you be able to use any installed `openstack` client.
 
 ## Creating an OpenStack user
 
-From your favorite web browser, navigate to the [Cleura 
-Cloud](https://{{gui_domain}}) page, and login into your 
+From your favorite web browser, navigate to the
+[{{gui}}](https://{{gui_domain}}) start page, and login into your
 {{brand}} account.
 
 Please make sure the left-hand side pane on the {{gui}} is fully 
@@ -148,7 +148,7 @@ examples follow.
 
 Provided you have already sourced your RC file, you can now use the 
 `openstack` command line tool to access various OpenStack APIs on the 
-{{brand}} Cloud.
+{{brand}}.
 
 To make sure your local installation of `openstack` works as expected, 
 type:
@@ -157,7 +157,7 @@ type:
 openstack token issue
 ```
 
-If `openstack` can indeed connect to the {{brand}} Cloud 
+If `openstack` can indeed connect to the {{brand}} 
 OpenStack APIs, then you will get information, in tabular format, 
 regarding the issuance of a new token.
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -6,8 +6,8 @@ specific tasks in {{brand}} and the services we support.
 There are several categories of How-To guides, and they tend to be
 focused on a specific cloud technology.
 
-* **Getting Started** How-Tos help you create an account in Cleura
-  Cloud, and start using our services.
+* **Getting Started** How-Tos help you create an account in {{brand}},
+  and start using our services.
 
 * **Kubernetes** How-Tos cover how you can create and manage your
   Kubernetes deployments using {{gui}}.

--- a/docs/howto/kubernetes/gardener/index.md
+++ b/docs/howto/kubernetes/gardener/index.md
@@ -10,7 +10,7 @@ worker nodes.
 You can read more about Gardener and its capabilities on its
 [documentation website](https://gardener.cloud/docs/gardener/).
 
-> Gardener in {{brand}} Cloud is currently in a **closed beta** stage.
+> Gardener in {{brand}} is currently in a **closed beta** stage.
 > For access to the closed beta, contact our
 > [{{support}}](https://{{support_domain}}/servicedesk).
 

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -1,6 +1,6 @@
 # Kubernetes in Cleura
 
-In {{brand}} Cloud you have several options for deploying and managing
+In {{brand}}, you have several options for deploying and managing
 Kubernetes clusters.
 
 [{{gui}}](https://{{gui_domain}}) includes management interfaces for

--- a/docs/howto/object-storage/s3/index.md
+++ b/docs/howto/object-storage/s3/index.md
@@ -3,9 +3,9 @@
 [S3](https://en.wikipedia.org/wiki/Amazon_S3) is an object-access API
 based on HTTP and HTTPS.
 
-In {{brand}} Cloud, you interact with the S3 API using either the
-`s3cmd` command-line interface (CLI), the MinIO client CLI (`mc`), or
-the standard `aws` CLI.
+In {{brand}}, you interact with the S3 API using either the `s3cmd`
+command-line interface (CLI), the MinIO client CLI (`mc`), or the
+standard `aws` CLI.
 
 Either way, [in addition to installing and configuring the Python
 `openstackclient`
@@ -27,6 +27,6 @@ install one of the aforementioned utilities.
 
 ## Availability
 
-The S3 API is available in select {{brand}} Cloud regions. Refer to
-[the feature support matrix](/reference/features/) for details on S3
-API availability.
+The S3 API is available in select {{brand}} regions. Refer to [the
+feature support matrix](/reference/features/) for details on S3 API
+availability.

--- a/docs/howto/object-storage/swift/index.md
+++ b/docs/howto/object-storage/swift/index.md
@@ -6,8 +6,8 @@ name](https://en.wikipedia.org/wiki/Swift_(programming_language))) is
 an object-access API similar to, but distinct from, the [S3](../s3/) object
 storage API.
 
-In {{brand}} Cloud, you interact with the Swift API using either the
-`swift` command-line interface (CLI), or the standard `openstack` CLI.
+In {{brand}}, you interact with the Swift API using either the `swift`
+command-line interface (CLI), or the standard `openstack` CLI.
 
 Either way, [in addition to installing and configuring the Python
 `openstackclient`
@@ -29,6 +29,6 @@ manager of your operating system, or `pip`:
 
 ## Availability
 
-The OpenStack Swift API is available in select {{brand}} Cloud
+The OpenStack Swift API is available in select {{brand}}
 regions. Refer to [the feature support matrix](/reference/features/)
 for details on Swift API availability.

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -178,7 +178,7 @@ However, this being a public container, you can *also* retrieve your
 object using any regular HTTP/HTTPS client, using a public URL. This
 URL is composed as follows:
 
-1. The Swift API's base URL, which differs by {{brand}} Cloud region
+1. The Swift API's base URL, which differs by {{brand}} region
    (`https://swift‑<region>.{{brand_domain}}:<port>/swift/v1/`),
 2. the container's account string, starting with `AUTH_`,
 3. the container name (in our example, `public-container`),

--- a/docs/howto/openstack/barbican/generic-secret.md
+++ b/docs/howto/openstack/barbican/generic-secret.md
@@ -16,7 +16,7 @@ openstack secret store \
   -n mysecret
 ```
 
-> The example output below uses {{brand}}’s `Fra1` region. In
+> The example output below uses {{brand}}'s `Fra1` region. In
 > other regions, the secret
 > [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
 > will differ.

--- a/docs/howto/openstack/magnum/new-k8s-cluster.md
+++ b/docs/howto/openstack/magnum/new-k8s-cluster.md
@@ -8,13 +8,13 @@ cluster following both approaches.
 
 ## Prerequisites
 
-First and foremost, you need an [account in {{brand}} 
-Cloud](/howto/getting-started/create-account). If you prefer
-to work with the OpenStack CLI, go ahead and [enable it 
-first](/howto/getting-started/enable-openstack-cli). Then, in
-addition to the Python `openstackclient` module, make sure you
-also install the corresponding plugin module for Magnum. Use 
-either the package manager of your operating system or `pip`:
+First and foremost, you need an [account in
+{{brand}}](/howto/getting-started/create-account). If you prefer to
+work with the OpenStack CLI, go ahead and [enable it
+first](/howto/getting-started/enable-openstack-cli). Then, in addition
+to the Python `openstackclient` module, make sure you also install the
+corresponding plugin module for Magnum. Use either the package manager
+of your operating system or `pip`:
 
 === "Debian/Ubuntu"
 	```bash
@@ -30,10 +30,10 @@ either the package manager of your operating system or `pip`:
 
 ## Creating a Kubernetes cluster
 
-To create a Kubernetes cluster from the {{gui}}, fire up your favorite 
-web browser, navigate to the [{{brand}} Cloud](https://{{gui_domain}}) 
-page, and log into your {{brand}} account. On the other hand, if you 
-prefer to work with the OpenStack CLI, please do not forget to [source 
+To create a Kubernetes cluster from the {{gui}}, fire up your favorite
+web browser, navigate to the [{{gui}}](https://{{gui_domain}}) start
+page, and log into your {{brand}} account. On the other hand, if you
+prefer to work with the OpenStack CLI, please do not forget to [source
 the RC file first](/howto/getting-started/enable-openstack-cli).
 
 === "{{gui}}"

--- a/docs/howto/openstack/neutron/create-security-groups.md
+++ b/docs/howto/openstack/neutron/create-security-groups.md
@@ -9,9 +9,9 @@ the default rules for their group and add new rule sets."_
 
 ## Creating a security group
 
-Navigate to the [{{gui}}](https://{{gui_domain}}) page, and log into
-your {{brand}} account. On the other hand, if you prefer to work with
-the OpenStack CLI, please do not forget to [source the RC file
+Navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log
+into your {{brand}} account. On the other hand, if you prefer to work
+with the OpenStack CLI, please do not forget to [source the RC file
 first](/howto/getting-started/enable-openstack-cli).
 
 === "{{gui}}"

--- a/docs/howto/openstack/neutron/new-network.md
+++ b/docs/howto/openstack/neutron/new-network.md
@@ -1,24 +1,24 @@
 # Creating new networks
 
-Before creating a server in {{brand}} Cloud, you need at least
+Before creating a server in {{brand}}, you need at least
 one network to make the new server a member of. Since you may have
 more than one network per region, let us now walk through creating
 a new network using the {{gui}}, or using the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the
-OpenStack CLI, you need to [have an account](/howto/getting-started/create-account)
-in {{brand}} Cloud. Additionally, to use the OpenStack
-CLI make sure to [enable it first](/howto/getting-started/enable-openstack-cli).
+Whether you choose to work from the {{gui}} or with the OpenStack CLI,
+you need to [have an account](/howto/getting-started/create-account)
+in {{brand}}. Additionally, to use the OpenStack CLI make sure to
+[enable it first](/howto/getting-started/enable-openstack-cli).
 
 ## Creating a network
 
 To create a network from the {{gui}}, fire up your favorite web
-browser, navigate to the [Cleura Cloud](https://{{gui_domain}})
-page, and login into your {{brand}} account. On the other hand,
-if you prefer to work with OpenStack CLI, please do not forget to
-source the RC file first.
+browser, navigate to the [Cleura Cloud](https://{{gui_domain}}) start
+page, and login into your {{brand}} account. On the other hand, if you
+prefer to work with OpenStack CLI, please do not forget to source the
+RC file first.
 
 === "{{gui}}"
     On the top right-hand side of the {{gui}}, click the _Create_
@@ -29,7 +29,7 @@ source the RC file first.
 
     You will notice several rounded boxes prominently displayed on that
     pane, each for defining, configuring, and instantiating a different
-    {{brand}} Cloud object. Go ahead and click the _Network_ box. A
+    {{brand}} object. Go ahead and click the _Network_ box. A
     new pane titled _Create Network_ will slide over. At the top, type
     in a name and select one of the available regions for the new
     network.

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -11,7 +11,7 @@ CLI. Let us demonstrate the process following both approaches.
 
 Whether you choose to work from the {{gui}} or with the OpenStack CLI, 
 you need to [have an account](/howto/getting-started/create-account) in 
-{{brand}} Cloud. If you prefer to work with the [OpenStack 
+{{brand}}. If you prefer to work with the [OpenStack 
 CLI](/howto/getting-started/enable-openstack-cli), then in addition to 
 the Python `openstackclient` module, you need to install the 
 Python `neutronclient` module also. Use either the package manager 
@@ -31,20 +31,20 @@ of your operating system or `pip`:
 
 ## Creating a VPN connection between two regions
 
-To create and establish such a connection from the {{gui}}, fire up 
-your favorite web browser, navigate to the [{{brand}} 
-Cloud](https://{{gui_domain}}) page, and log into your {{brand}} 
-account. Should you decide to follow the OpenStack CLI route instead, 
-please make sure you have the appropriate
-[RC file](/howto/getting-started/enable-openstack-cli) for each
-region involved.
+To create and establish such a connection from the {{gui}}, fire up
+your favorite web browser, navigate to the
+[{{gui}}](https://{{gui_domain}}) start page, and log into your
+{{brand}} account. Should you decide to follow the OpenStack CLI route
+instead, please make sure you have the appropriate [RC
+file](/howto/getting-started/enable-openstack-cli) for each region
+involved.
 
 === "{{gui}}"
     On the top right-hand side of the {{gui}}, click the _Create_ 
     button. A vertical pane titled _Create_ will slide into view from the 
     right-hand side of the browser window. You will notice several rounded 
     boxes, each one for defining, configuring, and instantiating a 
-    different {{brand}} Cloud object. Go ahead and click the _VPN_ box.
+    different {{brand}} object. Go ahead and click the _VPN_ box.
         
     ![Create new object](assets/vpnaas/shot-01.png)
         

--- a/docs/howto/openstack/nova/config-drive.md
+++ b/docs/howto/openstack/nova/config-drive.md
@@ -7,7 +7,7 @@ OpenStack Compute uses metadata to inject custom configurations to
 servers on boot. You can add custom scripts, install packages, and
 add SSH keys to the servers using metadata.
 
-By default, metadata discovery in {{brand}} Cloud uses an HTTP
+By default, metadata discovery in {{brand}} uses an HTTP
 data source that booting servers connect to. Sometimes this is
 undesirable or — for specific server/networking configurations —
 unreliable. Under those circumstances, you can use an alternate

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -1,10 +1,10 @@
 # Creating new servers
 
-Once you have an [account in {{brand}} 
-Cloud](/howto/getting-started/create-account), you can create virtual 
-machines --- henceforth simply _servers_ --- using either the 
-{{gui}} or the OpenStack CLI. Let us demonstrate the creation of 
-a new server, following both approaches.
+Once you have an [account in
+{{brand}}](/howto/getting-started/create-account), you can create
+virtual machines --- henceforth simply _servers_ --- using either the
+{{gui}} or the OpenStack CLI. Let us demonstrate the creation of a new
+server, following both approaches.
 
 ## Prerequisites
 
@@ -16,11 +16,11 @@ first](/howto/getting-started/enable-openstack-cli).
 
 ## Creating a server
 
-To create a server from the {{gui}}, fire up your favorite web 
-browser, navigate to the [Cleura Cloud](https://{{gui_domain}}) 
-page, and log into your {{brand}} account. On the other hand, 
-if you prefer to work with the OpenStack CLI, please do not forget to 
-[source the RC file first](/howto/getting-started/enable-openstack-cli).
+To create a server from the {{gui}}, fire up your favorite web
+browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page,
+and log into your {{brand}} account. On the other hand, if you prefer
+to work with the OpenStack CLI, please do not forget to [source the RC
+file first](/howto/getting-started/enable-openstack-cli).
 
 === "{{gui}}"
 	On the top right-hand side of the {{gui}}, click the 
@@ -30,7 +30,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	![Create new object](assets/new-server/shot-01.png)
 		
 	You will notice several rounded boxes on that pane, each for 
-	defining, configuring, and instantiating a different {{brand}} 
+	defining, configuring, and instantiating a different {{company}} 
 	Cloud object. Go ahead and click the _Server_ box. A new pane titled 
 	_Create a Server_ will slide over. At the top, type in a name for the 
 	new server and select one of the available regions.
@@ -87,7 +87,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	![Networking and security groups](assets/new-server/shot-05.png)
 		
 	If you already have one or more public keys in your 
-	{{brand}} Cloud account, you can now select a key to be included 
+	{{brand}} account, you can now select a key to be included 
 	in the `~/.ssh/authorized_keys` file of the server's default user. That 
 	way, you can securely log into the remote user's account without typing 
 	a password. If there are no public keys to choose from, activate the 
@@ -104,7 +104,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 		
 	![User-data propagation method](assets/new-server/shot-07.png)
 		
-	It is now time to create your {{brand}} Cloud server; 
+	It is now time to create your {{brand}} server; 
 	click the green _Create_ button, and the new server will be readily 
 	available in a few seconds.
 		
@@ -148,7 +148,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	```
 		
 	Your server should have an image to boot off of (`IMAGE_NAME`). 
-	For a list of all available images in {{brand}} Cloud, type:
+	For a list of all available images in {{brand}}, type:
 		
 	```bash
 	openstack image list
@@ -219,14 +219,14 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 		
 	You most likely want a server you can remotely connect to via 
 	SSH without typing a password. Upload one of our public keys to your 
-	{{brand}} Cloud account:
+	{{brand}} account:
 		
 	```bash
 	openstack keypair create --public-key ~/.ssh/id_ed25519.pub bahnhof
 	```
 		
 	In the example above, we uploaded the public key 
-	`~/.ssh/id_ed25519.pub` to our {{brand}} Cloud account and named 
+	`~/.ssh/id_ed25519.pub` to our {{brand}} account and named 
 	it `bahnhof`. Follow our example and do not forget to set the 
 	`KEY_NAME`:
 		
@@ -271,10 +271,10 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	used the actual values and not the variables we so meticulously set.) 
 	The `--wait` parameter is optional. Whenever you choose to 
 	use it, you get back control of your terminal only after the server is 
-	readily available in {{brand}} Cloud.
+	readily available in {{brand}}.
 	
 	To connect to your server remotely, you need to create a floating IP
-	for the external network in the {{brand}} Cloud, and then assign
+	for the external network in the {{brand}}, and then assign
 	this IP to your server. First, create the floating IP: 
 	
 	```bash
@@ -332,7 +332,7 @@ if you prefer to work with the OpenStack CLI, please do not forget to
 	![Launch remote console](assets/new-server/shot-10.png)
 		
 	A new window pops up, and that's your web console to your 
-	{{brand}} Cloud server. Please note that this window cannot be 
+	{{brand}} server. Please note that this window cannot be 
 	resized but can be opened on a new browser window or tab.
 		
 	![Server console](assets/new-server/shot-11.png)

--- a/docs/howto/openstack/nova/resize-server.md
+++ b/docs/howto/openstack/nova/resize-server.md
@@ -131,7 +131,7 @@ Choose a new flavor that you want your server to use instead.
     +-----------------------+---------------+
     ```
 
-The resize process might take a minute or more. {{brand}} Cloud will
+The resize process might take a minute or more. {{brand}} will
 now make a restore point in case the resize process fails. It would
 then restore your server to the state it was before the resize.
 
@@ -169,4 +169,4 @@ automatically have the resize confirmed after 24 hours.
     openstack server resize revert <server_id>
     ```
 
-This concludes the process of resizing a server in {{brand}} Cloud.
+This concludes the process of resizing a server in {{brand}}.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # Start Here
 
-This is the {{brand}} **Beta** documentation web site.
+This is the {{company}} **Beta** documentation web site.
 
 ## What does "Beta" mean?
 
 The fact that this site is in a Beta stage means that any information
-you find here should be reliable and accurate for {{brand}}
+you find here should be reliable and accurate for {{company}}
 products and services. If you find any published documentation that is
 inaccurate or not in line with functionality as you observe it on
 {{brand}}, we would very much appreciate if you filed

--- a/docs/reference/features/index.md
+++ b/docs/reference/features/index.md
@@ -1,13 +1,13 @@
 # Feature support matrix
 
-Services in {{brand}} Cloud constantly evolve, and we gradually
+Services in {{brand}} constantly evolve, and we gradually
 add features to regions as they become available and mature.
 
-This page lists the cloud features available in each {{brand}}
+This page lists the cloud features available in each {{company}}
 Cloud region.
 
-* [Public Cloud](public.md): features supported in our {{brand}}
+* [Public Cloud](public.md): features supported in our {{company}}
   Public Cloud regions.
 
 * [Compliant Cloud](compliant.md): features supported in our
-  {{brand}} Compliant Cloud regions.
+  {{company}} Compliant Cloud regions.

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -1,6 +1,6 @@
 # Flavors
 
-Any server instance running in {{brand}} Cloud has a **flavor**,
+Any server instance running in {{brand}} has a **flavor**,
 which defines the number of virtual CPU cores, the amount of virtual
 RAM, and other performance-related factors.
 
@@ -25,12 +25,12 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
 
 ## Compute tiers
 
-{{brand}} Cloud defines the following compute tiers:
+{{brand}} defines the following compute tiers:
 
 * `b`: General purpose. This is the default compute tier. Instances
   launched with matching flavors use highly available network-attached
   storage. This makes them flexible to migrate within the
-  {{brand}} Cloud infrastructure, without interruption.
+  {{brand}} infrastructure, without interruption.
   Some
   [limitations](../../howto/openstack/cinder/encrypted-volumes/#block-device-encryption-caveats)
   apply to instances with attached [encrypted
@@ -49,10 +49,10 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
   access to a
   [GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit).
 
-Some tiers are only available in select {{brand}} Cloud
+Some tiers are only available in select {{brand}}
 regions. For details on tier availability, see the [Feature support
 matrix](../features/index.md).
 
 The general-purpose tier is always available to all {{brand}}
-Cloud customers. For access to other tiers, contact our
+customers. For access to other tiers, contact our
 [{{support}}](https://{{support_domain}}/servicedesk).

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -1,27 +1,27 @@
 # Service version matrix
 
-Services in {{brand}} Cloud are updated on a regular basis and
+Services in {{brand}} are updated on a regular basis and
 on a rolling schedule.
 
 This section lists the cloud API service versions available in each
-{{brand}} Cloud region.
+{{brand}} region.
 
-* [Public Cloud](public.md): versions running in our {{brand}}
+* [Public Cloud](public.md): versions running in our {{company}}
   Public Cloud regions.
 
 * [Compliant Cloud](compliant.md): versions running in our
-  {{brand}} Compliant Cloud regions.
+  {{company}} Compliant Cloud regions.
 
 
 ## OpenStack Services
 
 [OpenStack releases](https://releases.openstack.org/) are named, in
 alphabetical order, and occur on a six-month release schedule. In
-{{brand}} Public Cloud we upgrade OpenStack releases annually; this
+{{company}} Public Cloud we upgrade OpenStack releases annually; this
 means that we deploy every other OpenStack release and skip the
 intervening one.
 
-{{brand}} Cloud currently runs OpenStack
+{{brand}} currently runs OpenStack
 [Xena](https://releases.openstack.org/xena).
 
 
@@ -31,5 +31,5 @@ intervening one.
 releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
-{{brand}} Cloud currently runs Ceph
+{{brand}} currently runs Ceph
 [Pacific](https://docs.ceph.com/en/latest/releases/pacific/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ extra:
   analytics:
     domain: docs.cleura.cloud
     provider: plausible
-  brand: "Cleura"
+  brand: "Cleura Cloud"
   brand_domain: "citycloud.com"
   company: "Cleura"
   company_domain: "cleura.com"


### PR DESCRIPTION
We did a poor job at defining the `company` and `brand` extra variables early on. `company` should really refer to the company name (in our case, "Cleura"), and `brand` should refer to the cloud product (in our case, "Cleura Cloud").

Update the variables accordingly, and fix the references.