### PR TITLE
feat: Add HowTo rescue servers

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,7 +2,7 @@
 
 ## OpenStack Services
 
-|                                | Kna1  | Sto2   | Fra1  | Dx1   | Tky1   |
+|                                | KNA1  | STO2   | FRA1  | DX1   | TKY1   |
 | ------------------------------ | ----- | ------ | ----- | ----- | ------ |
 | Barbican (secret storage)      | Xena  | Xena   | Xena  | Xena  | Xena   |
 | Cinder (block storage)         | Xena  | Xena   | Xena  | Xena  | Xena   |
@@ -17,7 +17,7 @@
 
 ## Ceph Services
 
-|                               | Kna1      | Sto2             | Fra1     | Dx1      | Tky1             |
+|                               | KNA1      | STO2             | FRA1     | DX1      | TKY1             |
 | --------------------------    | --------- | ------           | -----    | -----    | ------           |
 | Block storage (for OpenStack) | Nautilus  | Nautilus         | Nautilus | Nautilus | Nautilus         |
 | Object storage (Swift API)    | Nautilus  | :material-close: | Nautilus | Pacific  | :material-close: |


### PR DESCRIPTION
This guide will walk you through the required steps to access the the rescue mode when you need to
 
 1. Access the server operating system disk to fix corrupted file system.
 2. Reset access credential due losing it.