### PR TITLE
feat: Explain how to disable object expiry in the S3 how-to

### DIFF
--- a/docs/howto/object-storage/s3/expiry.md
+++ b/docs/howto/object-storage/s3/expiry.md
@@ -7,6 +7,8 @@
 You can set a bucket's lifecycle configuration such that it automatically 
 deletes objects after a certain number of days. 
 
+## Enabling object expiry
+
 First, you need to create a JSON file, `lifecycle.json`, that contains
 the lifecycle configuration rule. Be sure to set `Days` to your
 desired value:
@@ -32,8 +34,8 @@ the following commands:
     aws --profile <region> \
       --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api put-bucket-lifecycle-configuration \
-	  --lifecycle-configuration file://lifecycle.json \ 
-	  --bucket <bucket-name>
+      --lifecycle-configuration file://lifecycle.json \ 
+      --bucket <bucket-name>
     ```
 === "mc"
     ```bash
@@ -41,5 +43,34 @@ the following commands:
     ```
 === "s3cmd"
     ```bash
-	s3cmd -c ~/.s3cfg-<region> setlifecycle lifecycle.json s3://<bucket-name>
+    s3cmd -c ~/.s3cfg-<region> setlifecycle lifecycle.json s3://<bucket-name>
+    ```
+
+## Removing object expiry
+
+At some point, you might want to remove the object expiry
+functionality configuration from a bucket, so that objects in it no
+longer auto-delete after a period.
+
+=== "aws"
+    With the `aws s3api` command, you can remove the lifecycle
+    configuration from a bucket:
+    ```bash
+    aws --profile <region> \
+      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      s3api delete-bucket-lifecycle \
+      --bucket <bucket-name>
+    ```
+=== "mc"
+    With `mc`, you are able to remove just an individual bucket
+    lifecycle rule. Assuming your rule uses the ID `cleanup`, here is
+    how you remove it:
+    ```bash
+    mc ilm rm --id "cleanup" <region>/<bucket-name>
+    ```
+=== "s3cmd"
+    With `s3cmd`, you can remove the lifecycle configuration from a
+    bucket:
+    ```bash
+    s3cmd -c ~/.s3cfg-<region> dellifecycle s3://<bucket-name>
     ```


### PR DESCRIPTION
Previously, we only explained how to enable object expiry on an
S3 bucket. Extend the how-to guide to also cover removing the
object expiry lifecycle policy.
