### PR TITLE
build: Add Markdown linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # necessary here, but for some reason tox invokes no testenvs
         # at all if invoked as just "tox" from the GitHub Actions
         # workflow. Until that is fixed, name the testenvs.
-        run: tox -e gitlint,yamllint,bashate,build
+        run: tox -e gitlint,yamllint,bashate,markdownlint,build
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -1,0 +1,24 @@
+{
+    "extensions": {
+        "front-matter": {
+            "enabled": true
+        }
+    },
+    "plugins" : {
+        "blanks-around-fences": {
+            "enabled": false
+        },
+        "code-block-style": {
+            "enabled": false
+        },
+        "line-length": {
+            "enabled": false
+        },
+        "no-multiple-blanks": {
+            "maximum": 2
+        },
+        "blanks-around-headings": {
+            "enabled": false
+        }
+    }
+}

--- a/docs/background/gui-vs-api.md
+++ b/docs/background/gui-vs-api.md
@@ -1,43 +1,43 @@
 # Cleura Cloud Management Panel vs. OpenStack API
 
 You can do many tasks in {{brand}} via the
-[{{gui}}](https://{{gui_domain}}) or via the OpenStack API, e.g., with 
+[{{gui}}](https://{{gui_domain}}) or via the OpenStack API, e.g., with
 the help of the
 [OpenStack CLI](../../howto/getting-started/enable-openstack-cli) tool.
 For some tasks, though, you *will need* the OpenStack API.
- 
+
 But when does it make sense to prefer a particular way of working?
 What are the reasons, if any, for choosing one method over the other?
 
 ## The case for {{gui}}
 
-Ease of use is probably the main reason for choosing the {{gui}} over 
-the OpenStack API. Provided you have an [account in 
-{{brand}}](../../howto/getting-started/create-account), you can simply 
-log in and then follow step-by-step guides to create entities such as 
-[networks](../../howto/openstack/neutron/new-network), 
-[servers](../../howto/openstack/nova/new-server), or even 
-[Kubernetes clusters](../../howto/openstack/magnum/new-k8s-cluster). 
-You can just as easily perform administrative tasks like creating 
-[security 
-groups](../../howto/openstack/neutron/create-security-groups), setting 
-up [region-to-region VPN](../../howto/openstack/neutron/vpnaas) 
-connections, [deleting 
-networks](../../howto/openstack/neutron/delete-network), modifying 
-[billing data](../../howto/account-billing/change-billing-data), or 
+Ease of use is probably the main reason for choosing the {{gui}} over
+the OpenStack API. Provided you have an [account in
+{{brand}}](../../howto/getting-started/create-account), you can simply
+log in and then follow step-by-step guides to create entities such as
+[networks](../../howto/openstack/neutron/new-network),
+[servers](../../howto/openstack/nova/new-server), or even
+[Kubernetes clusters](../../howto/openstack/magnum/new-k8s-cluster).
+You can just as easily perform administrative tasks like creating
+[security
+groups](../../howto/openstack/neutron/create-security-groups), setting
+up [region-to-region VPN](../../howto/openstack/neutron/vpnaas)
+connections, [deleting
+networks](../../howto/openstack/neutron/delete-network), modifying
+[billing data](../../howto/account-billing/change-billing-data), or
 [managing invoices](../../howto/account-billing/manage-invoices).
 
-All in all, there are many instances when the {{gui}} is all you want 
+All in all, there are many instances when the {{gui}} is all you want
 and, at the same time, is more than enough for what you want.
 
 ## The case for OpenStack API
 
-There will be times when working from the terminal of your laptop is 
-preferable to using the {{gui}}. In cases like this, you will use the 
-OpenStack API via a tool like the OpenStack CLI. Although `openstack` 
-usually requires some reading before doing a specific task, it doesn't 
-take much time to get used to its logic for constructing commands to 
-achieve what you want. Plus, there is hardly a thing you can't do with 
+There will be times when working from the terminal of your laptop is
+preferable to using the {{gui}}. In cases like this, you will use the
+OpenStack API via a tool like the OpenStack CLI. Although `openstack`
+usually requires some reading before doing a specific task, it doesn't
+take much time to get used to its logic for constructing commands to
+achieve what you want. Plus, there is hardly a thing you can't do with
 `openstack` or a CLI tool that talks to the OpenStack API.
 
 We should also point out that specific tasks can be performed _only_
@@ -51,10 +51,10 @@ with the OpenStack API and various CLI tools, is when you have to
 interact with the [S3 API](../../howto/object-storage/s3) or the
 [Swift API](../../howto/object-storage/swift).
 
-Even though the command syntax of `openstack` may sometimes look overly 
-complicated, the potential for scripting can speed up many operations 
-considerably. In addition to that, the OpenStack API is employed by 
-configuration management systems and automation platforms like 
+Even though the command syntax of `openstack` may sometimes look overly
+complicated, the potential for scripting can speed up many operations
+considerably. In addition to that, the OpenStack API is employed by
+configuration management systems and automation platforms like
 [Ansible](https://www.ansible.com), and infrastructure as code
 systems like [Terraform](https://www.terraform.io) and
 [Pulumi](https://www.pulumi.com).

--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -4,4 +4,4 @@ This section contains discussions regarding various features and
 modes of operation {{brand}} provides. Those discussions are not
 concerned with how to do specific tasks, but rather with what
 features to take advantage of or how to go about achieving a
-set goal. 
+set goal.

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -59,7 +59,7 @@ First, create a fork of the documentation repository:
     Open <{{ config.repo_url }}> and click the *Fork* button.
     When you create your new fork, it's fine to leave the
     *Copy the `main` branch only* option enabled.
-    
+
     Then, proceed to create a new local checkout of your fork:
     ```bash
     git clone git@github.com:<yourusername>/<your-repo-fork> {{ brand | lower }}-docs
@@ -70,9 +70,9 @@ First, create a fork of the documentation repository:
     gh repo fork --clone {{ config.repo_url }} -- {{ brand | lower }}-docs
     cd {{ brand | lower }}-docs
     ```
-    
+
 Next, create a local topic branch and make your modifications:
-    
+
 ```bash
 git checkout -b <your-topic-branch-name>
 # edit your files

--- a/docs/contrib/quality.md
+++ b/docs/contrib/quality.md
@@ -11,6 +11,9 @@ you [send your PR](modifications.md):
   message style.
 * We check whether the documentation still builds correctly, with your
   change applied.
+* We apply [pymarkdownlnt](https://github.com/jackdewinter/pymarkdown)
+  checks for Markdown consistency and to encourage some good
+  documentation practices.
 * We check to make sure that no internal or external links in the
   documentation are dead. This is one example where the checks might
   fail through no fault of yours — some external link may have

--- a/docs/howto/account-billing/manage-invoices.md
+++ b/docs/howto/account-billing/manage-invoices.md
@@ -1,49 +1,49 @@
 # Managing invoices
 
-You may quickly review your invoices regarding the monthly usage of 
-{{brand}} resources, selectively pay outstanding invoices, save any 
-number in PDF format, and change the email address for receiving such 
+You may quickly review your invoices regarding the monthly usage of
+{{brand}} resources, selectively pay outstanding invoices, save any
+number in PDF format, and change the email address for receiving such
 invoices.
 
-First, fire up your favorite web browser, navigate to the 
-[{{gui}}](https://{{gui_domain}}) start page, and log into your 
+First, fire up your favorite web browser, navigate to the
+[{{gui}}](https://{{gui_domain}}) start page, and log into your
 {{brand}} account.
 
 ## Listing invoices
 
-Make sure the vertical pane on the left-hand side of the dashboard is 
-expanded. Please look at the options and click on _Invoices_ (right 
-below _Users_). Then, in the main pane of the dashboard, you will see a 
+Make sure the vertical pane on the left-hand side of the dashboard is
+expanded. Please look at the options and click on _Invoices_ (right
+below _Users_). Then, in the main pane of the dashboard, you will see a
 list of paid and outstanding invoices.
 
 ![All invoices](assets/mgmnt-inv/shot-01.png)
 
-Any paid invoice has a green circle-with-tick icon at the left of its 
-row. Also, look at the _Outstanding Amount_ column, where there is a 
+Any paid invoice has a green circle-with-tick icon at the left of its
+row. Also, look at the _Outstanding Amount_ column, where there is a
 value of `0.00` for each paid invoice.
 
 ![Paid invoices](assets/mgmnt-inv/shot-02.png)
 
 ## Displaying invoice details
 
-Notice the three-dot orange icon at the right of any invoice row. By 
-clicking on it, you get a pop-up with specific options regarding the 
-corresponding invoice. For example, you can view the invoice's PDF or 
+Notice the three-dot orange icon at the right of any invoice row. By
+clicking on it, you get a pop-up with specific options regarding the
+corresponding invoice. For example, you can view the invoice's PDF or
 download it onto your computer.
 
 ![Options regarding selected invoice](assets/mgmnt-inv/shot-03.png)
 
 ## Paying outstanding invoices
 
-There is also the _Pay this invoice_ option. Choose it for an 
-outstanding invoice and you will get a pop-up with a detailed rundown 
+There is also the _Pay this invoice_ option. Choose it for an
+outstanding invoice and you will get a pop-up with a detailed rundown
 of the dues, together with supported payment methods.
 
 ![Payment options](assets/mgmnt-inv/shot-04.png)
 
 ## Changing your invoice email address
 
-Finally, you may change the email address for receiving invoices. At 
+Finally, you may change the email address for receiving invoices. At
 the right-hand side of the dashboard, click the user icon at the top
 of the page. A pane titled _Account settings_ will slide over.
 
@@ -51,10 +51,10 @@ There are three tabs in that pane:
 
 * _Customer Info_,
 * _Contact_,
-* _Settings_. 
+* _Settings_.
 
-Click the middle one, _Contact_. If there is only one email address, it 
-will have all available roles activated --- including the _Billing_ 
+Click the middle one, _Contact_. If there is only one email address, it
+will have all available roles activated --- including the _Billing_
 role.
 
 ![Contact info](assets/mgmnt-inv/shot-05.png)

--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -11,7 +11,7 @@ Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
 At your leisure, please read the [City Network General Terms And
 Conditions](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf)
-and our 
+and our
 [Data Processing Agreement](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf).
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.

--- a/docs/howto/getting-started/enable-openstack-cli.md
+++ b/docs/howto/getting-started/enable-openstack-cli.md
@@ -6,10 +6,10 @@ various OpenStack APIs. Using the OpenStack CLI tool, you can remotely
 create and manage the lifecycle of objects related, for example, to
 Compute, Networking, or Storage.
 
-Before installing `openstack` to your local laptop or workstation, you 
-first need to have an OpenStack user in your {{brand}} account. 
-Next, you create and download a special RC file onto your computer, 
-modify it to reflect your OpenStack user's credentials, and source it. 
+Before installing `openstack` to your local laptop or workstation, you
+first need to have an OpenStack user in your {{brand}} account.
+Next, you create and download a special RC file onto your computer,
+modify it to reflect your OpenStack user's credentials, and source it.
 Only then will you be able to use any installed `openstack` client.
 
 ## Creating an OpenStack user
@@ -18,67 +18,67 @@ From your favorite web browser, navigate to the
 [{{gui}}](https://{{gui_domain}}) start page, and login into your
 {{brand}} account.
 
-Please make sure the left-hand side pane on the {{gui}} is fully 
-visible, click the _Users_ category to expand it, and click on 
+Please make sure the left-hand side pane on the {{gui}} is fully
+visible, click the _Users_ category to expand it, and click on
 _Openstack Users_.
 
 ![Add a new OpenStack user](assets/ostack-cli/shot-01.png)
 
-Then, at the top right-hand side of the {{gui}}, click once more 
-the _Add new Openstack user_ option. A new pane will slide into view, 
+Then, at the top right-hand side of the {{gui}}, click once more
+the _Add new Openstack user_ option. A new pane will slide into view,
 titled _Create Openstack User_.
 
 ![Create new OpenStack user](assets/ostack-cli/shot-02.png)
 
-Type in a username and a password for the new OpenStack user. To ensure 
-you typed the password correctly, you must re-type it below. This 
-password should be adequately strong, and thus a password manager may 
+Type in a username and a password for the new OpenStack user. To ensure
+you typed the password correctly, you must re-type it below. This
+password should be adequately strong, and thus a password manager may
 come in handy.
 
 ![Set username and password](assets/ostack-cli/shot-03.png)
 
-Scroll down a bit, so the _Regions_ section is in full view. Expand one 
-or more of the available regions you want your new user to have access 
-to. For each one of the expanded regions, select one or more 
+Scroll down a bit, so the _Regions_ section is in full view. Expand one
+or more of the available regions you want your new user to have access
+to. For each one of the expanded regions, select one or more
 _Projects_. For each project, activate one or more _Roles_. (Hint: For
 an overview of the rights that roles provide, hover the mouse pointer
-over the exclamation mark icon by the _Roles_.) 
+over the exclamation mark icon by the _Roles_.)
 
 ![Regions, projects, and roles](assets/ostack-cli/shot-04.png)
 
-Optionally, type in a description for the new OpenStack user. Then, 
-create the user by clicking the green _Create_ button below the 
+Optionally, type in a description for the new OpenStack user. Then,
+create the user by clicking the green _Create_ button below the
 _Description_ box.
 
 ![User description and creation](assets/ostack-cli/shot-05.png)
 
-The new OpenStack user will be ready in just a few seconds. At any 
-time, you can view all available OpenStack users by going to the 
-left-hand side pane on the {{gui}} and selecting _Users_ > 
+The new OpenStack user will be ready in just a few seconds. At any
+time, you can view all available OpenStack users by going to the
+left-hand side pane on the {{gui}} and selecting _Users_ >
 _Openstack Users_.
 
 ![All available OpenStack users](assets/ostack-cli/shot-06.png)
 
 ## Creating and downloading an RC file
 
-On the {{gui}} expand the left-hand side pane, click _Users_ and 
-then _Openstack Users_. You will then see, listed in the main pane 
-titled _Openstack Users_, all available users. Click on the 
-three-dotted round icon on the right of the user you want to create an 
+On the {{gui}} expand the left-hand side pane, click _Users_ and
+then _Openstack Users_. You will then see, listed in the main pane
+titled _Openstack Users_, all available users. Click on the
+three-dotted round icon on the right of the user you want to create an
 RC file for. From the pop-up that appears, select _Generate RC file_.
 
 ![Generate  RC file](assets/ostack-cli/shot-07.png)
 
-The RC file will be generated automatically. Before downloading it onto 
-your local computer, you must select one of the available projects to 
+The RC file will be generated automatically. Before downloading it onto
+your local computer, you must select one of the available projects to
 relate the RC file to. Do so and then click the blue _Download_ button.
 
 ![Select project and download](assets/ostack-cli/shot-08.png)
 
-A "Save as" dialog window appears, specific to the operating system you 
+A "Save as" dialog window appears, specific to the operating system you
 are currently using. Select a convenient location and save your RC file.
- 
-## Modifying and sourcing the RC file 
+
+## Modifying and sourcing the RC file
 
 The general naming for RC files goes like this:
 
@@ -86,8 +86,8 @@ The general naming for RC files goes like this:
 your_username--region_name--project_name--rc
 ```
 
-So, assuming your username is `olafsdottir`, and the RC file has been 
-created for the `fra1` region and the `katla` project, your RC file 
+So, assuming your username is `olafsdottir`, and the RC file has been
+created for the `fra1` region and the `katla` project, your RC file
 name should be this:
 
 ```plain
@@ -109,8 +109,8 @@ export OS_AUTH_VERSION=3
 export OS_IDENTITY_API_VERSION=3
 ```
 
-Before you source the RC file, and thus initialize all relevant environment 
-variables, make sure to edit the file and put your OpenStack user 
+Before you source the RC file, and thus initialize all relevant environment
+variables, make sure to edit the file and put your OpenStack user
 password in place of `<your password goes here>`. Also, change the
 permissions of the file, so it is readable and writable by your local
 user only:
@@ -127,38 +127,38 @@ source olafsdottir--fra1--katla--rc
 
 ## Installing the OpenStack CLI
 
-If you do not have the OpenStack CLI tool readily available, use your 
-operating system's package manager or `pip` to install it. Some 
+If you do not have the OpenStack CLI tool readily available, use your
+operating system's package manager or `pip` to install it. Some
 examples follow.
 
 === "Debian/Ubuntu"
-	```bash
-	apt update && apt install python3-openstackclient 
-	```
+    ```bash
+    apt update && apt install python3-openstackclient
+    ```
 === "Mac OS X with Homebrew"
-	```bash
-	brew install openstackclient
-	```
+    ```bash
+    brew install openstackclient
+    ```
 === "Python package"
-	```bash
-	pip install python-openstackclient
-	```
+    ```bash
+    pip install python-openstackclient
+    ```
 
 ## Testing access
 
-Provided you have already sourced your RC file, you can now use the 
-`openstack` command line tool to access various OpenStack APIs on the 
+Provided you have already sourced your RC file, you can now use the
+`openstack` command line tool to access various OpenStack APIs on the
 {{brand}}.
 
-To make sure your local installation of `openstack` works as expected, 
+To make sure your local installation of `openstack` works as expected,
 type:
 
 ```bash
 openstack token issue
 ```
 
-If `openstack` can indeed connect to the {{brand}} 
-OpenStack APIs, then you will get information, in tabular format, 
+If `openstack` can indeed connect to the {{brand}}
+OpenStack APIs, then you will get information, in tabular format,
 regarding the issuance of a new token.
 
 To get general help regarding `openstack`, type:
@@ -167,7 +167,7 @@ To get general help regarding `openstack`, type:
 openstack --help
 ```
 
-When you need help on a specific command, type something like 
+When you need help on a specific command, type something like
 `openstack help command`.
 
 

--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -66,8 +66,8 @@ How exactly you do that depends on your preferred client:
       https://s3-<region>.{{brand_domain}}:8080 \
       <access-key> <secret-key>
     ```
-	Once you have configured an alias like this, you are able to
-	run bucket operations with `mc` using the `alias/bucket` syntax.
+    Once you have configured an alias like this, you are able to
+    run bucket operations with `mc` using the `alias/bucket` syntax.
 === "s3cmd"
     `s3cmd` does not support configuration profiles, so you need to use
     a separate configuration file for each {{brand}} region you

--- a/docs/howto/object-storage/s3/expiry.md
+++ b/docs/howto/object-storage/s3/expiry.md
@@ -1,9 +1,6 @@
 ---
-description: >
-  You can set a bucket’s lifecycle configuration such that it
-  automatically deletes objects after a certain number of days.
+description: You can set a bucket’s lifecycle configuration such that it automatically deletes objects after a certain number of days.
 ---
-
 # Object expiry
 
 > Object expiry requires that you configure your environment with
@@ -38,7 +35,7 @@ the following commands:
     aws --profile <region> \
       --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
       s3api put-bucket-lifecycle-configuration \
-      --lifecycle-configuration file://lifecycle.json \ 
+      --lifecycle-configuration file://lifecycle.json \
       --bucket <bucket-name>
     ```
 === "mc"

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -36,15 +36,15 @@ request being made:
 In order to generate encryption key and store it in Barbican, proceed
 as follows.
 
-1.  Generate secret:
+1. Generate secret:
 
         secret_raw=$(pwgen 32 1)
 
-2.  Store secret in Barbican:
+2. Store secret in Barbican:
 
         barbican_secret_url=$(openstack secret store --name objectSecret --algorithm aes --bit-length 256 --payload ${secret_raw} -f value -c 'Secret href')
 
-3.  Retrieve secret from Barbican:
+3. Retrieve secret from Barbican:
 
         secret=$(openstack secret get ${barbican_secret_url} -p -c Payload -f value)
 

--- a/docs/howto/object-storage/swift/expiry.md
+++ b/docs/howto/object-storage/swift/expiry.md
@@ -28,6 +28,7 @@ automatically deleted at that time:
 
 ```console
 $ swift post -H "X-Delete-At: 1709164800" private-container testobj.txt
+
 ```
 
 Then, you can read back the header with `swift stat`:
@@ -58,6 +59,7 @@ deleted after that timespan. This example uses 600 seconds or
 
 ```console
 $ swift post -H "X-Delete-After: 600" private-container testobj.txt
+
 ```
 
 The Swift API then converts this into an `X-Delete-At` header, adding

--- a/docs/howto/object-storage/swift/private-container.md
+++ b/docs/howto/object-storage/swift/private-container.md
@@ -22,8 +22,8 @@ with proper Swift API credentials), use the following command:
     +---------------------------------------+-------------------+----------------------------------------------------+
     ```
 === "Swift CLI"
-    ```console
-    $ swift post private-container
+    ```bash
+    swift post private-container
     ```
     This command produces no output.
 
@@ -90,8 +90,8 @@ you can also use this command:
 
 To upload an object into the container, create a local test file:
 
-```console
-$ echo "hello world" > testobj.txt
+```bash
+echo "hello world" > testobj.txt
 ```
 
 Then, upload the file (as a Swift object) into your container, and

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -72,7 +72,7 @@ included in the container.
     ```
 === "Swift CLI"
     ```console
-    $ swift stat public-container 
+    $ swift stat public-container
                           Account: AUTH_30a7768a0ffc40359d6110f21a6e7d88
                         Container: public-container
                           Objects: 0
@@ -96,8 +96,8 @@ included in the container.
 
 To upload an object into the container, create a local test file:
 
-```console
-$ echo "hello world" > testobj.txt
+```bash
+echo "hello world" > testobj.txt
 ```
 
 Then, upload the file (as a Swift object) into your container, and
@@ -205,7 +205,7 @@ it by parsing the CLI's debug output:
 Once you have retrieved your public URL, you can fetch the object's
 contents using the client of your choice. This example uses `curl`:
 
-```
+```console
 $ curl https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
 hello world
 ```

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -86,10 +86,10 @@ Then, use `swift tempurl` and specify
 * the HTTP method for which the TempURL should apply (usually `GET`),
 * the TempURL lifetime, in seconds,
 * the full path to the object including
-    - the `/v1` prefix,
-    - the account identifier starting with `AUTH_`,
-    - the container name,
-    - the object name,
+  * the `/v1` prefix,
+  * the account identifier starting with `AUTH_`,
+  * the container name,
+  * the object name,
 * the TempURL key.
 
 When specified in this way, the command returns a path similar to the

--- a/docs/howto/object-storage/swift/versioning.md
+++ b/docs/howto/object-storage/swift/versioning.md
@@ -22,8 +22,8 @@ In addition to the container holding your live objects,
 versions. In this example, we use the name
 `private-container-versions` for that container:
 
-```console
-$ swift post private-container-versions
+```bash
+swift post private-container-versions
 ```
 This command produces no output.
 
@@ -32,8 +32,8 @@ This command produces no output.
 You must next set the `X-Versions-Location` header on the *original*
 container:
 
-```console
-$ swift post -H "X-Versions-Location: private-container-versions" private-container
+```bash
+swift post -H "X-Versions-Location: private-container-versions" private-container
 ```
 
 ## Testing object versioning
@@ -44,6 +44,7 @@ You can now verify that object versioning is working correctly.
    ```console
    $ echo "bye bye" > testobj.txt
    $ swift upload private-container testobj.txt
+
    ```
 2. Observe that there is now a newly created object in the
    `private-container-versions` container:

--- a/docs/howto/openstack/barbican/generic-secret.md
+++ b/docs/howto/openstack/barbican/generic-secret.md
@@ -22,7 +22,7 @@ openstack secret store \
 > will differ.
 
 
-```
+```console
 +---------------+--------------------------------------------------------------------------------+
 | Field         | Value                                                                          |
 +---------------+--------------------------------------------------------------------------------+
@@ -50,11 +50,8 @@ options, if desired.
 Secrets are stored in Barbican in an encrypted format. You can see
 a list of secrets created for your user with the following command:
 
-```bash
-openstack secret list
-```
-
-```
+```console
+$ openstack secret list
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 | Secret href                                                                    | Name     | Created                   | Status | Content types                           | Algorithm | Bit length | Secret type | Mode | Expiration |
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
@@ -66,12 +63,9 @@ openstack secret list
 You can retrieve the decrypted secret with the `openstack secret get`
 command, adding the `-p` (or `--payload`) option:
 
-```bash
+```console
 $ openstack secret get -p \
   https://fra1.{{brand_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba
-```
-
-```
 +---------+---------------------------+
 | Field   | Value                     |
 +---------+---------------------------+

--- a/docs/howto/openstack/barbican/share-secret.md
+++ b/docs/howto/openstack/barbican/share-secret.md
@@ -13,7 +13,7 @@ To do so, you will need
 > Any {{brand}} user can always retrieve their own user ID
 > with the following command:
 >
-> ```
+> ```bash
 > openstack token issue -f value -c user_id
 > ```
 

--- a/docs/howto/openstack/cinder/encrypted-volumes.md
+++ b/docs/howto/openstack/cinder/encrypted-volumes.md
@@ -1,7 +1,5 @@
 ---
-description: >
-  Using Barbican secrets for block storage encryption, you can store
-  data in persistent storage volumes in an encrypted fashion.
+description: Using Barbican secrets for block storage encryption, you can store data in persistent storage volumes in an encrypted fashion.
 ---
 # Encrypted volumes
 
@@ -17,10 +15,8 @@ For the creation of an encrypted volume, you need to provide a
 specific *volume type.* You can retrieve the list of available volume
 types with the following command:
 
-```bash
-openstack volume type list
-```
-```
+```console
+$ openstack volume type list
 +--------------------------------------+-----------------------+-----------+
 | ID                                   | Name                  | Is Public |
 +--------------------------------------+-----------------------+-----------+
@@ -38,13 +34,11 @@ To create a volume with encryption, you need to explicitly specify the
 following example creates a volume using the `volumes_hdd_encrypted`
 type, naming it `enc_drive` and setting its size to 10 GiB:
 
-```bash
-openstack volume create \
+```console
+$ openstack volume create \
   --type volumes_hdd_encrypted \
   --size 10 \
   enc_drive
-```
-```
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+

--- a/docs/howto/openstack/magnum/new-k8s-cluster.md
+++ b/docs/howto/openstack/magnum/new-k8s-cluster.md
@@ -1,9 +1,9 @@
 # Creating new Kubernetes clusters
 
-By employing OpenStack 
-[Magnum](https://docs.openstack.org/magnum/latest) you can easily 
-create Kubernetes clusters over OpenStack, using either the {{gui}} or 
-the OpenStack CLI. Let us demonstrate the creation of a Kubernetes 
+By employing OpenStack
+[Magnum](https://docs.openstack.org/magnum/latest) you can easily
+create Kubernetes clusters over OpenStack, using either the {{gui}} or
+the OpenStack CLI. Let us demonstrate the creation of a Kubernetes
 cluster following both approaches.
 
 ## Prerequisites
@@ -17,16 +17,16 @@ corresponding plugin module for Magnum. Use either the package manager
 of your operating system or `pip`:
 
 === "Debian/Ubuntu"
-	```bash
-	apt install python3-magnumclient
-	```
+    ```bash
+    apt install python3-magnumclient
+    ```
 === "Mac OS X with Homebrew"
-	This Python module is unavailable via `brew`, but you can
-	install it via `pip`.
+    This Python module is unavailable via `brew`, but you can
+    install it via `pip`.
 === "Python Package"
-	```bash
-	pip install python-magnumclient
-	```
+    ```bash
+    pip install python-magnumclient
+    ```
 
 ## Creating a Kubernetes cluster
 
@@ -37,242 +37,242 @@ prefer to work with the OpenStack CLI, please do not forget to [source
 the RC file first](/howto/getting-started/enable-openstack-cli).
 
 === "{{gui}}"
-	On the top right-hand side of the {{gui}}, click the _Create_ 
-	button. A new pane titled _Create_ will slide into view from the 
-	right-hand side of the browser window.
-	
-	![Create new object](assets/new-k8s/shot-01.png)
-	
-	You will notice several rounded boxes on that pane. Go ahead 
-	and click the one labeled _Magnum Cluster_. A new pane titled _Create a 
-	Magnum Cluster_ will slide over. At the top, type in a name for the new 
-	Kubernetes cluster and select one of the available regions.
+    On the top right-hand side of the {{gui}}, click the _Create_
+    button. A new pane titled _Create_ will slide into view from the
+    right-hand side of the browser window.
 
-	![Name and region](assets/new-k8s/shot-02.png)
+    ![Create new object](assets/new-k8s/shot-01.png)
 
-	Then, select one of the available templates to base the new 
-	cluster on. In the example below, we have selected the template named 
-	_Kubernetes 1.18.6 on Fedora-coreos 33 2C-4GB-20GB No Master LB_. The 
-	naming of any template indicates the version of Kubernetes that is 
-	about to be deployed, the characteristics of the cluster nodes, the 
-	operating system they run, and the presence or not of a load balancer 
-	for the control plane. Optionally, select one of the available keypairs 
-	for secure SSH access to the individual cluster nodes.
+    You will notice several rounded boxes on that pane. Go ahead
+    and click the one labeled _Magnum Cluster_. A new pane titled _Create a
+    Magnum Cluster_ will slide over. At the top, type in a name for the new
+    Kubernetes cluster and select one of the available regions.
 
-	![Template and keypair](assets/new-k8s/shot-03.png)
+    ![Name and region](assets/new-k8s/shot-02.png)
 
-	For now, you may skip the _Advanced Option_ section. Click the 
-	green _Create_ button, and Magnum will start creating the new 
-	Kubernetes cluster. Please note that the whole process may take several 
-	minutes to complete.
+    Then, select one of the available templates to base the new
+    cluster on. In the example below, we have selected the template named
+    _Kubernetes 1.18.6 on Fedora-coreos 33 2C-4GB-20GB No Master LB_. The
+    naming of any template indicates the version of Kubernetes that is
+    about to be deployed, the characteristics of the cluster nodes, the
+    operating system they run, and the presence or not of a load balancer
+    for the control plane. Optionally, select one of the available keypairs
+    for secure SSH access to the individual cluster nodes.
+
+    ![Template and keypair](assets/new-k8s/shot-03.png)
+
+    For now, you may skip the _Advanced Option_ section. Click the
+    green _Create_ button, and Magnum will start creating the new
+    Kubernetes cluster. Please note that the whole process may take several
+    minutes to complete.
 === "OpenStack CLI"
-	A simple, general command for creating a new Kubernetes cluster 
-	with Magnum looks like this:
-	
-	```bash
-	openstack coe cluster create \
-		--cluster-template $CLUSTER_TMPL \
-		--keypair $KEYPAIR \
-		$CLUSTER_NAME
-	```
+    A simple, general command for creating a new Kubernetes cluster
+    with Magnum looks like this:
 
-	Let us list all available templates in the region:
-	
-	```bash
-	openstack coe cluster template list
-	```
+    ```bash
+    openstack coe cluster create \
+        --cluster-template $CLUSTER_TMPL \
+        --keypair $KEYPAIR \
+        $CLUSTER_NAME
+    ```
 
-	```plain
-	+--------------------------------------+----------------------------------------------------------------+------+
-	| uuid                                 | name                                                           | tags |
-	+--------------------------------------+----------------------------------------------------------------+------+
-	| 3f476f01-b3de-4687-a188-6829ed947db0 | Kubernetes 1.15.5 on Fedora-atomic 29 4C-8GB-20GB No Master LB | None |
-	| c458f02d-54b0-4ef8-abbc-e1c25b61165a | Kubernetes 1.15.5 on Fedora-atomic 29 2C-4GB-20GB No Master LB | None |
-	| f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf | Kubernetes 1.18.6 on Fedora-coreos 33 2C-4GB-20GB No Master LB | None |
-	+--------------------------------------+----------------------------------------------------------------+------+
-	```
+    Let us list all available templates in the region:
 
-	Select the template you want by setting the corresponding 
-	`uuid` value to the  `CLUSTER_TMPL` variable:
-	
-	```bash
-	CLUSTER_TMPL="f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf" # just an example
-	```
-	
-	Then, list all available keypairs...
-	
-	```bash
-	openstack keypair list
-	```
+    ```bash
+    openstack coe cluster template list
+    ```
 
-	```plain
-	+---------+-------------------------------------------------+------+
-	| Name    | Fingerprint                                     | Type |
-	+---------+-------------------------------------------------+------+
-	| husavik | 34:3b:58:ba:ec:95:f5:17:17:df:04:38:11:89:e6:3d | ssh  |
-	+---------+-------------------------------------------------+------+
-	```
-	
-	...and set the `KEYPAIR` variable to the name of the keypair 
-	you want:
-	
-	```bash
-	KEYPAIR="husavik" # again, this is just an example
-	```
-	
-	Finally, decide on a name for your new Kubernetes cluster:
-	
-	```bash
-	CLUSTER_NAME="bangor"
-	```
-	
-	With everything in place, go ahead and create your new 
-	Kubernetes cluster:
-	
-	```bash
-	openstack coe cluster create \
-		--cluster-template $CLUSTER_TMPL \
-		--keypair husavik
-		bangor
-	```
-	If everything went well with your request for a new cluster, 
-	on your terminal, you would see a message like the following:
-	 
-	 ```plain
-	 Request to create cluster e0df8c62-c6f6-4c7d-b67e-33e3606e9ab6 accepted
-	 ```
-	
-	The cluster creation process takes some time to complete, and 
-	while you are waiting, you can check if everything is progressing 
-	smoothly:
-	
-	```bash
-	openstack coe cluster list -c status
-	```
-	
-	If everything is going well, the message you will get will be 
-	`CREATE_IN_PROGRESS`. When Magnum has finished creating the cluster, 
-	the message will be `CREATE_COMPLETE`.
+    ```plain
+    +--------------------------------------+----------------------------------------------------------------+------+
+    | uuid                                 | name                                                           | tags |
+    +--------------------------------------+----------------------------------------------------------------+------+
+    | 3f476f01-b3de-4687-a188-6829ed947db0 | Kubernetes 1.15.5 on Fedora-atomic 29 4C-8GB-20GB No Master LB | None |
+    | c458f02d-54b0-4ef8-abbc-e1c25b61165a | Kubernetes 1.15.5 on Fedora-atomic 29 2C-4GB-20GB No Master LB | None |
+    | f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf | Kubernetes 1.18.6 on Fedora-coreos 33 2C-4GB-20GB No Master LB | None |
+    +--------------------------------------+----------------------------------------------------------------+------+
+    ```
+
+    Select the template you want by setting the corresponding
+    `uuid` value to the  `CLUSTER_TMPL` variable:
+
+    ```bash
+    CLUSTER_TMPL="f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf" # just an example
+    ```
+
+    Then, list all available keypairs...
+
+    ```bash
+    openstack keypair list
+    ```
+
+    ```plain
+    +---------+-------------------------------------------------+------+
+    | Name    | Fingerprint                                     | Type |
+    +---------+-------------------------------------------------+------+
+    | husavik | 34:3b:58:ba:ec:95:f5:17:17:df:04:38:11:89:e6:3d | ssh  |
+    +---------+-------------------------------------------------+------+
+    ```
+
+    ...and set the `KEYPAIR` variable to the name of the keypair
+    you want:
+
+    ```bash
+    KEYPAIR="husavik" # again, this is just an example
+    ```
+
+    Finally, decide on a name for your new Kubernetes cluster:
+
+    ```bash
+    CLUSTER_NAME="bangor"
+    ```
+
+    With everything in place, go ahead and create your new
+    Kubernetes cluster:
+
+    ```bash
+    openstack coe cluster create \
+        --cluster-template $CLUSTER_TMPL \
+        --keypair husavik
+        bangor
+    ```
+    If everything went well with your request for a new cluster,
+    on your terminal, you would see a message like the following:
+
+     ```plain
+     Request to create cluster e0df8c62-c6f6-4c7d-b67e-33e3606e9ab6 accepted
+     ```
+
+    The cluster creation process takes some time to complete, and
+    while you are waiting, you can check if everything is progressing
+    smoothly:
+
+    ```bash
+    openstack coe cluster list -c status
+    ```
+
+    If everything is going well, the message you will get will be
+    `CREATE_IN_PROGRESS`. When Magnum has finished creating the cluster,
+    the message will be `CREATE_COMPLETE`.
 
 ## Viewing the Kubernetes cluster
 
-After the Kubernetes cluster is ready, you may at any time view it and 
+After the Kubernetes cluster is ready, you may at any time view it and
 get detailed information about it.
 
 === "{{gui}}"
-	In the left vertical pane of the {{gui}}, click through 
-	_Kubernetes_, _Magnum_, and _Clusters_. In the central pane on the 
-	right, you will then see all your Kubernetes clusters in every region.
-	
-	![All k8s clusters](assets/new-k8s/shot-04.png)
-	
-	Click on the three-dot icon on the right of the cluster you 
-	want to inspect, and select _View details_.
+    In the left vertical pane of the {{gui}}, click through
+    _Kubernetes_, _Magnum_, and _Clusters_. In the central pane on the
+    right, you will then see all your Kubernetes clusters in every region.
 
-	![Cluster details](assets/new-k8s/shot-05.png)
+    ![All k8s clusters](assets/new-k8s/shot-04.png)
+
+    Click on the three-dot icon on the right of the cluster you
+    want to inspect, and select _View details_.
+
+    ![Cluster details](assets/new-k8s/shot-05.png)
 === "OpenStack CLI"
-	To list all available Kubernetes clusters, just type:
-	
-	```bash
-	openstack coe cluster list
-	```
+    To list all available Kubernetes clusters, just type:
 
-	```plain
-	+---------------+--------+---------+------------+--------------+---------------+---------------+
-	| uuid          | name   | keypair | node_count | master_count | status        | health_status |
-	+---------------+--------+---------+------------+--------------+---------------+---------------+
-	| e0df8c62-c6f6 | bangor | husavik |          1 |            1 | CREATE_COMPLE | HEALTHY       |
-	| -4c7d-b67e-33 |        |         |            |              | TE            |               |
-	| e3606e9ab6    |        |         |            |              |               |               |
-	+---------------+--------+---------+------------+--------------+---------------+---------------+
-	```
+    ```bash
+    openstack coe cluster list
+    ```
 
-	For many more details on a specific cluster, note its name and 
-	run a command like this:
-	
-	```bash
-	openstack coe cluster show bangor
-	```
+    ```plain
+    +---------------+--------+---------+------------+--------------+---------------+---------------+
+    | uuid          | name   | keypair | node_count | master_count | status        | health_status |
+    +---------------+--------+---------+------------+--------------+---------------+---------------+
+    | e0df8c62-c6f6 | bangor | husavik |          1 |            1 | CREATE_COMPLE | HEALTHY       |
+    | -4c7d-b67e-33 |        |         |            |              | TE            |               |
+    | e3606e9ab6    |        |         |            |              |               |               |
+    +---------------+--------+---------+------------+--------------+---------------+---------------+
+    ```
 
-	```plain
-	+----------------------+---------------------------------------------------------------------------+
-	| Field                | Value                                                                     |
-	+----------------------+---------------------------------------------------------------------------+
-	| status               | CREATE_COMPLETE                                                           |
-	| health_status        | HEALTHY                                                                   |
-	| cluster_template_id  | f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf                                      |
-	| node_addresses       | ['185.52.156.105']                                                        |
-	| uuid                 | e0df8c62-c6f6-4c7d-b67e-33e3606e9ab6                                      |
-	| stack_id             | e3725aed-f665-4e8d-9409-85f5ee5e2f4a                                      |
-	| status_reason        | None                                                                      |
-	| created_at           | 2022-11-14T07:32:02+00:00                                                 |
-	| updated_at           | 2022-11-14T07:37:26+00:00                                                 |
-	| coe_version          | v1.18.6                                                                   |
-	| labels               | {'kube_tag': 'v1.18.6', 'heat_container_agent_tag': 'train-stable'}       |
-	| labels_overridden    | {}                                                                        |
-	| labels_skipped       | {}                                                                        |
-	| labels_added         | {}                                                                        |
-	| fixed_network        | None                                                                      |
-	| fixed_subnet         | None                                                                      |
-	| floating_ip_enabled  | True                                                                      |
-	| faults               |                                                                           |
-	| keypair              | husavik                                                                   |
-	| api_address          | https://89.46.80.136:6443                                                 |
-	| master_addresses     | ['89.46.80.136']                                                          |
-	| master_lb_enabled    | False                                                                     |
-	| create_timeout       | 60                                                                        |
-	| node_count           | 1                                                                         |
-	| discovery_url        | https://discovery.etcd.io/23af721dc3ee773d2674db4881ff70cb                |
-	| docker_volume_size   | 50                                                                        |
-	| master_count         | 1                                                                         |
-	| container_version    | 1.12.6                                                                    |
-	| name                 | bangor                                                                    |
-	| master_flavor_id     | 2C-4GB-20GB                                                               |
-	| flavor_id            | 2C-4GB-20GB                                                               |
-	| health_status_reason | {'bangor-id6nijycp2wy-master-0.Ready': 'True', 'bangor-id6nijycp2wy-      |
-	|                      | node-0.Ready': 'True', 'api': 'ok'}                                       |
-	| project_id           | dfc700467396428bacba4376e72cc3e9                                          |
-	+----------------------+---------------------------------------------------------------------------+
-	```
+    For many more details on a specific cluster, note its name and
+    run a command like this:
+
+    ```bash
+    openstack coe cluster show bangor
+    ```
+
+    ```plain
+    +----------------------+---------------------------------------------------------------------------+
+    | Field                | Value                                                                     |
+    +----------------------+---------------------------------------------------------------------------+
+    | status               | CREATE_COMPLETE                                                           |
+    | health_status        | HEALTHY                                                                   |
+    | cluster_template_id  | f9e1a2ea-b1ff-43e7-8d1e-6dd5861b82cf                                      |
+    | node_addresses       | ['185.52.156.105']                                                        |
+    | uuid                 | e0df8c62-c6f6-4c7d-b67e-33e3606e9ab6                                      |
+    | stack_id             | e3725aed-f665-4e8d-9409-85f5ee5e2f4a                                      |
+    | status_reason        | None                                                                      |
+    | created_at           | 2022-11-14T07:32:02+00:00                                                 |
+    | updated_at           | 2022-11-14T07:37:26+00:00                                                 |
+    | coe_version          | v1.18.6                                                                   |
+    | labels               | {'kube_tag': 'v1.18.6', 'heat_container_agent_tag': 'train-stable'}       |
+    | labels_overridden    | {}                                                                        |
+    | labels_skipped       | {}                                                                        |
+    | labels_added         | {}                                                                        |
+    | fixed_network        | None                                                                      |
+    | fixed_subnet         | None                                                                      |
+    | floating_ip_enabled  | True                                                                      |
+    | faults               |                                                                           |
+    | keypair              | husavik                                                                   |
+    | api_address          | https://89.46.80.136:6443                                                 |
+    | master_addresses     | ['89.46.80.136']                                                          |
+    | master_lb_enabled    | False                                                                     |
+    | create_timeout       | 60                                                                        |
+    | node_count           | 1                                                                         |
+    | discovery_url        | https://discovery.etcd.io/23af721dc3ee773d2674db4881ff70cb                |
+    | docker_volume_size   | 50                                                                        |
+    | master_count         | 1                                                                         |
+    | container_version    | 1.12.6                                                                    |
+    | name                 | bangor                                                                    |
+    | master_flavor_id     | 2C-4GB-20GB                                                               |
+    | flavor_id            | 2C-4GB-20GB                                                               |
+    | health_status_reason | {'bangor-id6nijycp2wy-master-0.Ready': 'True', 'bangor-id6nijycp2wy-      |
+    |                      | node-0.Ready': 'True', 'api': 'ok'}                                       |
+    | project_id           | dfc700467396428bacba4376e72cc3e9                                          |
+    +----------------------+---------------------------------------------------------------------------+
+    ```
 
 ## Accessing the Kubernetes cluster with kubectl
 
-You may install the Kubernetes command line tool, `kubectl`, on your 
-local computer, and run commands against your cluster. To install 
+You may install the Kubernetes command line tool, `kubectl`, on your
+local computer, and run commands against your cluster. To install
 `kubectl`, use the package manager of your operating system.
 
 === "Debian/Ubuntu"
-	```bash
-	apt install kubectl
-	```
+    ```bash
+    apt install kubectl
+    ```
 === "Mac OS X with Homebrew"
-	```bash
-	brew install kubectl
-	```
+    ```bash
+    brew install kubectl
+    ```
 
-Before running commands against a specific cluster, you must have the 
+Before running commands against a specific cluster, you must have the
 corresponding `config` file on your computer.
 
 === "{{gui}}"
-	Downloading a `config` file from the {{gui}} is currently not 
-	supported. You can still fetch the `config` file of your newly
-	created Kubernetes cluster using the OpenStack CLI.
+    Downloading a `config` file from the {{gui}} is currently not
+    supported. You can still fetch the `config` file of your newly
+    created Kubernetes cluster using the OpenStack CLI.
 === "OpenStack CLI"
-	To download the `config` file for your Kubernetes cluster, type 
-	the following:
+    To download the `config` file for your Kubernetes cluster, type
+    the following:
 
-	```bash
-	openstack coe cluster config --dir=${PWD} bangor
-	```
+    ```bash
+    openstack coe cluster config --dir=${PWD} bangor
+    ```
 
-After saving the `config` file locally, set the value of variable 
+After saving the `config` file locally, set the value of variable
 `KUBECONFIG` to the full path of the file. Type, for example:
 
 ```bash
 export KUBECONFIG=${PWD}/config
 ```
 
-Then, you can use `kubectl` to run commands against your cluster. See, 
+Then, you can use `kubectl` to run commands against your cluster. See,
 for instance, all cluster nodes...
 
 ```bash

--- a/docs/howto/openstack/neutron/delete-network.md
+++ b/docs/howto/openstack/neutron/delete-network.md
@@ -1,22 +1,22 @@
 # Deleting networks
 
-Deleting a network in {{brand}} may sound like a pretty straightforward 
-task --- and it is. It's just that before deleting a network, there are 
-some steps we almost always need to take. In what follows we show, step 
-by step and through specific examples, how we delete networks using 
+Deleting a network in {{brand}} may sound like a pretty straightforward
+task --- and it is. It's just that before deleting a network, there are
+some steps we almost always need to take. In what follows we show, step
+by step and through specific examples, how we delete networks using
 either the {{gui}} or the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the OpenStack CLI, 
-you need to [have an account](/howto/getting-started/create-account) in 
-{{brand}}. Additionally, to use the OpenStack CLI, make sure to [enable 
-it](/howto/getting-started/enable-openstack-cli) for the region you 
+Whether you choose to work from the {{gui}} or with the OpenStack CLI,
+you need to [have an account](/howto/getting-started/create-account) in
+{{brand}}. Additionally, to use the OpenStack CLI, make sure to [enable
+it](/howto/getting-started/enable-openstack-cli) for the region you
 will be working in.
 
 ## Selecting a network
 
-Unless you already have the ID or know the name of the network you wish 
+Unless you already have the ID or know the name of the network you wish
 to delete, you may first list all available networks.
 
 === "{{gui}}"
@@ -24,17 +24,17 @@ to delete, you may first list all available networks.
     [{{gui}}](https://{{gui_domain}}) start page, and log into your
     {{brand}} account.
 
-    In the vertical pane on the left-hand side of the dashboard, expand the 
-    _Networking_ section and click _Networks_. In the central pane of the 
-    page, you will see all networks in all regions you have access to. For 
-    the purposes of this guide, let us assume you no longer need network 
+    In the vertical pane on the left-hand side of the dashboard, expand the
+    _Networking_ section and click _Networks_. In the central pane of the
+    page, you will see all networks in all regions you have access to. For
+    the purposes of this guide, let us assume you no longer need network
     `carmacks`, so now you want to delete it.
-    
+
     ![Listing networks](assets/del-net/shot-01.png)
 === "OpenStack CLI"
-    To list all available networks in the region you are currently in, type 
+    To list all available networks in the region you are currently in, type
     the following:
-    
+
     ```bash
     openstack network list --internal
     ```
@@ -48,32 +48,32 @@ to delete, you may first list all available networks.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-    
+
 Let us assume you wish to delete the network named `carmacks`.
 
 ## Determining component dependencies
 
-If the network to be deleted has a subnet component --- and most likely 
-it will have ---, you will first have to delete the subnet before 
-deleting the network. If, in addition, the network is behind a router 
-(figurately speaking), then before deleting the subnet, you will have 
-to disconnect it from the router. Finally, you will have the option to 
-delete the router also. Let us see what the situation is with network 
+If the network to be deleted has a subnet component --- and most likely
+it will have ---, you will first have to delete the subnet before
+deleting the network. If, in addition, the network is behind a router
+(figurately speaking), then before deleting the subnet, you will have
+to disconnect it from the router. Finally, you will have the option to
+delete the router also. Let us see what the situation is with network
 `carmacks`.
 
 === "{{gui}}"
-    For more information on `carmacks`, click the three-dot icon 
-    (right-hand side of the network row) and select _View details_. Four 
-    tabs immediately appear below; _Details_, _Ports_, _Subnets_, and 
-    _Routers_. Looking at the _Details_ tab, it is clear that network 
-    `carmacks` has a subnet and is behind a router. You may click on tabs 
-    _Subnets_ and _Routers_, to see more information regarding the network 
+    For more information on `carmacks`, click the three-dot icon
+    (right-hand side of the network row) and select _View details_. Four
+    tabs immediately appear below; _Details_, _Ports_, _Subnets_, and
+    _Routers_. Looking at the _Details_ tab, it is clear that network
+    `carmacks` has a subnet and is behind a router. You may click on tabs
+    _Subnets_ and _Routers_, to see more information regarding the network
     subnet and the router in front of the network.
-    
+
     ![Network details](assets/del-net/shot-02.png)
 === "OpenStack CLI"
     To quickly check whether network `carmacks` has a subnet or not, type:
-        
+
     ```bash
     openstack network show carmacks -c subnets
     ```
@@ -84,19 +84,19 @@ delete the router also. Let us see what the situation is with network
     | subnets | 7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5 |
     +---------+--------------------------------------+
     ```
-        
-    If the value for the field `subnets` is non-empty, like in the example 
-    output above, that means the network has a subnet indeed, and the value 
-    is the ID of that subnet. At this point, it helps to assign the subnet 
+
+    If the value for the field `subnets` is non-empty, like in the example
+    output above, that means the network has a subnet indeed, and the value
+    is the ID of that subnet. At this point, it helps to assign the subnet
     ID to an environment variable, like so:
-        
+
     ```bash
     SUBNET_ID="7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5"
     ```
-        
+
     What about a router in front of `carmacks`? You might try checking the
     output of this command:
-        
+
     ```bash
     openstack network show carmacks
     ```
@@ -134,14 +134,14 @@ delete the router also. Let us see what the situation is with network
     | updated_at                | 2022-12-09T18:55:18Z                 |
     +---------------------------+--------------------------------------+
     ```
-        
-    While it usually pays off to use `openstack` commands with the verb 
-    `show` on various objects, in this case, you don't get what you're 
-    looking for --- which is an indication of the presence or absence of a 
-    router in front of `carmacks`. In cases like this, try looking at 
-    things from a different vantage point. Try, in particular, to list all 
+
+    While it usually pays off to use `openstack` commands with the verb
+    `show` on various objects, in this case, you don't get what you're
+    looking for --- which is an indication of the presence or absence of a
+    router in front of `carmacks`. In cases like this, try looking at
+    things from a different vantage point. Try, in particular, to list all
     routers:
-        
+
     ```bash
     openstack router list
     ```
@@ -155,10 +155,10 @@ delete the router also. Let us see what the situation is with network
     | af61-91e923fac87b      |                 |        |       | 01aef82359             |      |
     +------------------------+-----------------+--------+-------+------------------------+------+
     ```
-        
-    The name of the second router says it all, but since it is just a name, 
+
+    The name of the second router says it all, but since it is just a name,
     it doesn't hurt to verify the role of this router:
-        
+
     ```bash
     openstack router show carmacks-router -c interfaces_info
     ```
@@ -170,13 +170,13 @@ delete the router also. Let us see what the situation is with network
     |                 | "subnet_id": "7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5"}]                          |
     +-----------------+--------------------------------------------------------------------------------+
     ```
-        
-    Looking at the value of `interfaces_info`, it is easy to see that 
-    `subnet_id` has the value of the variable `SUBNET_ID` you just 
-    instantiated. In other words, router `carmacks-router` is indeed in 
+
+    Looking at the value of `interfaces_info`, it is easy to see that
+    `subnet_id` has the value of the variable `SUBNET_ID` you just
+    instantiated. In other words, router `carmacks-router` is indeed in
     front of network `carmacks`.
-        
-    > There will be times when router names won't help much. Then, try a 
+
+    > There will be times when router names won't help much. Then, try a
     more exhaustive search approach:
     >
     > ```bash
@@ -194,78 +194,78 @@ delete the router also. Let us see what the situation is with network
 
 ## Tearing down networks
 
-Now that you know you're dealing with a full-blown network and a 
-router, you start by disconnecting the subnet from the router. Then, 
-you will move on to deleting the subnet and the network, and after 
+Now that you know you're dealing with a full-blown network and a
+router, you start by disconnecting the subnet from the router. Then,
+you will move on to deleting the subnet and the network, and after
 that, you can finish up with deleting the router.
 
 === "{{gui}}"
-    Go to the _Subnets_ tab of the `carmacks` network, and click the gray 
+    Go to the _Subnets_ tab of the `carmacks` network, and click the gray
     notepad-and-pen icon (at the left of the red circle-with-trashcan icon).
-        
+
     ![Network subnets](assets/del-net/shot-03.png)
-    
-    A vertical pane titled _Modify Subnet_ will slide over from the 
-    right-hand side of the page. Pay attention to the _Router Connections_ 
-    section. You will notice an active connection to the router. Click the 
-    red circle-with-line-over-chainlink icon to deactivate the connection, 
+
+    A vertical pane titled _Modify Subnet_ will slide over from the
+    right-hand side of the page. Pay attention to the _Router Connections_
+    section. You will notice an active connection to the router. Click the
+    red circle-with-line-over-chainlink icon to deactivate the connection,
     effectively disconnecting the subnet from the router.
-        
+
     ![Disconnect subnet](assets/del-net/shot-04.png)
-        
-    A pop-up window will appear, asking if you really want to go ahead with 
+
+    A pop-up window will appear, asking if you really want to go ahead with
     the disconnection. Just click the red _Yes, Remove interface_ button.
-        
+
     ![Remove interface](assets/del-net/shot-05.png)
-        
-    After disconnecting the subnet, click the red circle-and-trashcan icon 
-    to delete it. Once more, a pop-up will appear asking for confirmation. 
+
+    After disconnecting the subnet, click the red circle-and-trashcan icon
+    to delete it. Once more, a pop-up will appear asking for confirmation.
     Click the red _Yes, Delete_ button.
-        
+
     ![Delete subnet](assets/del-net/shot-06.png)
-        
-    As soon as you delete the subnet, in the _Subnets_ tab you will see the 
+
+    As soon as you delete the subnet, in the _Subnets_ tab you will see the
     message _No subnets found_.
-        
+
     ![No subnets](assets/del-net/shot-07.png)
-        
-    You can now delete the network. Click the three-dot icon (right-hand 
+
+    You can now delete the network. Click the three-dot icon (right-hand
     side of the network row) and select _Delete Network_.
-        
+
     ![Delete Carmacks](assets/del-net/shot-08.png)
-        
-    Of course, you will have to confirm this action. Clicking the red _Yes, 
+
+    Of course, you will have to confirm this action. Clicking the red _Yes,
     Delete_ button is enough.
-        
+
     ![Confirm network delete](assets/del-net/shot-09.png)
-        
-    After deleting the network, it will not be on the list of all available 
+
+    After deleting the network, it will not be on the list of all available
     networks.
-        
+
     ![List of networks](assets/del-net/shot-10.png)
-        
-    There's still that router lying around, and if you have no use for it, 
-    go to the _Routers_ page to delete it. In the vertical pane on the 
-    left, expand the _Networking_ section and click on _Routers_. In the 
-    central pane of the page, you will see all routers in all regions you 
+
+    There's still that router lying around, and if you have no use for it,
+    go to the _Routers_ page to delete it. In the vertical pane on the
+    left, expand the _Networking_ section and click on _Routers_. In the
+    central pane of the page, you will see all routers in all regions you
     have access to.
-    
+
     ![All routers](assets/del-net/shot-11.png)
-        
-    Click the red three-dot icon of the router you wish to delete and 
-    select _Delete Router_. A pop-up will appear asking for confirmation, 
+
+    Click the red three-dot icon of the router you wish to delete and
+    select _Delete Router_. A pop-up will appear asking for confirmation,
     so click the red _Yes, Delete_ button.
-    
+
     ![Confirm router delete](assets/del-net/shot-12.png)
-    
-    After successfully deleting the router, there will be no trace of it in 
+
+    After successfully deleting the router, there will be no trace of it in
     the list of all routers.
-        
+
     ![Router is gone](assets/del-net/shot-13.png)
 === "OpenStack CLI"
     First, take a look at all available subnets:
-    
-    ```bash    
+
+    ```bash
     openstack subnet list
     ```
     ```plain
@@ -280,11 +280,11 @@ that, you can finish up with deleting the router.
     | fff47e997e7b                  |                 | f88292870c1d                   |               |
     +-------------------------------+-----------------+--------------------------------+---------------+
     ```
-    
-    As you would expect, included on the list is subnet `carmacks-subnet`, 
+
+    As you would expect, included on the list is subnet `carmacks-subnet`,
     which you are about to delete. That's easier said than done, though:
-    
-    ```bash    
+
+    ```bash
     openstack subnet delete $SUBNET_ID
     ```
     ```plain
@@ -294,27 +294,27 @@ that, you can finish up with deleting the router.
     One or more ports have an IP allocation from this subnet.
     1 of 1 subnets failed to delete.
     ```
-        
-    The trick here is to first disconnect the subnet from the corresponding 
-    router, which is perfectly doable from the side of the router. As we 
-    discovered a bit earlier, the router we are talking about is 
+
+    The trick here is to first disconnect the subnet from the corresponding
+    router, which is perfectly doable from the side of the router. As we
+    discovered a bit earlier, the router we are talking about is
     `carmacks-router`:
-        
+
     ```bash
     openstack router remove subnet carmacks-router $SUBNET_ID
     ```
-    
-    If the command above is successful, you will see no output on your 
-    terminal. Now, an attempt to delete `carmacks-subnet` should go through 
+
+    If the command above is successful, you will see no output on your
+    terminal. Now, an attempt to delete `carmacks-subnet` should go through
     with flying colors:
-        
+
     ```bash
     openstack subnet delete $SUBNET_ID
     ```
-        
-    Again, no command output means success, but we suggest you check 
+
+    Again, no command output means success, but we suggest you check
     yourself:
-        
+
     ```bash
     openstack subnet list
     ```
@@ -328,11 +328,11 @@ that, you can finish up with deleting the router.
     | fff47e997e7b                   |               | f88292870c1d                    |               |
     +--------------------------------+---------------+---------------------------------+---------------+
     ```
-        
-    The subnet `carmacks-subnet` is not on the list, which is what you 
-    wanted exactly. Next is network `carmacks`, which you should be able to 
+
+    The subnet `carmacks-subnet` is not on the list, which is what you
+    wanted exactly. Next is network `carmacks`, which you should be able to
     delete by now. First, take a look at all available networks:
-    
+
     ```bash
     openstack network list --internal
     ```
@@ -346,17 +346,17 @@ that, you can finish up with deleting the router.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-        
-    Network `carmacks` is on the list, and by looking at the `Subnets` 
-    column, you see that it has no subnet. That's expected, so go ahead and 
+
+    Network `carmacks` is on the list, and by looking at the `Subnets`
+    column, you see that it has no subnet. That's expected, so go ahead and
     delete the network:
-        
+
     ```bash
     openstack network delete carmacks
     ```
-        
+
     No command output signals success, but it never hurts to verify yourself:
-    
+
     ```bash
     openstack network list --internal
     ```
@@ -369,16 +369,16 @@ that, you can finish up with deleting the router.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-        
-    Network `carmacks` is gone, and if you have no use of 
+
+    Network `carmacks` is gone, and if you have no use of
     `carmacks-router`, go ahead and delete it:
-        
+
     ```bash
     openstack router delete carmacks-router
     ```
-        
+
     There is no output on the terminal, and yet the router is gone:
-        
+
     ```bash
     openstack router list
     ```
@@ -393,34 +393,34 @@ that, you can finish up with deleting the router.
 
 ## Networks with a subnet but no router
 
-These are faster to delete, for there is no router to disconnect the 
-subnet from. For our demonstration, we created network `teslin`, with 
-subnet `teslin-subnet` and no router in front of it. 
+These are faster to delete, for there is no router to disconnect the
+subnet from. For our demonstration, we created network `teslin`, with
+subnet `teslin-subnet` and no router in front of it.
 
 === "{{gui}}"
-    In the vertical pane on the left-hand side of the dashboard, expand the 
-    _Networking_ section and click _Networks_. In the central pane of the 
-    page, you will see all networks in all regions you have access to. 
-    Select a network with a subnet and no router --- like `teslin` in our 
+    In the vertical pane on the left-hand side of the dashboard, expand the
+    _Networking_ section and click _Networks_. In the central pane of the
+    page, you will see all networks in all regions you have access to.
+    Select a network with a subnet and no router --- like `teslin` in our
     example.
-    
-    Looking at the network details, it is immediately apparent that there's 
+
+    Looking at the network details, it is immediately apparent that there's
     no router in front of it.
-        
+
     ![No router in sight](assets/del-net/shot-14.png)
-        
-    Go to the _Subnets_ tab, and click the red circle-with-trashcan icon to 
+
+    Go to the _Subnets_ tab, and click the red circle-with-trashcan icon to
     delete the subnet.
-        
+
     ![Delete subnet](assets/del-net/shot-15.png)
-        
-    Then, click the red three-dot icon at the right-hand side of the 
+
+    Then, click the red three-dot icon at the right-hand side of the
     `teslin` row, and select _Delete Network_.
-        
+
     ![Delete Teslin](assets/del-net/shot-16.png)
 === "OpenStack CLI"
     Let us first take a look at all available networks...
-    
+
     ```bash
     openstack network list --internal
     ```
@@ -433,9 +433,9 @@ subnet `teslin-subnet` and no router in front of it.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-    
+
     ...and at all available subnets:
-    
+
     ```bash
     openstack subnet list
     ```
@@ -449,17 +449,17 @@ subnet `teslin-subnet` and no router in front of it.
     | fff47e997e7b                   |               | f88292870c1d                    |               |
     +--------------------------------+---------------+---------------------------------+---------------+
     ```
-        
-    Since there is nothing to disconnect the `teslin-subnet` from, you may 
+
+    Since there is nothing to disconnect the `teslin-subnet` from, you may
     go ahead and delete the subnet:
-        
+
     ```bash
     openstack subnet delete teslin-subnet
     ```
-    
-    There is no command output. This is expected, but why not check 
+
+    There is no command output. This is expected, but why not check
     yourself?
-        
+
     ```bash
     openstack subnet list
     ```
@@ -471,16 +471,16 @@ subnet `teslin-subnet` and no router in front of it.
     | 42ef4a866dd9                    |             | d6c87479e190                     |               |
     +---------------------------------+-------------+----------------------------------+---------------+
     ```
-    
+
     Finally, network `teslin` can go away with a single command:
-        
+
     ```bash
     openstack network delete teslin
     ```
-        
-    The absence of any output means the command was successful. Take a look 
+
+    The absence of any output means the command was successful. Take a look
     yourself:
-        
+
     ```bash
     openstack network list --internal
     ```
@@ -492,23 +492,23 @@ subnet `teslin-subnet` and no router in front of it.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-    
+
 ## Networks with no subnet and no router
 
-You may directly, without the slightest preparation, delete networks 
-like these. For our demonstration, we created a network named `mayo`, 
+You may directly, without the slightest preparation, delete networks
+like these. For our demonstration, we created a network named `mayo`,
 with no subnet and no router in front of it.
 
 === "{{gui}}"
-    While viewing all available networks, click the red three-dot icon at 
-    the right-hand side of the `mayo` row and select _Delete Network_. You 
-    will have to confirm the action, and the network will be gone as soon 
+    While viewing all available networks, click the red three-dot icon at
+    the right-hand side of the `mayo` row and select _Delete Network_. You
+    will have to confirm the action, and the network will be gone as soon
     as you do.
-    
+
     ![Delete Mayo](assets/del-net/shot-17.png)
 === "OpenStack CLI"
     Once more, take a look at all remaining networks:
-        
+
     ```bash
     openstack network list --internal
     ```
@@ -520,15 +520,15 @@ with no subnet and no router in front of it.
     | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
-        
+
     Since `mayo` has no subnet, issue a single command to delete it:
-        
+
     ```bash
     openstack network delete mayo
     ```
-        
+
     And, yes, it is still a good idea to check yourself:
-        
+
     ```bash
     openstack network list --internal
     ```
@@ -542,7 +542,7 @@ with no subnet and no router in front of it.
 
 ## Recap: Of networks and towns
 
-Depending on the features of a Neutron network, deleting it may require 
+Depending on the features of a Neutron network, deleting it may require
 some preparation work. For the purposes of this guide, we created three
 different networks with different characteristics; `carmacks`, `teslin`,
 and `mayo`. Then, either from the {{gui}} or with the help of OpenStack

--- a/docs/howto/openstack/neutron/multiple-public-ips.md
+++ b/docs/howto/openstack/neutron/multiple-public-ips.md
@@ -24,7 +24,7 @@ to map to it.
 
 Assume you already have a network port inside your private network:
 
-```
+```console
 $ openstack port show 51dae637-ad79-4ba9-9e41-78e5e0f3332c -c fixed_ips
 +-----------+--------------------------------------------------------------------------+
 | Field     | Value                                                                    |
@@ -35,7 +35,7 @@ $ openstack port show 51dae637-ad79-4ba9-9e41-78e5e0f3332c -c fixed_ips
 
 And you also have a floating IP associated with it:
 
-```
+```console
 $ openstack floating ip list -c ID -c "Floating IP Address" -c "Fixed IP Address" -c Port
 +--------------------------------------+---------------------+------------------+--------------------------------------+
 | ID                                   | Floating IP Address | Fixed IP Address | Port                                 |
@@ -47,13 +47,13 @@ $ openstack floating ip list -c ID -c "Floating IP Address" -c "Fixed IP Address
 
 Then what you need to do, is to add extra IP address to your existing port:
 
-```
-$ openstack port set --fixed-ip subnet=5efeae9f-06b8-41a5-987f-085e8c7113a6 51dae637-ad79-4ba9-9e41-78e5e0f3332c
+```bash
+openstack port set --fixed-ip subnet=5efeae9f-06b8-41a5-987f-085e8c7113a6 51dae637-ad79-4ba9-9e41-78e5e0f3332c
 ```
 
-You can then confirm that the port does have two entries in its `fixed_ips` list: 
+You can then confirm that the port does have two entries in its `fixed_ips` list:
 
-```
+```console
 $ openstack port show 51dae637-ad79-4ba9-9e41-78e5e0f3332c -c fixed_ips
 +-----------+---------------------------------------------------------------------------+
 | Field     | Value                                                                     |
@@ -68,15 +68,17 @@ $ openstack port show 51dae637-ad79-4ba9-9e41-78e5e0f3332c -c fixed_ips
 When you have an IP address on your port that is not yet assigned to any
 floating IP, you can assign it to the new floating IP. Proceed with:
 
-```
-$ openstack floating ip set c45a5eaf-2f3a-4679-89fe-266a5cbe840a --port 51dae637-ad79-4ba9-9e41-78e5e0f3332c --fixed-ip-address 10.2.0.228
+```bash
+openstack floating ip set c45a5eaf-2f3a-4679-89fe-266a5cbe840a \
+  --port 51dae637-ad79-4ba9-9e41-78e5e0f3332c \
+  --fixed-ip-address 10.2.0.228
 ```
 
 Then, list the floating (public) IP addresses, together with their
 fixed (private) counterparts:
 
 
-```
+```console
 $ openstack floating ip list -c ID -c "Floating IP Address" -c "Fixed IP Address" -c Port
 +--------------------------------------+---------------------+------------------+--------------------------------------+
 | ID                                   | Floating IP Address | Fixed IP Address | Port                                 |

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -1,33 +1,33 @@
 # Creating a VPN connection between regions
 
-Thanks to the Openstack Neutron VPN as a Service (VPNaaS) feature, you 
-can bridge two different regions via a site-to-site IPSec VPN 
-connection. This is made possible without setting up and configuring a 
-virtual machine in any one of the regions. On the contrary, you can 
-quickly establish such a connection using the {{gui}} or the OpenStack 
+Thanks to the Openstack Neutron VPN as a Service (VPNaaS) feature, you
+can bridge two different regions via a site-to-site IPSec VPN
+connection. This is made possible without setting up and configuring a
+virtual machine in any one of the regions. On the contrary, you can
+quickly establish such a connection using the {{gui}} or the OpenStack
 CLI. Let us demonstrate the process following both approaches.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the OpenStack CLI, 
-you need to [have an account](/howto/getting-started/create-account) in 
-{{brand}}. If you prefer to work with the [OpenStack 
-CLI](/howto/getting-started/enable-openstack-cli), then in addition to 
-the Python `openstackclient` module, you need to install the 
-Python `neutronclient` module also. Use either the package manager 
+Whether you choose to work from the {{gui}} or with the OpenStack CLI,
+you need to [have an account](/howto/getting-started/create-account) in
+{{brand}}. If you prefer to work with the [OpenStack
+CLI](/howto/getting-started/enable-openstack-cli), then in addition to
+the Python `openstackclient` module, you need to install the
+Python `neutronclient` module also. Use either the package manager
 of your operating system or `pip`:
 
 === "Debian/Ubuntu"
-	```bash
-	apt install python3-neutronclient
-	```
+    ```bash
+    apt install python3-neutronclient
+    ```
 === "Mac OS X with Homebrew"
-    This Python module is unavailable via `brew`, but you can 
+    This Python module is unavailable via `brew`, but you can
     install it via `pip`.
 === "Python Package"
-	```bash
-	pip install python-neutronclient
-	```
+    ```bash
+    pip install python-neutronclient
+    ```
 
 ## Creating a VPN connection between two regions
 
@@ -40,69 +40,69 @@ file](/howto/getting-started/enable-openstack-cli) for each region
 involved.
 
 === "{{gui}}"
-    On the top right-hand side of the {{gui}}, click the _Create_ 
-    button. A vertical pane titled _Create_ will slide into view from the 
-    right-hand side of the browser window. You will notice several rounded 
-    boxes, each one for defining, configuring, and instantiating a 
+    On the top right-hand side of the {{gui}}, click the _Create_
+    button. A vertical pane titled _Create_ will slide into view from the
+    right-hand side of the browser window. You will notice several rounded
+    boxes, each one for defining, configuring, and instantiating a
     different {{brand}} object. Go ahead and click the _VPN_ box.
-        
+
     ![Create new object](assets/vpnaas/shot-01.png)
-        
-    A new pane titled _Create a VPN Service_ will slide over. Between 
+
+    A new pane titled _Create a VPN Service_ will slide over. Between
     the two boxes, click the one titled _Quick (Guided) Connect_.
-    
+
     ![Quick connect](assets/vpnaas/shot-02.png)
-    
+
     Type in a name for the new site-to-site VPN connection.
-        
+
     ![Connection name](assets/vpnaas/shot-03.png)
-        
-    Select a region, project, and network for each of the two data 
+
+    Select a region, project, and network for each of the two data
     centers involved.
-        
+
     ![Data center choices](assets/vpnaas/shot-04.png)
-        
-    Look at the pre-shared key and, optionally, expand the _Advanced 
-    Options_ section to see all presets. You do not have to change anything 
-    there. When you are ready, click the green _Create_ button. The VPN 
+
+    Look at the pre-shared key and, optionally, expand the _Advanced
+    Options_ section to see all presets. You do not have to change anything
+    there. When you are ready, click the green _Create_ button. The VPN
     connection between the two regions will be established in a few seconds.
-        
+
     ![Create](assets/vpnaas/shot-05.png)
 === "OpenStack CLI"
-    First, you need to have the RC files of the two regions you will be 
-    connecting. In the example that follows, we demonstrate establishing a 
-    site-to-site connection between regions `fra1` and `kna1`. This means 
-    that, while following through, before working in `fra1` you need to 
-    source the RC file for `fra1`, and before working in `kna1` you need 
+    First, you need to have the RC files of the two regions you will be
+    connecting. In the example that follows, we demonstrate establishing a
+    site-to-site connection between regions `fra1` and `kna1`. This means
+    that, while following through, before working in `fra1` you need to
+    source the RC file for `fra1`, and before working in `kna1` you need
     to source the RC file for `kna1`.
-        
-    > It helps to imagine the site-to-site connection schematically, 
-    with `fra1` being on the left side and `kna1` being on the right side 
-    of the connection. That is why we interchange the terms `fra1`, _left_ 
+
+    > It helps to imagine the site-to-site connection schematically,
+    with `fra1` being on the left side and `kna1` being on the right side
+    of the connection. That is why we interchange the terms `fra1`, _left_
     and `kna1`, _right_.
-    
-    You also have to decide which subnets from either side you will 
-    connect. Additionally, you need to know the respective CIDR notations 
-    and routers. In the examples that follow, on the left side we have 
-    subnet `subnet-fra1` with CIDR `10.15.25.0/24` and router 
-    `router-fra1`, and on the right side we have subnet `subnet-kna1` with 
-    CIDR `10.15.20.0/24` and router `router-kna1`. For convenience, we have 
+
+    You also have to decide which subnets from either side you will
+    connect. Additionally, you need to know the respective CIDR notations
+    and routers. In the examples that follow, on the left side we have
+    subnet `subnet-fra1` with CIDR `10.15.25.0/24` and router
+    `router-fra1`, and on the right side we have subnet `subnet-kna1` with
+    CIDR `10.15.20.0/24` and router `router-kna1`. For convenience, we have
     set the shell variables `SUBNET_FRA1` and `SUBNET_KNA1`:
-    
+
     ```bash
     SUBNET_FRA1="10.15.25.0/24"
     SUBNET_KNA1="10.15.20.0/24"
     ```
-        
+
     ### Prepare the left side (region `fra1`)
-        
-    Begin by creating a new 
+
+    Begin by creating a new
     [IKE](https://en.wikipedia.org/wiki/Internet_Key_Exchange) policy:
-        
+
     ```bash
     openstack vpn ike policy create ike-pol-fra1
     ```
-    
+
     ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
@@ -120,14 +120,14 @@ involved.
     | project_id                    | dfc700467396428bacba4376e72cc3e9     |
     +-------------------------------+--------------------------------------+
     ```
-        
-    Then, create a new [IPSec](https://en.wikipedia.org/wiki/IPsec) 
+
+    Then, create a new [IPSec](https://en.wikipedia.org/wiki/IPsec)
     policy:
-        
+
     ```bash
     openstack vpn ipsec policy create ipsec-pol-fra1
     ```
-    
+
     ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
@@ -145,13 +145,13 @@ involved.
     | project_id                    | dfc700467396428bacba4376e72cc3e9     |
     +-------------------------------+--------------------------------------+
     ```
-    
+
     You are ready to create a new VPN service:
-        
+
     ```bash
     openstack vpn service create --router router-fra1 vpn-service-fra1
     ```
-    
+
     ```plain
     +----------------+--------------------------------------+
     | Field          | Value                                |
@@ -170,29 +170,29 @@ involved.
     | project_id     | dfc700467396428bacba4376e72cc3e9     |
     +----------------+--------------------------------------+
     ```
-    
-    Notice in the command output that the `Status` is `PENDING_CREATE`. 
-    This is expected. Also, jot down the value of the `external_v4_ip` 
-    parameter. Better yet, set this value to a new variable, `EXT_IP_FRA1`, 
+
+    Notice in the command output that the `Status` is `PENDING_CREATE`.
+    This is expected. Also, jot down the value of the `external_v4_ip`
+    parameter. Better yet, set this value to a new variable, `EXT_IP_FRA1`,
     for you will soon need it:
-        
+
     ```bash
     EXT_IP_FRA1="198.51.100.50"
     ```
-    
-    The site-to-site connection you are about to create needs two 
-    end-point groups on the left, and two end-point groups on the right. 
-    More specifically, on either side of the connection, there should be 
-    one end-point group for the local subnet and one end-point group for 
-    the peer (remote) subnet. You are now on the left side of the 
-    connection (region `fra1`), so begin with the left local end-point 
+
+    The site-to-site connection you are about to create needs two
+    end-point groups on the left, and two end-point groups on the right.
+    More specifically, on either side of the connection, there should be
+    one end-point group for the local subnet and one end-point group for
+    the peer (remote) subnet. You are now on the left side of the
+    connection (region `fra1`), so begin with the left local end-point
     group...
-        
+
     ```bash
     openstack vpn endpoint group create \
         --type subnet --value subnet-fra1 local-epg-fra1
     ```
-    
+
     ```plain
     +-------------+------------------------------------------+
     | Field       | Value                                    |
@@ -206,14 +206,14 @@ involved.
     | project_id  | dfc700467396428bacba4376e72cc3e9         |
     +-------------+------------------------------------------+
     ```
-        
+
     ...and then move on to creating the left peer end-point group:
-        
+
     ```bash
     openstack vpn endpoint group create \
         --type cidr --value $SUBNET_KNA1 peer-epg-fra1
     ```
-    
+
     ```plain
     +-------------+--------------------------------------+
     | Field       | Value                                |
@@ -227,21 +227,21 @@ involved.
     | project_id  | dfc700467396428bacba4376e72cc3e9     |
     +-------------+--------------------------------------+
     ```
-        
+
     ### Prepare the right side (region `kna1`)
-        
-    Before establishing a site-to-site VPN connection between the two 
-    regions, you must make similar preparations on the right side of the 
-    connection (region `kna1`). You should adjust all commands you entered 
-    above and execute them on the right side. For your convenience, these 
+
+    Before establishing a site-to-site VPN connection between the two
+    regions, you must make similar preparations on the right side of the
+    connection (region `kna1`). You should adjust all commands you entered
+    above and execute them on the right side. For your convenience, these
     are all the adjusted commands with the respective outputs:
-    
+
     Create a new IKE policy:
-        
+
     ```bash
     openstack vpn ike policy create ike-pol-kna1
     ```
-    
+
     ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
@@ -259,13 +259,13 @@ involved.
     | project_id                    | 94109c764a754e24ac0f6b01aef82359     |
     +-------------------------------+--------------------------------------+
     ```
-     
+
     Create a new IPSec policy:
-        
+
     ```bash
     openstack vpn ipsec policy create ipsec-pol-kna1
     ```
-    
+
     ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
@@ -283,13 +283,13 @@ involved.
     | project_id                    | 94109c764a754e24ac0f6b01aef82359     |
     +-------------------------------+--------------------------------------+
     ```
-    
+
     Create a new VPN service:
-        
+
     ```bash
     openstack vpn service create --router router-kna1 vpn-service-kna1
     ```
-    
+
     ```plain
     +----------------+--------------------------------------+
     | Field          | Value                                |
@@ -308,21 +308,21 @@ involved.
     | project_id     | 94109c764a754e24ac0f6b01aef82359     |
     +----------------+--------------------------------------+
     ```
-    
-    For convenience, set the value of parameter `external_v4_ip ` to a 
+
+    For convenience, set the value of parameter `external_v4_ip ` to a
     shell variable:
-        
+
     ```bash
     EXT_IP_KNA1="203.0.113.101"
     ```
-        
+
     Create a local end-point group:
-     
+
     ```bash
     openstack vpn endpoint group create \
         --type subnet --value subnet-kna1 local-epg-kna1
     ```
-    
+
     ```plain
     +-------------+------------------------------------------+
     | Field       | Value                                    |
@@ -336,14 +336,14 @@ involved.
     | project_id  | 94109c764a754e24ac0f6b01aef82359         |
     +-------------+------------------------------------------+
     ```
-    
+
     Create a peer (remote) end-point group:
-    
+
     ```bash
     openstack vpn endpoint group create \
         --type cidr --value $SUBNET_FRA1 peer-epg-kna1
     ```
-    
+
     ```plain
     +-------------+--------------------------------------+
     | Field       | Value                                |
@@ -357,30 +357,30 @@ involved.
     | project_id  | 94109c764a754e24ac0f6b01aef82359     |
     +-------------+--------------------------------------+
     ```
-    
+
     ### Instantiate a pre-shared key
-       
-    Before establishing a site-to-site IPSec VPN connection, you must 
-    have a randomly generated pre-shared key. You may use `openssl` for 
+
+    Before establishing a site-to-site IPSec VPN connection, you must
+    have a randomly generated pre-shared key. You may use `openssl` for
     generating a random string and immediately set it to a shell variable:
-        
+
     ```bash
     PRE_SHARED_KEY=$(openssl rand -hex 24)
     ```
-    
+
     The above is just an example. The key should not necessarily be a
     hexadecimal string, nor do you have to use `openssl`. Another option
     would be to use the fine `pwgen` tool, for example like this:
-    
+
     ```bash
     PRE_SHARED_KEY=$(pwgen 64 1)
     ```
-     
+
     ### Establish a left-to-right connection (region `fra1`)
-        
-    To create a VPN connection from left to right, i.e., from region 
+
+    To create a VPN connection from left to right, i.e., from region
     `fra1` to region `kna1`, issue the following command:
-        
+
     ```bash
     openstack vpn ipsec site connection create \
       --vpnservice vpn-service-fra1 \
@@ -393,7 +393,7 @@ involved.
       --psk $PRE_SHARED_KEY \
       vpn-conn-to-kna1
     ```
-    
+
     ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
@@ -422,12 +422,12 @@ involved.
     | project_id               | dfc700467396428bacba4376e72cc3e9                   |
     +--------------------------+----------------------------------------------------+
     ```
-    
+
     ### Establish a right-to-left connection (region `kna1`)
-    
-    Similarly, to create a VPN connection from right to left, i.e., 
+
+    Similarly, to create a VPN connection from right to left, i.e.,
     from region `kna1` to region `fra1`, issue the following command:
-    
+
     ```bash
     openstack vpn ipsec site connection create \
       --vpnservice vpn-service-kna1 \
@@ -440,7 +440,7 @@ involved.
       --psk $PRE_SHARED_KEY \
       vpn-conn-to-fra1
     ```
-    
+
     ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
@@ -472,31 +472,31 @@ involved.
 
 ## Viewing VPN connections and getting details
 
-No matter if you use the {{gui}} or the OpenStack CLI, you may at any 
+No matter if you use the {{gui}} or the OpenStack CLI, you may at any
 time list all VPN connections and get relevant details.
 
 === "{{gui}}"
-    In the vertical pane on the left-hand side of the {{gui}}, expand 
-    the _Networking_ section and then the _VPN Services_ subsection. From 
-    the available options, click _VPN Services_ again. You will see two VPN 
+    In the vertical pane on the left-hand side of the {{gui}}, expand
+    the _Networking_ section and then the _VPN Services_ subsection. From
+    the available options, click _VPN Services_ again. You will see two VPN
     connections in the main pane, each from one region to the other.
-        
+
     ![Create](assets/vpnaas/shot-06.png)
-        
-    For more information regarding a specific connection, click the 
-    corresponding three-dot icon (right-hand side) and select _View 
-    details_. Then, you can glance over all the details regarding, for 
+
+    For more information regarding a specific connection, click the
+    corresponding three-dot icon (right-hand side) and select _View
+    details_. Then, you can glance over all the details regarding, for
     example, the connection status and public IP address.
-        
+
     ![Create](assets/vpnaas/shot-07.png)
 === "OpenStack CLI"
-    You can list all IPSec VPN connections working from any of the two 
+    You can list all IPSec VPN connections working from any of the two
     regions involved. See, for example, the view from `fra1`:
-        
+
     ```bash
     openstack vpn ipsec site connection list
     ```
-        
+
     ```plain
     +--------------------------+------------------+---------------+--------------------------+--------+
     | ID                       | Name             | Peer Address  | Authentication Algorithm | Status |
@@ -505,14 +505,14 @@ time list all VPN connections and get relevant details.
     | 9e2d97be55e1             |                  |               |                          |        |
     +--------------------------+------------------+---------------+--------------------------+--------+
     ```
-    
-    If you want more information regarding a specific connection, type 
+
+    If you want more information regarding a specific connection, type
     something like this:
-        
+
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1
     ```
-    
+
     ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
@@ -544,10 +544,10 @@ time list all VPN connections and get relevant details.
 
 ## Testing the site-to-site VPN connection
 
-One way to test the VPN connection is to have two servers (e.g., 
-`server-fra1` and `server-kna1`), each on a different region (e.g., 
-`fra1` and `kna1` respectively), ping each other using private IP 
-addresses. With no VPN connection between the two regions, pinging 
+One way to test the VPN connection is to have two servers (e.g.,
+`server-fra1` and `server-kna1`), each on a different region (e.g.,
+`fra1` and `kna1` respectively), ping each other using private IP
+addresses. With no VPN connection between the two regions, pinging
 should not be possible:
 
 ```console
@@ -566,7 +566,7 @@ PING 10.15.25.58 (10.15.25.58) 56(84) bytes of data.
 3 packets transmitted, 0 received, 100% packet loss, time 2045ms
 ```
 
-On the other hand, with a VPN connection established between the two 
+On the other hand, with a VPN connection established between the two
 regions, pinging should be all possible:
 
 ```console
@@ -598,21 +598,21 @@ rtt min/avg/max/mdev = 32.533/32.832/33.336/0.358 ms
 You may, at any time, disable an active site-to-site VPN connection.
 
 === "{{gui}}"
-    Currently, there is no way to disable an active connection from the 
-    {{gui}}. If you want to disable an active connection, please use the 
+    Currently, there is no way to disable an active connection from the
+    {{gui}}. If you want to disable an active connection, please use the
     OpenStack CLI.
 === "OpenStack CLI"
-    All you have to do is get on either side of the connection and 
-    disable the VPN connection across the other side. Suppose you are on 
-    the left side of the connection (region `fra1`), and for whatever 
-    reason, you want to disable the site-to-site connection between left 
-    and right (regions `fra1` and `kna1`). First, you might want to 
+    All you have to do is get on either side of the connection and
+    disable the VPN connection across the other side. Suppose you are on
+    the left side of the connection (region `fra1`), and for whatever
+    reason, you want to disable the site-to-site connection between left
+    and right (regions `fra1` and `kna1`). First, you might want to
     remember the name of the VPN connection to the right:
-        
+
     ```bash
     openstack vpn ipsec site connection list
     ```
-        
+
     ```plain
     +--------------------------+------------------+---------------+--------------------------+--------+
     | ID                       | Name             | Peer Address  | Authentication Algorithm | Status |
@@ -621,20 +621,20 @@ You may, at any time, disable an active site-to-site VPN connection.
     | 9e2d97be55e1             |                  |               |                          |        |
     +--------------------------+------------------+---------------+--------------------------+--------+
     ```
-        
-    That would be `vpn-conn-to-kna1`, and according to the command 
+
+    That would be `vpn-conn-to-kna1`, and according to the command
     output above, it is active. To disable it, type the following:
-        
+
     ```bash
     openstack vpn ipsec site connection set --disable vpn-conn-to-kna1
     ```
-        
+
     Check if it is really disabled:
-        
+
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
     ```
-        
+
     ```plain
     +--------+-------+
     | Field  | Value |
@@ -642,24 +642,24 @@ You may, at any time, disable an active site-to-site VPN connection.
     | Status | DOWN  |
     +--------+-------+
     ```
-        
+
     It looks like it is disabled --- or `DOWN`.
-        
-    > You will probably have to wait several seconds before seeing a 
+
+    > You will probably have to wait several seconds before seeing a
     status change. If you are impatient, try something like this:
     ```bash
     watch "openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status"
     ```
     Hit CTRL+C as soon as you see the status change you expect.
-        
-    Now, get on the right side of the connection (region `kna1`), 
-    optionally look for the name of the VPN connection to the left (in our 
+
+    Now, get on the right side of the connection (region `kna1`),
+    optionally look for the name of the VPN connection to the left (in our
     example, that would be `vpn-conn-to-fra1`), and check its status:
-        
+
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-fra1 -c Status
     ```
-        
+
     ```plain
     +--------+-------+
     | Field  | Value |
@@ -667,7 +667,7 @@ You may, at any time, disable an active site-to-site VPN connection.
     | Status | DOWN  |
     +--------+-------+
     ```
-    
+
     It turns out that this direction of the connection is also disabled.
 
 To test that a previously enabled site-to-site connection is now disabled,
@@ -698,20 +698,20 @@ PING 10.15.25.58 (10.15.25.58) 56(84) bytes of data.
 You can easily enable an inactive site-to-site VPN connection.
 
 === "{{gui}}"
-    Currently, there is no way to enable an inactive connection from 
+    Currently, there is no way to enable an inactive connection from
     the {{gui}}. If you want to re-enable an inactive connection,
     please use the OpenStack CLI.
 === "OpenStack CLI"
-    Make sure you hop on the side where you initially disabled the 
-    connection. According to the example scenario we described in the 
-    previous section, that would be the left side (region `fra1`), and the 
-    name of the disabled connection would be `vpn-conn-to-kna1`. Make sure 
+    Make sure you hop on the side where you initially disabled the
+    connection. According to the example scenario we described in the
+    previous section, that would be the left side (region `fra1`), and the
+    name of the disabled connection would be `vpn-conn-to-kna1`. Make sure
     the connection status is `DOWN`:
-        
+
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
     ```
-        
+
     ```plain
     +--------+-------+
     | Field  | Value |
@@ -719,22 +719,22 @@ You can easily enable an inactive site-to-site VPN connection.
     | Status | DOWN  |
     +--------+-------+
     ```
-        
-    Note that if you issued a similar command from the right side of 
-    the connection (region `kna1`), you would also get a `DOWN` status. 
-    Being on the left side, all you have to do to enable the inactive 
+
+    Note that if you issued a similar command from the right side of
+    the connection (region `kna1`), you would also get a `DOWN` status.
+    Being on the left side, all you have to do to enable the inactive
     connection is type the following:
-        
+
     ```bash
     openstack vpn ipsec site connection set --enable vpn-conn-to-kna1
     ```
-        
+
     Check the connection status --- it should be `ACTIVE`:
-        
+
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
     ```
-        
+
     ```plain
     +--------+--------+
     | Field  | Value  |
@@ -742,15 +742,15 @@ You can easily enable an inactive site-to-site VPN connection.
     | Status | ACTIVE |
     +--------+--------+
     ```
-        
-    You get the same status by issuing a similar command from the right 
+
+    You get the same status by issuing a similar command from the right
     side.
-        
-    > Again, since you may have to wait several seconds before seeing 
-    the status change you expect, try something like this: 
+
+    > Again, since you may have to wait several seconds before seeing
+    the status change you expect, try something like this:
     ```bash
     watch "openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status"
-    ``` 
+    ```
     Hit CTRL+C to stop watching.
 
 To test that a previously disabled site-to-site connection is now enabled,
@@ -783,4 +783,3 @@ PING 10.15.25.58 (10.15.25.58) 56(84) bytes of data.
 3 packets transmitted, 3 received, 0% packet loss, time 2003ms
 rtt min/avg/max/mdev = 32.560/32.899/33.357/0.336 ms
 ```
-

--- a/docs/howto/openstack/nova/move-server-between-regions.md
+++ b/docs/howto/openstack/nova/move-server-between-regions.md
@@ -226,7 +226,7 @@ You are now done with the steps for the source region. The following
 steps will be done on the target region.
 
 > It is now safe to remove the image you created earlier, using the
-> command: 
+> command:
 > ```bash
 > openstack image delete <image_id>
 > ```

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -8,11 +8,11 @@ server, following both approaches.
 
 ## Prerequisites
 
-You need to [have at least one 
-network](/howto/openstack/neutron/new-network) in the region you are 
-interested in. Additionally, if you prefer to work with the OpenStack 
-CLI, then make sure to properly [enable it 
-first](/howto/getting-started/enable-openstack-cli). 
+You need to [have at least one
+network](/howto/openstack/neutron/new-network) in the region you are
+interested in. Additionally, if you prefer to work with the OpenStack
+CLI, then make sure to properly [enable it
+first](/howto/getting-started/enable-openstack-cli).
 
 ## Creating a server
 
@@ -23,326 +23,326 @@ to work with the OpenStack CLI, please do not forget to [source the RC
 file first](/howto/getting-started/enable-openstack-cli).
 
 === "{{gui}}"
-	On the top right-hand side of the {{gui}}, click the 
-	_Create_ button. A new pane titled _Create_ will slide into view from 
-	the right-hand side of the browser window.
-		
-	![Create new object](assets/new-server/shot-01.png)
-		
-	You will notice several rounded boxes on that pane, each for 
-	defining, configuring, and instantiating a different {{company}} 
-	Cloud object. Go ahead and click the _Server_ box. A new pane titled 
-	_Create a Server_ will slide over. At the top, type in a name for the 
-	new server and select one of the available regions.
-		
-	![Create new server](assets/new-server/shot-02.png)
-		
-	In the _Boot source_ section below, click the dropdown menu on 
-	the left and make sure you select _Boot from image_, so you can choose 
-	one of the readily available OS images to boot the new server off of. 
-	To pick one of the images, click on the dropdown menu on the right. For 
-	this how-to guide, we have chosen _ubuntu_ in general and 
-	_Ubuntu 22.04 Jammy Jellyfish 20220810_ in particular.
-		
-	![Boot source](assets/new-server/shot-03.png)
-		
-	Next, make sure _Boot Target_ is set to _Volume (Recommended)_. 
-	Regarding the server's CPU core count and amount of memory, set the 
-	[_Flavor_](/reference/flavors) accordingly.
-	The default flavor specifies a server with 1 CPU core and 1GB of RAM.
-	You can start with that or select a different configuration by clicking
-	the dropdown menu at the right of _Flavor_. Please note that, depending on 
-	the chosen flavor, the estimated monthly cost of the server changes. (While a 
-	server is shut off you are still getting charged for it, but less so.) 
-	At any time, this estimated cost is displayed in the green rectangular area 
-	at the top. Something else that affects the cost is the size of the root 
-	device. Take a look at the _Size_ parameter below, and notice the 
-	default (in 
-	[gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary))). 
-	You may leave the root device size unchanged, or modify it to be lower 
-	or higher than the default.
-		
-	When, at a later time, you decide to delete the server, you can 
-	do so but **keep** its boot volume (you may want, for example, to 
-	attach the exact same volume to a new server). Just leave the _Delete 
-	on termination_ option disabled if you want this kind of flexibility. 
-	On the other hand, if you want your root volume to be automatically
-	deleted when the server terminates, enable _Delete on termination_.
-	Use this option with caution.
-		
-	Finally, you may enable _Disaster recovery_ for the server. If 
-	you do, then daily server snapshots will be created, and you will have 
-	the option for easy and fast rollups to previous snapshots. Please be 
-	aware that enabling this option increases the server's monthly estimated
-	cost (again, it is displayed in the green rectangular area at the top).
-		
-	![Server configuration](assets/new-server/shot-04.png)
-		
-	Regarding networking, select one of the available networks to 
-	attach the new server to. If you want the server accessible from the 
-	Internet, do not forget to enable the _I want an external IP for my 
-	server_ option. In the section below, set _Security Groups_ to 
-	_default_.
-		
-	![Networking and security groups](assets/new-server/shot-05.png)
-		
-	If you already have one or more public keys in your 
-	{{brand}} account, you can now select a key to be included 
-	in the `~/.ssh/authorized_keys` file of the server's default user. That 
-	way, you can securely log into the remote user's account without typing 
-	a password. If there are no public keys to choose from, activate the 
-	_Password login enabled_ option and set a password for a specific user 
-	(with a username you define).
-		
-	![Login and keypairs](assets/new-server/shot-06.png)
-		
-	A configuration script is automatically prepared based on the 
-	choices you have already made. That script runs during system boot and 
-	performs housekeeping tasks like user account creation, enabling 
-	acceptable authentication methods, and configuring remote package 
-	repositories. Click on _Advanced Options_ to see the default script.
-		
-	![User-data propagation method](assets/new-server/shot-07.png)
-		
-	It is now time to create your {{brand}} server; 
-	click the green _Create_ button, and the new server will be readily 
-	available in a few seconds.
-		
-	![Create new server](assets/new-server/shot-08.png)
+    On the top right-hand side of the {{gui}}, click the
+    _Create_ button. A new pane titled _Create_ will slide into view from
+    the right-hand side of the browser window.
+
+    ![Create new object](assets/new-server/shot-01.png)
+
+    You will notice several rounded boxes on that pane, each for
+    defining, configuring, and instantiating a different {{company}}
+    Cloud object. Go ahead and click the _Server_ box. A new pane titled
+    _Create a Server_ will slide over. At the top, type in a name for the
+    new server and select one of the available regions.
+
+    ![Create new server](assets/new-server/shot-02.png)
+
+    In the _Boot source_ section below, click the dropdown menu on
+    the left and make sure you select _Boot from image_, so you can choose
+    one of the readily available OS images to boot the new server off of.
+    To pick one of the images, click on the dropdown menu on the right. For
+    this how-to guide, we have chosen _ubuntu_ in general and
+    _Ubuntu 22.04 Jammy Jellyfish 20220810_ in particular.
+
+    ![Boot source](assets/new-server/shot-03.png)
+
+    Next, make sure _Boot Target_ is set to _Volume (Recommended)_.
+    Regarding the server's CPU core count and amount of memory, set the
+    [_Flavor_](/reference/flavors) accordingly.
+    The default flavor specifies a server with 1 CPU core and 1GB of RAM.
+    You can start with that or select a different configuration by clicking
+    the dropdown menu at the right of _Flavor_. Please note that, depending on
+    the chosen flavor, the estimated monthly cost of the server changes. (While a
+    server is shut off you are still getting charged for it, but less so.)
+    At any time, this estimated cost is displayed in the green rectangular area
+    at the top. Something else that affects the cost is the size of the root
+    device. Take a look at the _Size_ parameter below, and notice the
+    default (in
+    [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary))).
+    You may leave the root device size unchanged, or modify it to be lower
+    or higher than the default.
+
+    When, at a later time, you decide to delete the server, you can
+    do so but **keep** its boot volume (you may want, for example, to
+    attach the exact same volume to a new server). Just leave the _Delete
+    on termination_ option disabled if you want this kind of flexibility.
+    On the other hand, if you want your root volume to be automatically
+    deleted when the server terminates, enable _Delete on termination_.
+    Use this option with caution.
+
+    Finally, you may enable _Disaster recovery_ for the server. If
+    you do, then daily server snapshots will be created, and you will have
+    the option for easy and fast rollups to previous snapshots. Please be
+    aware that enabling this option increases the server's monthly estimated
+    cost (again, it is displayed in the green rectangular area at the top).
+
+    ![Server configuration](assets/new-server/shot-04.png)
+
+    Regarding networking, select one of the available networks to
+    attach the new server to. If you want the server accessible from the
+    Internet, do not forget to enable the _I want an external IP for my
+    server_ option. In the section below, set _Security Groups_ to
+    _default_.
+
+    ![Networking and security groups](assets/new-server/shot-05.png)
+
+    If you already have one or more public keys in your
+    {{brand}} account, you can now select a key to be included
+    in the `~/.ssh/authorized_keys` file of the server's default user. That
+    way, you can securely log into the remote user's account without typing
+    a password. If there are no public keys to choose from, activate the
+    _Password login enabled_ option and set a password for a specific user
+    (with a username you define).
+
+    ![Login and keypairs](assets/new-server/shot-06.png)
+
+    A configuration script is automatically prepared based on the
+    choices you have already made. That script runs during system boot and
+    performs housekeeping tasks like user account creation, enabling
+    acceptable authentication methods, and configuring remote package
+    repositories. Click on _Advanced Options_ to see the default script.
+
+    ![User-data propagation method](assets/new-server/shot-07.png)
+
+    It is now time to create your {{brand}} server;
+    click the green _Create_ button, and the new server will be readily
+    available in a few seconds.
+
+    ![Create new server](assets/new-server/shot-08.png)
 === "OpenStack CLI"
-	An `openstack` command for creating a server may look like 
-	this:
-		
-	```bash
-	openstack server create \
-		--flavor $FLAVOR_NAME \
-		--image $IMAGE_NAME \
-		--boot-from-volume $VOL_SIZE \
-		--network $NETWORK_NAME \
-		--security-group $SEC_GROUP_NAME \
-		--key-name $KEY_NAME \
-		--wait \
-		$SERVER_NAME
-	```
-		
-	Each variable represents a piece of information we have to look 
-	for or, in the cases of `KEY_NAME` and `SERVER_NAME`, arbitrarily 
-	define.
-	
-	Let us begin with the [_flavors_](/reference/flavors) (`FLAVOR_NAME`), which 
-	describe combinations of CPU core count and memory size. Each server has a 
-	distinct flavor, and to see all available flavors type:
-	
-	```bash
-	openstack flavor list
-	```
-		
-	You will get a pretty long list of flavors. For our demonstration,
-	we suggest you go with `b.1c1gb`. A server with this particular flavor will 
-	have one CPU core and one
-	[gibibyte](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)) of 
-	RAM. Go ahead and set `FLAVOR_NAME` accordingly:
-		
-	```bash
-	FLAVOR_NAME="b.1c1gb"
-	```
-		
-	Your server should have an image to boot off of (`IMAGE_NAME`). 
-	For a list of all available images in {{brand}}, type:
-		
-	```bash
-	openstack image list
-	```
-		
-	This time you get a shorter list, but you can still filter for 
-	images with the OS you prefer. For example, filter for Ubuntu:
-		
-	```bash
-	openstack image list --tag "os:ubuntu"
-	```
-		
-	Continue with the `Ubuntu 22.04 Jammy Jellyfish 20220810` image:
-		
-	```bash
-	IMAGE_NAME="Ubuntu 22.04 Jammy Jellyfish 20220810"
-	```
-	
-	Before you go on, decide on the capacity (in gibibytes) of the server's
-	boot volume (`VOL_SIZE`). We suggest you start with 20 gibibytes:
-	
-	```bash
-	VOL_SIZE="20"
-	```
-	
-	You need at least one network in the region you're about to 
-	create your new server (`NETWORK_NAME`). To get the names of all 
-	available (internal) networks, type:
-	
-	```bash
-	openstack network list --internal -c Name
-	```
-		
-	```plain
-	+----------------+
-	| Name           |
-	+----------------+
-	| nordostbahnhof |
-	+----------------+
-	```
-		
-	Set the `NETWORK_NAME` variable accordingly:
-	
-	```bash
-	NETWORK_NAME="nordostbahnhof"
-	```
-		
-	Regarding the security group (`SEC_GROUP_NAME`), unless you 
-	have already created one yourself, you will find only one per region:
-	
-	```bash
-	openstack security group list -c Name -c Description
-	```
-		
-	```plain
-	+---------+------------------------+
-	| Name    | Description            |
-	+---------+------------------------+
-	| default | Default security group |
-	+---------+------------------------+
-	```
-		
-	Go ahead and set `SEC_GROUP_NAME`:
-		
-	```bash
-	SEC_GROUP_NAME="default"
-	```
-		
-	You most likely want a server you can remotely connect to via 
-	SSH without typing a password. Upload one of our public keys to your 
-	{{brand}} account:
-		
-	```bash
-	openstack keypair create --public-key ~/.ssh/id_ed25519.pub bahnhof
-	```
-		
-	In the example above, we uploaded the public key 
-	`~/.ssh/id_ed25519.pub` to our {{brand}} account and named 
-	it `bahnhof`. Follow our example and do not forget to set the 
-	`KEY_NAME`:
-		
-	```bash
-	KEY_NAME="bahnhof"
-	```
-		
-	By the way, check all uploaded public keys...
-		
-	```bash
-	openstack keypair list
-	```
-		
-	...and get more information regarding the one you just uploaded:
-		
-	```bash
-	openstack keypair show bahnhof
-	```
-		
-	You are almost ready to create your new server. Decide on a 
-	name...
-		
-	```bash
-	SERVER_NAME="zug" # just an example
-	```
-		
-	...and then go ahead and create it:
-			
-	```bash
-	openstack server create \
-		--flavor b.1c1gb \
-		--image $IMAGE_NAME \
-		--boot-from-volume 20 \
-		--network nordostbahnhof \
-		--security-group default \
-		--key-name bahnhof \
-		--wait \
-		zug
-	```
-		
-	(For clarity's sake, and with the exception of `IMAGE_NAME`, we 
-	used the actual values and not the variables we so meticulously set.) 
-	The `--wait` parameter is optional. Whenever you choose to 
-	use it, you get back control of your terminal only after the server is 
-	readily available in {{brand}}.
-	
-	To connect to your server remotely, you need to create a floating IP
-	for the external network in the {{brand}}, and then assign
-	this IP to your server. First, create the floating IP: 
-	
-	```bash
-	openstack floating ip create ext-net
-	```
-		
-	See all floating IPs...
-		
-	```bash
-	openstack floating ip list
-	```
-		
-	...and assign the one you just created to your server:
-		
-	```bash
-	openstack server add floating ip zug 198.51.100.12
-	```
-		
-	The username of the default user account in the Ubuntu image is 
-	`ubuntu`, so now you can connect to your remote server via SSH without 
-	typing a password:
-	
-	```bash
-	ssh ubuntu@198.51.100.12
-	```
+    An `openstack` command for creating a server may look like
+    this:
+
+    ```bash
+    openstack server create \
+        --flavor $FLAVOR_NAME \
+        --image $IMAGE_NAME \
+        --boot-from-volume $VOL_SIZE \
+        --network $NETWORK_NAME \
+        --security-group $SEC_GROUP_NAME \
+        --key-name $KEY_NAME \
+        --wait \
+        $SERVER_NAME
+    ```
+
+    Each variable represents a piece of information we have to look
+    for or, in the cases of `KEY_NAME` and `SERVER_NAME`, arbitrarily
+    define.
+
+    Let us begin with the [_flavors_](/reference/flavors) (`FLAVOR_NAME`), which
+    describe combinations of CPU core count and memory size. Each server has a
+    distinct flavor, and to see all available flavors type:
+
+    ```bash
+    openstack flavor list
+    ```
+
+    You will get a pretty long list of flavors. For our demonstration,
+    we suggest you go with `b.1c1gb`. A server with this particular flavor will
+    have one CPU core and one
+    [gibibyte](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)) of
+    RAM. Go ahead and set `FLAVOR_NAME` accordingly:
+
+    ```bash
+    FLAVOR_NAME="b.1c1gb"
+    ```
+
+    Your server should have an image to boot off of (`IMAGE_NAME`).
+    For a list of all available images in {{brand}}, type:
+
+    ```bash
+    openstack image list
+    ```
+
+    This time you get a shorter list, but you can still filter for
+    images with the OS you prefer. For example, filter for Ubuntu:
+
+    ```bash
+    openstack image list --tag "os:ubuntu"
+    ```
+
+    Continue with the `Ubuntu 22.04 Jammy Jellyfish 20220810` image:
+
+    ```bash
+    IMAGE_NAME="Ubuntu 22.04 Jammy Jellyfish 20220810"
+    ```
+
+    Before you go on, decide on the capacity (in gibibytes) of the server's
+    boot volume (`VOL_SIZE`). We suggest you start with 20 gibibytes:
+
+    ```bash
+    VOL_SIZE="20"
+    ```
+
+    You need at least one network in the region you're about to
+    create your new server (`NETWORK_NAME`). To get the names of all
+    available (internal) networks, type:
+
+    ```bash
+    openstack network list --internal -c Name
+    ```
+
+    ```plain
+    +----------------+
+    | Name           |
+    +----------------+
+    | nordostbahnhof |
+    +----------------+
+    ```
+
+    Set the `NETWORK_NAME` variable accordingly:
+
+    ```bash
+    NETWORK_NAME="nordostbahnhof"
+    ```
+
+    Regarding the security group (`SEC_GROUP_NAME`), unless you
+    have already created one yourself, you will find only one per region:
+
+    ```bash
+    openstack security group list -c Name -c Description
+    ```
+
+    ```plain
+    +---------+------------------------+
+    | Name    | Description            |
+    +---------+------------------------+
+    | default | Default security group |
+    +---------+------------------------+
+    ```
+
+    Go ahead and set `SEC_GROUP_NAME`:
+
+    ```bash
+    SEC_GROUP_NAME="default"
+    ```
+
+    You most likely want a server you can remotely connect to via
+    SSH without typing a password. Upload one of our public keys to your
+    {{brand}} account:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_ed25519.pub bahnhof
+    ```
+
+    In the example above, we uploaded the public key
+    `~/.ssh/id_ed25519.pub` to our {{brand}} account and named
+    it `bahnhof`. Follow our example and do not forget to set the
+    `KEY_NAME`:
+
+    ```bash
+    KEY_NAME="bahnhof"
+    ```
+
+    By the way, check all uploaded public keys...
+
+    ```bash
+    openstack keypair list
+    ```
+
+    ...and get more information regarding the one you just uploaded:
+
+    ```bash
+    openstack keypair show bahnhof
+    ```
+
+    You are almost ready to create your new server. Decide on a
+    name...
+
+    ```bash
+    SERVER_NAME="zug" # just an example
+    ```
+
+    ...and then go ahead and create it:
+
+    ```bash
+    openstack server create \
+        --flavor b.1c1gb \
+        --image $IMAGE_NAME \
+        --boot-from-volume 20 \
+        --network nordostbahnhof \
+        --security-group default \
+        --key-name bahnhof \
+        --wait \
+        zug
+    ```
+
+    (For clarity's sake, and with the exception of `IMAGE_NAME`, we
+    used the actual values and not the variables we so meticulously set.)
+    The `--wait` parameter is optional. Whenever you choose to
+    use it, you get back control of your terminal only after the server is
+    readily available in {{brand}}.
+
+    To connect to your server remotely, you need to create a floating IP
+    for the external network in the {{brand}}, and then assign
+    this IP to your server. First, create the floating IP:
+
+    ```bash
+    openstack floating ip create ext-net
+    ```
+
+    See all floating IPs...
+
+    ```bash
+    openstack floating ip list
+    ```
+
+    ...and assign the one you just created to your server:
+
+    ```bash
+    openstack server add floating ip zug 198.51.100.12
+    ```
+
+    The username of the default user account in the Ubuntu image is
+    `ubuntu`, so now you can connect to your remote server via SSH without
+    typing a password:
+
+    ```bash
+    ssh ubuntu@198.51.100.12
+    ```
 
 ## Viewing information about the newly created server
 === "{{gui}}"
-	From the {{gui}} you may, at any 
-	time, see all servers and get detailed information regarding each one 
-	of them; expand the left-hand side vertical pane, click _Compute_, then 
-	_Servers_, and, in the central pane, select the region you want. 
-		
-	![Servers and details](assets/new-server/shot-09.png)
+    From the {{gui}} you may, at any
+    time, see all servers and get detailed information regarding each one
+    of them; expand the left-hand side vertical pane, click _Compute_, then
+    _Servers_, and, in the central pane, select the region you want.
+
+    ![Servers and details](assets/new-server/shot-09.png)
 === "OpenStack CLI"
-	To see all available servers in the region, type:
-		
-	```bash
-	openstack server list
-	```
-		
-	You can always get specific information on a particular server:
-	
-	```bash
-	openstack server show zug
-	```
+    To see all available servers in the region, type:
+
+    ```bash
+    openstack server list
+    ```
+
+    You can always get specific information on a particular server:
+
+    ```bash
+    openstack server show zug
+    ```
 ## Connecting to the server console
-=== "{{gui}}"		
-	While viewing information regarding your server, you may get 
-	its public IP  address (e.g., from the _Addresses_ tab) and connect to 
-	it remotely. Alternatively, you may launch a web console and log in; 
-	click on the three-dot icon on the right of the server header, and from 
-	the pop-up menu that appears select _Remote Console_.  
-		
-	![Launch remote console](assets/new-server/shot-10.png)
-		
-	A new window pops up, and that's your web console to your 
-	{{brand}} server. Please note that this window cannot be 
-	resized but can be opened on a new browser window or tab.
-		
-	![Server console](assets/new-server/shot-11.png)
+=== "{{gui}}"
+    While viewing information regarding your server, you may get
+    its public IP  address (e.g., from the _Addresses_ tab) and connect to
+    it remotely. Alternatively, you may launch a web console and log in;
+    click on the three-dot icon on the right of the server header, and from
+    the pop-up menu that appears select _Remote Console_.
+
+    ![Launch remote console](assets/new-server/shot-10.png)
+
+    A new window pops up, and that's your web console to your
+    {{brand}} server. Please note that this window cannot be
+    resized but can be opened on a new browser window or tab.
+
+    ![Server console](assets/new-server/shot-11.png)
 === "OpenStack CLI"
-	You may have access to the web console of your server, and you need the 
-	corresponding URL for it:
-	
-	```bash
-	openstack console url show zug
-	```
-	
-	Usage of the web console is discouraged, though. Instead,
-	securely connect to your server via SSH.
+    You may have access to the web console of your server, and you need the
+    corresponding URL for it:
+
+    ```bash
+    openstack console url show zug
+    ```
+
+    Usage of the web console is discouraged, though. Instead,
+    securely connect to your server via SSH.

--- a/docs/howto/openstack/nova/rescue-server.md
+++ b/docs/howto/openstack/nova/rescue-server.md
@@ -24,55 +24,55 @@ first](../../getting-started/enable-openstack-cli.md).
     Navigate to the server list.
 
     ![The left hand side navigation panel, with the word "Servers"
-	highlighted.](assets/rescue-server/01-left-side-panel.png)
+    highlighted.](assets/rescue-server/01-left-side-panel.png)
 
     Find the server you want to rescue in the list, and on the
     right-hand side, click on its menu button.
 
     ![An orange circle with three white
-	dots.](assets/rescue-server/02-menu-button.png)
+    dots.](assets/rescue-server/02-menu-button.png)
 
     Click on _Rescue Server_.
 
     ![A list of server actions, with the line "Rescue Server"
-	highlighted.](assets/rescue-server/03-menu-list.png)
+    highlighted.](assets/rescue-server/03-menu-list.png)
 
     Once selected, the rescue dialog appears.
 
     Click _No_ to cancel or _Yes, Rescue_ to proceed.
 
     ![About to rescue a server, showing details about the Server name,
-	UUID and region with a question to confirm the rescue with "Yes,
-	Rescue" or cancel it with
-	"No".](assets/rescue-server/04-rescue-button.png)
+    UUID and region with a question to confirm the rescue with "Yes,
+    Rescue" or cancel it with
+    "No".](assets/rescue-server/04-rescue-button.png)
 
     When a server has been switched to rescue mode, its status icon
     appears with an exclamation mark:
 
     ![Exclamation mark on server icon showing the server on "rescue
-	mode".](assets/rescue-server/05-rescue-mode.png)
+    mode".](assets/rescue-server/05-rescue-mode.png)
 
 === "OpenStack CLI"
-	You must first select a system rescue image from the available
+    You must first select a system rescue image from the available
     images:
-	
-	```console
-	$ openstack image list --tag system-rescue
-	+--------------------------------------+---------------+--------+
-	| ID                                   | Name          | Status |
-	+--------------------------------------+---------------+--------+
-	| cb2217f3-1ca7-4440-b10e-df7ff2d92cae | system-rescue | active |
-	+--------------------------------------+---------------+--------+
-	```
-	
+
+    ```console
+    $ openstack image list --tag system-rescue
+    +--------------------------------------+---------------+--------+
+    | ID                                   | Name          | Status |
+    +--------------------------------------+---------------+--------+
+    | cb2217f3-1ca7-4440-b10e-df7ff2d92cae | system-rescue | active |
+    +--------------------------------------+---------------+--------+
+    ```
+
     To start the server using the system rescue image, use the
     following command, substituting the correct ID for the
     `system-rescue` image in your {{brand}} region:
 
     ```bash
     openstack --os-compute-api-version 2.87 \
-	  server rescue \
-	  --image cb2217f3-1ca7-4440-b10e-df7ff2d92cae <server_id>
+      server rescue \
+      --image cb2217f3-1ca7-4440-b10e-df7ff2d92cae <server_id>
     ```
 
     While the rescue is ongoing, the server should have the

--- a/docs/howto/openstack/octavia/tls-lb.md
+++ b/docs/howto/openstack/octavia/tls-lb.md
@@ -21,7 +21,7 @@ In case your certificate provider has made your certificate chain and
 key available separately, using the PEM format, you can easily convert
 it to PKCS #12 using the following `openssl` command:
 
-```
+```bash
 openssl pkcs12 -export -inkey key.pem -in fullchain.pem -out bundle.p12
 ```
 
@@ -35,14 +35,12 @@ contents of the bundle, *pre-encoded with
 [Base64](https://en.wikipedia.org/wiki/Base64)*, as the secret’s
 payload.
 
-```bash
-openstack secret store \
+```console
+$ openstack secret store \
   --name='tls_secret1' \
   -t 'application/octet-stream' \
   -e 'base64' \
   --payload="$(base64 < server.p12)"
-```
-```
 +---------------+---------------------------------------------------------------------------------+
 | Field         | Value                                                                           |
 +---------------+---------------------------------------------------------------------------------+
@@ -73,15 +71,13 @@ properties:
 
 You create such a listener with the following command:
 
-```bash
-openstack loadbalancer listener create \
+```console
+$ openstack loadbalancer listener create \
   --protocol-port 443 \
   --protocol TERMINATED_HTTPS \
   --name listener1 \
   --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae  \
   <loadbalancer-name-or-id>
-```
-```
 +-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Field                       | Value                                                                                                                                                                                                                                                                              |
 +-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -136,8 +132,8 @@ with no user-noticeable interruption to your service.
    following command:
    ```bash
    openstack loadbalancer listener set \
-	 --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/e2d8acc1-c6b9-4c01-9373-cc167b075c25  \
-	 <listener-name-or-id>
+     --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/e2d8acc1-c6b9-4c01-9373-cc167b075c25  \
+     <listener-name-or-id>
    ```
 
 Once all your load balancer listeners have completed the update, you

--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -45,7 +45,7 @@
 | VPN (IPsec with PSK) | :material-check: | :material-check: |
 
 
-## Load Balancers 
+## Load Balancers
 
 |                                                                                                             | Sto1HS           | Sto2HS           |
 | --------------------------------------------------------------------                                        | ---------------- | ---------------- |

--- a/docs/reference/features/index.md
+++ b/docs/reference/features/index.md
@@ -1,9 +1,6 @@
 ---
-description: >
-  Our services constantly evolve, and we gradually add features to
-  regions as they become available and mature.
+description: Our services constantly evolve, and we gradually add features to regions as they become available and mature.
 ---
-
 # Feature support matrix
 
 {{page.meta.description}}

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -8,8 +8,8 @@
 >
 > :material-close: Feature is not available
 
-## Virtualization
 
+## Virtualization
 |                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
 | [Dedicated CPU](../../flavors/#compute-tiers) | :material-close: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
@@ -17,7 +17,6 @@
 
 
 ## Block storage
-
 |                                                                 | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | ------------------------------                                  | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | Highly available storage                                        | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
@@ -25,9 +24,7 @@
 | [Volume encryption](/howto/openstack/cinder/encrypted-volumes/) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
-
 ## Object storage
-
 |                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | ------------------------------              | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | S3 API                                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
@@ -36,7 +33,6 @@
 
 
 ## Networking (Layer 2/3)
-
 |                      | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | -------------------- | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
@@ -44,8 +40,7 @@
 | VPN (IPsec with PSK) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
-## Load Balancers 
-
+## Load Balancers
 |                                                                                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | --------------------------------------------------------------------                                        | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
@@ -54,7 +49,6 @@
 
 
 ## Kubernetes management
-
 |                   | Kna1                  | Sto2                  | Fra1                  | Dx1              | Tky1             |
 | ----------------- | ----------------      | ----------------      | ----------------      | ---------------- | ---------------- |
 | OpenStack Magnum  | :material-check:      | :material-check:      | :material-check:      | :material-check: | :material-check: |

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -1,7 +1,5 @@
 ---
-description: >
-  Using flavors, you define a server’s performance characteristics and
-  supported features.
+description: Using flavors, you define a server’s performance characteristics and supported features.
 ---
 # Flavors
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = yamllint,bashate,build
+envlist = yamllint,bashate,markdownlint,build
 
 [testenv]
 envdir = {toxworkdir}/mkdocs

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,12 @@ envdir = {toxworkdir}/yamllint
 deps = yamllint
 commands = yamllint {toxinidir}
 
+[testenv:markdownlint]
+envdir = {toxworkdir}/markdownlint
+deps =
+  pymarkdownlnt
+commands = pymarkdown -c .pymarkdown.json scan -r docs
+
 [testenv:bumpversion]
 envdir = {toxworkdir}/bumpversion
 passenv =


### PR DESCRIPTION
Add pymarkdownlnt-based linting functionality for Markdown, to encourage some best practices for writing Markdown (such as avoiding trailing whitespace, using consistent lists, always specifying the language applying to fenced code blocks, etc.)

- build: Add markdownlint testenv
- fix: correct Markdown issues flagged by pymarkdownlnt
- build: Add markdownlint to list of default testenvs
