### PR TITLE
Update linter configuration, facilitate one-sentence-per-line policy

### DIFF
--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -12,7 +12,10 @@
             "enabled": false
         },
         "line-length": {
-            "enabled": false
+            "enabled": true,
+            "line_length": 600,
+            "heading_line_length": 80,
+            "code_blocks": false
         },
         "no-multiple-blanks": {
             "maximum": 2

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -1,32 +1,25 @@
 # Modifying content on this site
 
-You have two options for editing content: directly in your browser
-using GitHub, or using a Git-based workflow from your local work
-environment.
+You have two options for editing content: directly in your browser using GitHub, or using a Git-based workflow from your local work environment.
 
 ## Notes on content additions
 
+**Sections:** Generally, content additions should fit somewhere within the existing top-level and second-level sections (like [_Background_](../background/index.md), or [_Kubernetes_](../howto/kubernetes/index.md)).
+Try not to introduce a new top-level or second-level section.
 
-**Sections:** Generally, content additions should fit somewhere within
-the existing top-level and second-level sections. Try not to introduce
-a new top-level or second-level section.
+**Text:** Write your Markdown text in such a way that each sentence in a paragraph has its own line, and is followed immediately by a newline character with no spaces in between.
+This facilitates the review of your change, and it also helps you notice long run-on sentences as you write.
 
-**Screenshots:** If you are contributing a change that contains
-screenshots from {{gui}}, they should use a resolution of
-1920×1080 pixels (1080p). If your screen uses a larger resolution, use
-[Firefox Responsive Design
-Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
-or [Chrome/Chromium Device
-Mode](https://developer.chrome.com/docs/devtools/device-mode/) to
-configure your browser with 1080p.
-Screenshots should be added to a directory named `assets`, located in
-the same directory as the Markdown file you are adding or editing.
+**Headings:** Keep headings concise, under 80 characters.
 
-**CLI screen dumps:** If you are contributing a change that contains a
-screen dump from the `openstack` command-line client, please limit its
-width to 100 characters. You can do this by setting the following
-environment variable in your terminal, before you start work on your
-change.
+**Screenshots:** If you are contributing a change that contains screenshots from {{gui}}, they should use a resolution of 1920×1080 pixels (1080p).
+If your screen uses a larger resolution, use [Firefox Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
+or [Chrome/Chromium Device Mode](https://developer.chrome.com/docs/devtools/device-mode/) to configure your browser with 1080p.
+
+Screenshots should be added to a directory named `assets`, located in the same directory as the Markdown file you are adding or editing.
+
+**CLI screen dumps:** If you are contributing a change that contains a screen dump from the `openstack` command-line client, please limit its width to 100 characters.
+You can do this by setting the following environment variable in your terminal, before you start work on your change.
 
 ``` bash
 export CLIFF_MAX_TERM_WIDTH=100
@@ -34,33 +27,22 @@ export CLIFF_MAX_TERM_WIDTH=100
 
 ## Modifying content from your browser
 
-Every page on this site has an Edit button
-([:{{config.theme.icon.edit | replace('/','-')}}:]({{page.edit_url}})).
-If you click it, it’ll
-take you straight to its [corresponding source page]({{page.edit_url}}) in GitHub. Then,
-you can follow [GitHub’s
-documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository)
-on how to propose changes to another user’s repository.
-
+Every page on this site has an Edit button ([:{{config.theme.icon.edit | replace('/','-')}}:]({{page.edit_url}})).
+If you click it, it’ll take you straight to its [corresponding source page]({{page.edit_url}}) in GitHub.
+Then, you can follow [GitHub’s documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository) on how to propose changes to another user’s repository.
 
 ## Modifying content using Git
 
-The Git repository for this site lives [on GitHub]({{config.repo_url}}). You
-can [fork that
-repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo),
-make the proposed changes in your fork, and then send us a standard
-[GitHub pull
-request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+The Git repository for this site lives [on GitHub]({{config.repo_url}}).
+You can [fork that repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo), make the proposed changes in your fork, and then send us a standard [GitHub pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
-For this purpose, use `git` in combination with either GitHub's web
-interface, or the `gh` command-line interface (CLI).
+For this purpose, use `git` in combination with either GitHub's web interface, or the `gh` command-line interface (CLI).
 
 First, create a fork of the documentation repository:
 
 === "`git` client and web browser"
     Open [our GitHub repo]({{config.repo_url}}) and click the *Fork* button.
-    When you create your new fork, it's fine to leave the
-    *Copy the `main` branch only* option enabled.
+    When you create your new fork, it's fine to leave the *Copy the `main` branch only* option enabled.
 
     Then, proceed to create a new local checkout of your fork:
     ```bash
@@ -87,13 +69,11 @@ Please see our [notes on commit messages](quality.md).
 Finally, create a pull request (PR) from your changes:
 
 === "`git` client and web browser"
-    Run the following `git` command (assuming `origin` is the
-    remote that points to your fork):
+    Run the following `git` command (assuming `origin` is the remote that points to your fork):
     ```bash
     git push origin <your-topic-branch-name>
     ```
-    Then, open your browser to the URL suggested by the `git push`
-    command, and proceed to create a pull request.
+    Then, open your browser to the URL suggested by the `git push` command, and proceed to create a pull request.
 === "`gh` client"
     ```bash
     gh pr create --fill
@@ -101,9 +81,8 @@ Finally, create a pull request (PR) from your changes:
 
 ## Monitoring changes as you edit
 
-To see your changes as you work on them, you can use
-[tox](https://tox.wiki/en/latest/). Having created a topic branch with
-your modifications, run:
+To see your changes as you work on them, you can use [tox](https://tox.wiki/en/latest/).
+Having created a topic branch with your modifications, run:
 
 ```bash
 cd {{ brand | lower }}-docs
@@ -111,13 +90,10 @@ git checkout <your-topic-branch-name>
 tox -e serve
 ```
 
-A local copy of the documentation will then run on your local machine
-and be accessible from <http://localhost:8000> in your browser.
+A local copy of the documentation will then run on your local machine and be accessible from <http://localhost:8000> in your browser.
 
-When you are planning to make several changes in rapid succession, you
-may want to speed up rendering the site after each change. You may do
-so by disabling a plugin that checks all links (including external
-links) for accessibility:
+When you are planning to make several changes in rapid succession, you may want to speed up rendering the site after each change.
+You may do so by disabling a plugin that checks all links (including external links) for accessibility:
 
 ```bash
 cd {{ brand | lower }}-docs
@@ -127,28 +103,14 @@ tox -e serve
 
 ## Commit messages
 
-When you submit a change, you will need to provide a commit message,
-which is very nearly as important as the change itself. Excellent
-guides on what constitutes a good commit message are available from
-[Tim
-Pope](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-and [Colleen
-Murphy](http://www.gazlene.net/getting-work-done-in-open-source.html).
+When you submit a change, you will need to provide a commit message, which is very nearly as important as the change itself.
+Excellent guides on what constitutes a good commit message are available from [Tim Pope](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [Colleen Murphy](http://www.gazlene.net/getting-work-done-in-open-source.html).
 
-In addition, we have adopted the [Conventional
-Commits](https://www.conventionalcommits.org/en/v1.0.0/) style for
-commit message subjects. Please make sure that your commit message
-starts with one of the following prefixes:
+In addition, we have adopted the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style for commit message subjects.
+Please make sure that your commit message starts with one of the following prefixes:
 
-* `feat:` denotes a content addition, such as adding documentation for
-  some {{brand}} functionality that was not included in
-  the documentation before.
-* `fix:` denotes a content correction, such as fixing a
-  documentation bug.
-* `build:` denotes a change to the build process, such as an
-  improvement to a CI check.
-* `chore:` denotes a minor change that is neither a feature, nor a
-  fix, nor a build improvement, such as when you edit the `.mailmap`
-  file.
-* `docs:` denotes a change to the documention *for* this site, such as
-  an update to the `README.md` file.
+* `feat:` denotes a content addition, such as adding documentation for some {{brand}} functionality that was not included in the documentation before.
+* `fix:` denotes a content correction, such as fixing a documentation bug.
+* `build:` denotes a change to the build process, such as an improvement to a CI check.
+* `chore:` denotes a minor change that is neither a feature, nor a fix, nor a build improvement, such as when you edit the `.mailmap` file.
+* `docs:` denotes a change to the documention *for* this site, such as an update to the `README.md` file.

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -1,6 +1,6 @@
 # Modifying content on this site
 
-You have two options for editing content: directly in your browser using GitHub, or using a Git-based workflow from your local work environment.
+You have two options for editing content: directly in your browser using GitHub, or from your local work environment using a Git-based workflow.
 
 ## Notes on content additions
 
@@ -12,14 +12,14 @@ This facilitates the review of your change, and it also helps you notice long ru
 
 **Headings:** Keep headings concise, under 80 characters.
 
-**Screenshots:** If you are contributing a change that contains screenshots from {{gui}}, they should use a resolution of 1920×1080 pixels (1080p).
-If your screen uses a larger resolution, use [Firefox Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
+**Screenshots:** If you are contributing a change that contains screenshots from {{gui}}, they should have a resolution of 1920×1080 pixels (1080p).
+If your screen has a larger resolution, use [Firefox Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
 or [Chrome/Chromium Device Mode](https://developer.chrome.com/docs/devtools/device-mode/) to configure your browser with 1080p.
 
 Screenshots should be added to a directory named `assets`, located in the same directory as the Markdown file you are adding or editing.
 
 **CLI screen dumps:** If you are contributing a change that contains a screen dump from the `openstack` command-line client, please limit its width to 100 characters.
-You can do this by setting the following environment variable in your terminal, before you start work on your change.
+You can do this by setting the following environment variable in your terminal, before you start working on your change.
 
 ``` bash
 export CLIFF_MAX_TERM_WIDTH=100
@@ -28,7 +28,7 @@ export CLIFF_MAX_TERM_WIDTH=100
 ## Modifying content from your browser
 
 Every page on this site has an Edit button ([:{{config.theme.icon.edit | replace('/','-')}}:]({{page.edit_url}})).
-If you click it, it’ll take you straight to its [corresponding source page]({{page.edit_url}}) in GitHub.
+If you click it, it’ll take you straight to the [corresponding source page]({{page.edit_url}}) in GitHub.
 Then, you can follow [GitHub’s documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository) on how to propose changes to another user’s repository.
 
 ## Modifying content using Git
@@ -92,7 +92,7 @@ tox -e serve
 
 A local copy of the documentation will then run on your local machine and be accessible from <http://localhost:8000> in your browser.
 
-When you are planning to make several changes in rapid succession, you may want to speed up rendering the site after each change.
+When planning to make several changes in rapid succession, you may want to speed up site rendering after each change.
 You may do so by disabling a plugin that checks all links (including external links) for accessibility:
 
 ```bash

--- a/docs/howto/openstack/nova/server-group.md
+++ b/docs/howto/openstack/nova/server-group.md
@@ -39,12 +39,14 @@ openstack server group create \
   <server_group_name>
 ```
 
-With an `anti-affinity` or `soft-anti-affinity` policy, you may also configure how many servers you want to allow on the same physical compute node. To do this, use the option `--rule max_server_per_host=<number>`, where `<number>` is the amount of servers to allow on the same physical compute node.
+With an `anti-affinity` or `soft-anti-affinity` policy, you may also configure how many servers you want to allow on the same physical compute node.
+To do this, use the option `--rule max_server_per_host=<number>`, where `<number>` is the amount of servers to allow on the same physical compute node.
 
 
 ## Creating servers using server groups
 
-To apply a server group policy, you must specify the group when creating a server, as a *scheduling hint.* To do that, use the `--hint` parameter in the following command:
+To apply a server group policy, you must specify the group when creating a server, as a *scheduling hint.*
+To do that, use the `--hint` parameter in the following command:
 
 ```bash
 openstack server create --hint group=<server_group_id> [...] <server_name>
@@ -54,7 +56,9 @@ If you subsequently launch more servers referencing the same server group, {{bra
 
 ## Troubleshooting common issues
 
-If you keep creating servers within a server group with a policy of `anti-affinity`, you will eventually exceed the total amount of physical compute nodes in the region. The command will still succeed, but the server will subsequently fail to be scheduled to a compute node. Instead, it will assume the `ERROR` status with the following `fault` message: _No valid host was found. There are not enough hosts available._
+If you keep creating servers within a server group with a policy of `anti-affinity`, you will eventually exceed the total amount of physical compute nodes in the region.
+The command will still succeed, but the server will subsequently fail to be scheduled to a compute node.
+Instead, it will assume the `ERROR` status with the following `fault` message: _No valid host was found. There are not enough hosts available._
 
 ```console
 $ openstack server show -c fault -c status <server_id>
@@ -68,9 +72,11 @@ $ openstack server show -c fault -c status <server_id>
 +--------+--------------------------------------------------+
 ```
 
-This is normal as {{brand}} cannot schedule the server on a different physical compute node because there already is a server in the server group on every node. The same scheduling error and "fault" message will occur when using a server group with a policy of `affinity` as well, when you create more servers than a physical compute node can host.
+This is normal as {{brand}} cannot schedule the server on a different physical compute node because there already is a server in the server group on every node.
+The same scheduling error and "fault" message will occur when using a server group with a policy of `affinity` as well, when you create more servers than a physical compute node can host.
 
-However when using a soft affinity policy, such as `soft-affinity` or `soft-anti-affinity`, the scheduler is allowed to break the server group's policy if it is unable to uphold it. This means you may want to verify that your servers are on the same or on different physical compute nodes by looking at the _hostId_ value of your servers.
+However when using a soft affinity policy, such as `soft-affinity` or `soft-anti-affinity`, the scheduler is allowed to break the server group's policy if it is unable to uphold it.
+This means you may want to verify that your servers are on the same or on different physical compute nodes by looking at the _hostId_ value of your servers.
 
 ```console
 $ openstack server show -c hostId <server_id>

--- a/docs/howto/openstack/nova/server-group.md
+++ b/docs/howto/openstack/nova/server-group.md
@@ -72,7 +72,7 @@ $ openstack server show -c fault -c status <server_id>
 +--------+--------------------------------------------------+
 ```
 
-This is normal as {{brand}} cannot schedule the server on a different physical compute node because there already is a server in the server group on every node.
+This is normal as {{brand}} cannot schedule the server on a different physical compute node because there is already a server in the server group on every node.
 The same scheduling error and "fault" message will occur when using a server group with a policy of `affinity` as well, when you create more servers than a physical compute node can host.
 
 However when using a soft affinity policy, such as `soft-affinity` or `soft-anti-affinity`, the scheduler is allowed to break the server group's policy if it is unable to uphold it.


### PR DESCRIPTION
Implement a few changes in the Markdown linter:

* Set the maximum line length for non-code-blocks and non-headings to 200 characters.
* Set the maximum line length for headings to 80 characters
* Disable line length checking for code blocks.
    
The rationale behind this is that it enables us to adopt a Markdown style with one sentence per line. This style has the following benefits:
    
* It facilitates code reviews, as it ensures that any change to a sentence is also a change to a line, and vice versa.
* It makes long run-on sentences stand out visually while editing, encouraging the author to break them into shorter and more readable sentences.
* It has no bearing on the flow of the rendered text, since the Markdown renderer will only care about line breaks preceded by two spaces (which become a line break within a paragraph), and about multiple consecutive line breaks (which mark the end of a paragraph).
