### PR TITLE
chore: Explicitly switch gitlint to regex "search" semantics

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits
+regex-style-search=true
 
 # When invoked as just "gitlint" without any other arguments, Gitlint
 # processes the most recent commit message *unless* it's being fed


### PR DESCRIPTION
gitlint previously used regex "match" semantics, where it would evaluate regexes for `ignore-by-title` and `ignore-body-lines` from the beginning of a line. It is switching to "search" semantics, meaning the regex is applied against the whole line.

We are already using `ignore-by-title` and `ignore-body-lines` with anchored regexes (i.e. ones starting with "^"), so the only thing that we still need to set is regex-style-search in the "general" section, in order to silence the warning.

Reference:
https://jorisroovers.github.io/gitlint/configuration/#regex-style-search