### PR TITLE
build: Use tox-gh-actions as intended

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,10 @@ jobs:
       - env:
           DOCS_ENABLE_PDF_EXPORT: 1
         name: Test with tox
-        # Explicitly specifying the testenvs shouldn't really be
-        # necessary here, but for some reason tox invokes no testenvs
-        # at all if invoked as just "tox" from the GitHub Actions
-        # workflow. Until that is fixed, name the testenvs.
-        run: tox -e gitlint,yamllint,bashate,markdownlint,build
+        # Here, invoking just "tox" does not invoke the testenvs as
+        # listed in the tox.ini envlist, but the ones enumerated in
+        # the [gh-actions] section.
+        run: tox
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [tox]
 envlist = yamllint,bashate,markdownlint,build
 
+[gh-actions]
+python =
+    3.8: gitlint, yamllint, bashate, markdownlint, build
+    3.9: gitlint, yamllint, bashate, markdownlint, build
+    3.10: gitlint, yamllint, bashate, markdownlint, build
+
 [testenv]
 envdir = {toxworkdir}/mkdocs
 skip_install = True


### PR DESCRIPTION
Rather than enumerating the tox testenvs with `tox -e` from the `build.yml` workflow, add a `[gh-actions]` section to `tox.ini` and run just `tox` from the workflow.
