### PR TITLE
fix: Change URL textarea to input in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/gap.yml
+++ b/.github/ISSUE_TEMPLATE/gap.yml
@@ -31,7 +31,7 @@ body:
         be added, you can leave this blank.
       label: URL path
     id: url
-    type: textarea
+    type: input
     validations:
       required: false
   - attributes:


### PR DESCRIPTION
It's a bit silly to use a multi-line textarea for a URL, so just
change it to a one-line input box.
