### PR TITLE
fix: Restore edit button

### DIFF
--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -34,8 +34,10 @@ export CLIFF_MAX_TERM_WIDTH=100
 
 ## Modifying content from your browser
 
-Every page on this site has an Edit button 🖍️. If you click it, it’ll
-take you straight to the corresponding source page in GitHub. Then,
+Every page on this site has an Edit button
+([:{{config.theme.icon.edit | replace('/','-')}}:]({{page.edit_url}})).
+If you click it, it’ll
+take you straight to its [corresponding source page]({{page.edit_url}}) in GitHub. Then,
 you can follow [GitHub’s
 documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository)
 on how to propose changes to another user’s repository.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,9 @@ theme:
   favicon: assets/favicon.ico
   features:
     - navigation.indexes
+    - content.action.edit
   icon:
+    edit: material/file-edit-outline
     repo: fontawesome/brands/github
   logo: assets/logo.png
   name: material


### PR DESCRIPTION
Our contribution guide mentions an edit button on every page. However, as of mkdocs-material 9, this edit button is no longer on by default if `repo_url` is set, but it is toggled by a feature flag. It also uses a different icon.

Enable the feature flag, and also update the contribution guide to refer to the updated icon. In doing so, use a bit of Jinja trickery with mkdocs-macros so that the in-text edit icon auto-updates with the one in the configuration (in case we ever change it).

Reference:
https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions