### PR TITLE
fix: Add missing .pages file in OpenStack API reference section

### DIFF
--- a/docs/reference/api/openstack/.pages
+++ b/docs/reference/api/openstack/.pages
@@ -1,0 +1,1 @@
+title: OpenStack API


### PR DESCRIPTION
Fix the navigation so that it says "OpenStack API" in the API reference section, akin to "Cleura Cloud REST API".

(This file was accidentally omitted from #108.)