### PR TITLE
build: Toggle link checker in Git hooks, disable PDF output

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+if [ -z "${DOCS_ENABLE_HTMLPROOFER}" ]; then
+    export DOCS_ENABLE_HTMLPROOFER=false
+fi
 
 exec tox

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
+export DOCS_ENABLE_HTMLPROOFER=true
 exec tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           pip install tox
       - env:
-          DOCS_ENABLE_PDF_EXPORT: 1
+          DOCS_ENABLE_PDF_EXPORT: 0
         name: Test with tox
         run: |
           tox -e gitlint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           pip install tox
       - env:
-          DOCS_ENABLE_PDF_EXPORT: 1
+          DOCS_ENABLE_PDF_EXPORT: 0
         name: Deploy to gh-pages
         run: tox -e deploy-github
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ envdir = {toxworkdir}/bashate
 deps =
   bashate
 commands =
-  bashate {toxinidir}/scripts/from-markdown.sh
+  bashate {toxinidir}/scripts/from-markdown.sh {toxinidir}/.githooks/pre-commit {toxinidir}/.githooks/post-commit {toxinidir}/.githooks/pre-push
 
 [testenv:to-odt]
 envdir = {toxworkdir}/pandoc


### PR DESCRIPTION
PDF exports of the documentation pages are currently broken in two ways:
    
* Content tabs no longer convert to subsections that are shown one after the other, like they used to.
* Fenced code blocks render in a proportional, rather than a monospace font.
    
This renders the PDF output essentially useless, so until we can fix it, just disable it.

Also, set/unset the dead link checker in Git hooks. It's usually tedious and time-consuming to run the dead link checker on every commit, particularly if one is working on a local topic branch that gets frequent commits. So, update the `pre-commit` hook script to disable it (unless it has been specifically enabled in the environment already). However, enable it unconditionally in the `pre-push` hook so that we don't create broken pull requests.

In addition, include the commit hooks in the list of scripts linted by `bashate`.