### PR TITLE
refactor: Add reference URLs for Swift and S3

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -10,9 +10,9 @@ click on the _Create account_ button.
 Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
 At your leisure, please read the [City Network General Terms And
-Conditions](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf)
+Conditions]({{reference_url_s3}}/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf)
 and our
-[Data Processing Agreement](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf).
+[Data Processing Agreement]({{reference_url_s3}}/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf).
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.
 

--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -57,13 +57,13 @@ How exactly you do that depends on your preferred client:
 
     For the `aws` CLI, you cannot define a region's endpoint in the
     profile. As such, you must add the
-    `--endpoint-url=https://s3-<region>.{{brand_domain}}:8080`
+    `--endpoint-url={{reference_url_s3}}`
     option to each `aws s3api` call.
 === "mc"
     Create a new alias, named after your {{brand}} region:
     ```bash
     mc alias set <region> \
-      https://s3-<region>.{{brand_domain}}:8080 \
+      {{reference_url_s3}} \
       <access-key> <secret-key>
     ```
     Once you have configured an alias like this, you are able to

--- a/docs/howto/object-storage/s3/expiry.md
+++ b/docs/howto/object-storage/s3/expiry.md
@@ -33,7 +33,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api put-bucket-lifecycle-configuration \
       --lifecycle-configuration file://lifecycle.json \
       --bucket <bucket-name>
@@ -58,7 +58,7 @@ longer auto-delete after a period.
     configuration from a bucket:
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api delete-bucket-lifecycle \
       --bucket <bucket-name>
     ```

--- a/docs/howto/object-storage/s3/presign.md
+++ b/docs/howto/object-storage/s3/presign.md
@@ -24,7 +24,7 @@ To create a pre-signed URL for an object, you use the following command (replace
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3 presign \
       --expires-in <seconds>
       s3://<bucket-name>/<object-name>
@@ -53,7 +53,7 @@ The command will return the valid pre-signed URL.
 To access an object in a public bucket from a web browser or a generic HTTP/HTTPS client like `curl`, open the URL that the pre-sign command returned:
 
 ```console
-curl -f -O https://s3-<region>.{{brand_domain}}:8080/<bucket-name>/<object-name>?AWSAccessKeyId=<access-key>&Signature=<signature>&Expires=<expiry>
+curl -f -O {{reference_url_s3}}/<bucket-name>/<object-name>?AWSAccessKeyId=<access-key>&Signature=<signature>&Expires=<expiry>
 ```
 
 As long as the query parameters are correct and the signature has not yet expired, this command will succeed.
@@ -65,7 +65,7 @@ If the query parameters are incorrect or the pre-signed URL is past its expiry d
 For example, to retrieve an object named `bar.pdf` in a bucket named `foo` in the {{brand}} Kna1 region via its pre-signed URL, you would run:
 
 ```console
-$ curl -o bar.pdf https://s3-kna1.{{brand_domain}}:8080/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D
+$ curl -o bar.pdf {{reference_url_s3}}/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 62703  100 62703    0     0   186k      0 --:--:-- --:--:-- --:--:--  186k
@@ -83,7 +83,7 @@ To ensure that an object named `bar.pdf` in a bucket named `foo` is always downl
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api put-object \
       --content-disposition 'attachment;filename="bar.pdf"' \
       --bucket <bucket-name> \
@@ -123,7 +123,7 @@ To ensure that an object named `bar.pdf` in a bucket named `foo` is always downl
     To modify the `Content-Disposition` header of an existing object without downloading and re-uploading its contents, you must use `s3api copy-object`, with the object being its own copy source, and the metadata directive set to `replace`:
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api copy-object \
       --copy-source <bucket-name>/<object-name>
       --content-disposition 'attachment;filename="bar.pdf"' \
@@ -146,7 +146,7 @@ To ensure that an object named `bar.pdf` in a bucket named `foo` is always downl
 Once you have set the `Content-Disposition` header on an object and created a pre-signed URL for it, you can test its functionality with the `curl -OJ` command:
 
 ```console
-$ curl -f -OJ 'https://s3-kna1.{{brand_domain}}:8080/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D'
+$ curl -f -OJ '{{reference_url_s3}}/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 58503  100 58503    0     0   178k      0 --:--:-- --:--:-- --:--:--  178k

--- a/docs/howto/object-storage/s3/public-bucket.md
+++ b/docs/howto/object-storage/s3/public-bucket.md
@@ -35,7 +35,7 @@ To apply this policy to a bucket such that read-only access is permitted for eve
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api put-bucket-policy \
       --policy file://policy.json \
       --bucket <bucket-name>
@@ -54,7 +54,7 @@ To apply this policy to a bucket such that read-only access is permitted for eve
 To access an object in a public bucket from a web browser or a generic HTTP/HTTPS client like `curl`, you must construct its URI as follows:
 
 ```plain
-https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>/object-name
+{{reference_url_s3}}/<project-uuid>:<bucket-name>/object-name
 ```
 
 > Your project UUID is listed as the `project_id` field in the output of the `openstack ec2 credentials create` command you used to [create your S3-compatible credentials](credentials.md).
@@ -64,7 +64,7 @@ https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>/object-na
 For example, to retrieve an object named `bar.pdf` in a bucket named `foo` from the project with the UUID `07576783684248f7b2745e34356c6025` in the {{brand}} Kna1 region, you would run:
 
 ```console
-$ curl -O https://s3-kna1.{{brand_domain}}:8080/07576783684248f7b2745e34356c6025:foo/bar.pdf
+$ curl -O {{reference_url_s3}}/07576783684248f7b2745e34356c6025:foo/bar.pdf
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 62703  100 62703    0     0   186k      0 --:--:-- --:--:-- --:--:--  186k
@@ -104,7 +104,7 @@ You can then open a bucket path in your browser, to retrieve an XML document con
 You would construct the URL by the following schema:
 
 ```plain
-https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>
+{{reference_url_s3}}/<project-uuid>:<bucket-name>
 ```
 
 ## Removing a public read policy from a bucket
@@ -114,7 +114,7 @@ If you want to remove a previously-set public read policy from a bucket, and rev
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api delete-bucket-policy \
       --bucket <bucket-name>
     ```

--- a/docs/howto/object-storage/s3/versioning.md
+++ b/docs/howto/object-storage/s3/versioning.md
@@ -11,7 +11,7 @@ To enable versioning in a bucket, use one of the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api put-bucket-versioning \
       --versioning-configuration Status=Enabled \
       --bucket <bucket-name>
@@ -32,7 +32,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api get-bucket-versioning \
       --bucket <bucket-name>
     ```
@@ -58,7 +58,7 @@ that in unversioned buckets:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api put-object \
       --bucket <bucket-name> \
       --key <object-name> \
@@ -84,7 +84,7 @@ available for an object:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api list-object-versions \
       --bucket <bucket-name> \
       --key <object-name>
@@ -107,7 +107,7 @@ the following commands:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api get-object \
       --bucket <bucket-name> \
       --key <object-name> \
@@ -142,7 +142,7 @@ which case object removal does occur.
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api delete-object \
       --bucket <bucket-name> \
       --key <object-name>
@@ -163,7 +163,7 @@ specific object version:
 === "aws"
     ```bash
     aws --profile <region> \
-      --endpoint-url=https://s3-<region>.{{brand_domain}}:8080 \
+      --endpoint-url={{reference_url_s3}} \
       s3api delete-object \
       --version-id <versionid> \
       --bucket <bucket-name> \

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -191,21 +191,21 @@ it by parsing the CLI's debug output:
     ```console
     $ openstack object show --debug public-container testobj.txt 2>&1 \
       | grep -o "https://.*testobj.txt"
-    https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
-    https://swift-fra1.{{brand_domain}}:8080 "HEAD /swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
-    https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    {{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    {{reference_url_swift}} "HEAD /swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    {{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
     ```
 === "Swift CLI"
     ```console
     $ swift stat --debug public-container testobj.txt 2>&1 \
       | grep -o "https://.*testobj.txt"
-    https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    {{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
     ```
 
 Once you have retrieved your public URL, you can fetch the object's
 contents using the client of your choice. This example uses `curl`:
 
 ```console
-$ curl https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+$ curl {{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
 hello world
 ```

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -109,7 +109,7 @@ URL pointing to the object. This will enable you to fetch the object
 using a simple HTTP client, like `curl`:
 
 ```console
-$ curl 'https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
+$ curl '{{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
 hello world
 ```
 
@@ -118,7 +118,7 @@ its lifetime expired, they would be met with an [HTTP
 401](http://http.cat/401) error:
 
 ```console
-$ curl -i 'https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
+$ curl -i '{{reference_url_swift}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
 HTTP/1.1 401 Unauthorized
 content-length: 12
 x-trans-id: tx0000001113c5020d8a1de-00638df0ea-301ddeb-default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ extra:
   company_domain: "cleura.com"
   gui: "Cleura Cloud Management Panel"
   gui_domain: "cleura.cloud"
+  reference_url_s3: "https://s3-kna1.citycloud.com:8080"
+  reference_url_swift: "https://swift-kna1.citycloud.com:8080"
   rest_api: "Cleura Cloud REST API"
   rest_api_domain: "rest.cleura.cloud"
   support: "Service Center"


### PR DESCRIPTION
Rather than repetitively open-coding Swift and S3 URLs, define the
base URL as a macro and use that.

This also gives us the ability to change things in one swoop if the
endpoints were ever to change.
