### PR TITLE
feat: Explain that Swift and S3 public URLs are interchangeable

### DIFF
--- a/docs/howto/object-storage/s3/public-bucket.md
+++ b/docs/howto/object-storage/s3/public-bucket.md
@@ -70,6 +70,15 @@ $ curl -O https://s3-kna1.{{brand_domain}}:8080/07576783684248f7b2745e34356c6025
 100 62703  100 62703    0     0   186k      0 --:--:-- --:--:-- --:--:--  186k
 ```
 
+### Public bucket accessibility via the Swift API
+
+Once you make a bucket public via the S3 API, its objects also become accessible via [the corresponding Swift API path](../swift/public-container.md).
+
+Thus, the following URL paths allow you to retrieve the same public object:
+
+* `https://s3-kna1.{{brand_domain}}:8080/07576783684248f7b2745e34356c6025:foo/bar.pdf`
+* `https://swift-kna1.{{brand_domain}}:8080/swift/v1/AUTH_07576783684248f7b2745e34356c6025/foo/bar.pdf`
+
 ## Enabling bucket listing
 
 The `policy.json` file above allows anyone to retrieve known objects by name, but does not enable listing the bucket's contents.

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -1,3 +1,6 @@
+---
+description: You can use the Swift API to configure a container with public read access, so that anyone can download its objects with a web browser.
+---
 # Working with a public Swift container
 
 ## Prerequisites
@@ -209,3 +212,12 @@ contents using the client of your choice. This example uses `curl`:
 $ curl https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
 hello world
 ```
+
+### Public bucket accessibility via the S3 API
+
+Once you make a container public via the Swift API, its objects also become accessible via [the corresponding S3 API path](../s3/public-bucket.md).
+
+Thus, the following URL paths allow you to retrieve the same public object:
+
+* `https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt`
+* `https://s3-fra1.{{brand_domain}}:8080/30a7768a0ffc40359d6110f21a6e7d88:public-container/testobj.txt`


### PR DESCRIPTION
It perhaps isn't immediately obvious that our object storage buckets
and objects are one and the same when accessed via alternative paths
to the S3 and Swift APIs, and that as a result once an object has been
made public via one API, it's also public via the other.

Thus, add cross-references between the corresponding S3 and Swift
how-to guides explaining this.
