### PR TITLE
fix: Stop mentioning Dedicated CPU

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -14,7 +14,6 @@
 
 |                                               | Sto1HS                | Sto2HS                |
 | -------------                                 | ----------------      | --------------------- |
-| [Dedicated CPU](../../flavors/#compute-tiers) | :material-close:      | :material-close:      |
 | [Virtual GPU](../../flavors/#compute-tiers)   | :material-timer-sand: | :material-timer-sand: |
 
 

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -12,7 +12,6 @@
 ## Virtualization
 |                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Dedicated CPU](../../flavors/#compute-tiers) | :material-close: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
 | [Virtual GPU](../../flavors/#compute-tiers)   | :material-close: | :material-close:      | :material-close: | :material-close: | :material-close: |
 
 

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -45,10 +45,6 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
   latency for I/O intensive applications, but instances launched with
   these flavors must configure their own high availability and data
   replication.
-* `c`: Dedicated CPU. Instances launched with matching flavors are
-  guaranteed to run on compute hardware where CPU cores are allocated
-  to instances on a one-to-one basis and one virtual core maps
-  directly to a physical CPU core.
 * `g`: Virtual GPU. Instances launched with matching flavors have
   access to a
   [GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit).


### PR DESCRIPTION
The documentation was previously overly optimistic about the "coming soon" state of this feature. Remove it from the feature matrix and flavor reference, so as not to confuse users.
