### PR TITLE
refactor: Replace direct links to legal documents with macros

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -9,10 +9,9 @@ click on the _Create account_ button.
 
 Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
-At your leisure, please read the [City Network General Terms And
-Conditions](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf)
+At your leisure, please read the [{{ legal_docs.tc.name}}]({{ legal_docs.tc.url}})
 and our
-[Data Processing Agreement](https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf).
+[{{ legal_docs.cdpa.name}}]({{ legal_docs.cdpa.url}})
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,15 @@ extra:
   company_domain: "cleura.com"
   gui: "Cleura Cloud Management Panel"
   gui_domain: "cleura.cloud"
+  legal_docs:
+    cdpa:
+      name: "Data Processing Agreement"
+      # yamllint disable-line rule:line-length
+      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf"
+    tc:
+      name: "General Terms and Conditions"
+      # yamllint disable-line rule:line-length
+      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf"
   rest_api: "Cleura Cloud REST API"
   rest_api_domain: "rest.cleura.cloud"
   support: "Service Center"


### PR DESCRIPTION
Since it might come in handy using references to legal documents
in multiple spots in the documentation, define macros for them.
