### PR TITLE
refactor: Add macro placeholder for "Gardener"

### DIFF
--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -1,12 +1,12 @@
-# Creating Kubernetes clusters with Gardener
+# Creating Kubernetes clusters
 
 If you want to create a Kubernetes cluster, you can do it via
-{{gui}} using Gardener. This how-to shows you how to do
+{{gui}} using {{k8s_management_service}}. This how-to shows you how to do
 that, and how to deploy a sample application on such a cluster.
 
 ## Prerequisites
 
-* To access Gardener functionality from {{gui}}, you need to enroll in
+* To access {{k8s_management_service}} functionality from {{gui}}, you need to enroll in
   our closed beta. For access to the closed beta, contact our
   [{{support}}](https://{{support_domain}}/servicedesk).
 * To access the Kubernetes cluster from your computer, you will need
@@ -18,15 +18,15 @@ that, and how to deploy a sample application on such a cluster.
 To get started, navigate to <https://{{gui_domain}}>, and
 in the side panel choose Kubernetes → [Managed
 Kubernetes](https://{{gui_domain}}/containers/gardener).
-You will see a Gardener page, in which you can create and manage your
+You will see a {{k8s_management_service}} page, in which you can create and manage your
 clusters. Click `Create Kubernetes cluster`.
 
-![Gardener page in {{gui}}](assets/gardener_page.png)
+![{{k8s_management_service}} page in {{gui}}](assets/gardener_page.png)
 
-> In Gardener's terminology, a Kubernetes cluster is referred as a
+> In {{k8s_management_service}}'s terminology, a Kubernetes cluster is referred as a
 > **Shoot cluster**. You can see the name "Shoot" in various places
 > throughout the panel's UI, so it is good to know what it means. To
-> learn more, check out [Gardener
+> learn more, check out [{{k8s_management_service}}
 > architecture](https://gardener.cloud/docs/gardener/concepts/architecture/).
 
 In the opened form, fill in the name of the cluster and a region to
@@ -38,7 +38,7 @@ bottom.
 > In the form you can see a section about worker groups. This name
 > refers to Kubernetes worker nodes.
 
-In the list of clusters, you will see your new Gardener shoot
+In the list of clusters, you will see your new {{k8s_management_service}} shoot
 bootstrapping. The icon on the left marks the progress. Creating the
 cluster can take up to several minutes.
 
@@ -50,7 +50,7 @@ When the Shoot cluster is up and running, you need to get a kubeconfig
 file to be able to access it. To do that, click on the cluster to
 expand its properties, and open `Kubeconfig`.
 
-![Kubeconfig in Gardener Shoot view](assets/shoot_kubeconfig.png)
+![Kubeconfig in {{k8s_management_service}} Shoot view](assets/shoot_kubeconfig.png)
 
 You should now see the file's contents. You have the option to `Copy
 Config` or `Rotate Kubeconfig` if your credentials got compromised.
@@ -99,7 +99,7 @@ Check your available nodes by running:
 kubectl get nodes
 ```
 
-You should see Gardener's worker node that is available:
+You should see {{k8s_management_service}}'s worker node that is available:
 
 ```console
 NAME                                                STATUS   ROLES    AGE    VERSION

--- a/docs/howto/kubernetes/gardener/index.md
+++ b/docs/howto/kubernetes/gardener/index.md
@@ -1,18 +1,18 @@
-# Gardener
+# {{k8s_management_service}}
 
-Gardener is a Kubernetes-native system that provides automated
+{{k8s_management_service}} is a Kubernetes-native system that provides automated
 management and operation of Kubernetes clusters as a service.  It
 allows you to create clusters and automatically handle their lifecycle
 operations, including configurable maintenance windows, hibernation
 schedules, and automatic updates to Kubernetes control plane and
 worker nodes.
 
-You can read more about Gardener and its capabilities on its
+You can read more about {{k8s_management_service}} and its capabilities on its
 [documentation website](https://gardener.cloud/docs/gardener/).
 
-> Gardener in {{brand}} is currently in a **closed beta** stage.
+> {{k8s_management_service}} in {{brand}} is currently in a **closed beta** stage.
 > For access to the closed beta, contact our
 > [{{support}}](https://{{support_domain}}/servicedesk).
 
-To learn how to use Gardener in the {{gui}}, refer to [Creating
-Kubernetes clusters with Gardener](create-shoot-cluster.md).
+To learn how to use {{k8s_management_service}} in the {{gui}}, refer to [Creating
+Kubernetes clusters with {{k8s_management_service}}](create-shoot-cluster.md).

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -4,6 +4,6 @@ In {{brand}}, you have several options for deploying and managing
 Kubernetes clusters.
 
 [{{gui}}](https://{{gui_domain}}) includes management interfaces for
-[Gardener](gardener/) and [OpenStack Magnum](magnum/). To manage
+[{{k8s_management_service}}](gardener/) and [OpenStack Magnum](magnum/). To manage
 Magnum clusters, you can also use the [OpenStack command-line
 interface](../getting-started/enable-openstack-cli/).

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -48,7 +48,7 @@
 
 
 ## Kubernetes management
-|                   | Kna1                  | Sto2                  | Fra1                  | Dx1              | Tky1             |
-| ----------------- | ----------------      | ----------------      | ----------------      | ---------------- | ---------------- |
-| OpenStack Magnum  | :material-check:      | :material-check:      | :material-check:      | :material-check: | :material-check: |
-| Gardener          | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: |
+|                            | Kna1                  | Sto2                  | Fra1                  | Dx1              | Tky1             |
+| -----------------          | ----------------      | ----------------      | ----------------      | ---------------- | ---------------- |
+| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      | :material-check: | :material-check: |
+| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ extra:
   company_domain: "cleura.com"
   gui: "Cleura Cloud Management Panel"
   gui_domain: "cleura.cloud"
+  k8s_management_service: Gardener
   legal_docs:
     cc_by_sa:
       name: "Creative Commons Attribution-ShareAlike 4.0 International"


### PR DESCRIPTION
Since the service will launch with some name that will most probably not be "Gardener", replace the hard-coded mentions thereof with a macro reference.
