### PR TITLE
build: Disable link checking on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           pip install tox
       - env:
+          DOCS_ENABLE_HTMLPROOFER: false
           DOCS_ENABLE_PDF_EXPORT: 0
         name: Deploy to gh-pages
         run: tox -e deploy-github


### PR DESCRIPTION
The link checker (which we can enable and disable by toggling the `DOCS_ENABLE_HTMLPROOFER` variable) is not always reliable: for example, if one of the links we check uses some form of bandwidth throttling or DDOS protection, it might temporarily refuse access from the GitHub CI hosts.

In the build pipeline that isn't a problem: we can just re-run the failed job.

However, once we have merged a change and we've determined (during the pre-merge checks) that all links are alive, it does not make much sense to re-check on deploy, and possibly hold up the deployment because of a temporarily unavailable link.

Thus, just disable the link checker in the deploy stage.
