### PR TITLE
build: Remove PDF export plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install weasyprint
       - name: Install Python dependencies
         run: |
           pip install tox
-      - env:
-          DOCS_ENABLE_PDF_EXPORT: 0
-        name: Test with tox
+      - name: Test with tox
         run: |
           tox -e gitlint
           tox

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ jobs:
           pip install tox
       - env:
           DOCS_ENABLE_HTMLPROOFER: false
-          DOCS_ENABLE_PDF_EXPORT: 0
         name: Deploy to gh-pages
         run: tox -e deploy-github
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,6 @@ plugins:
       # yamllint disable-line rule:truthy
       on_error_fail: !ENV [DOCS_FAIL_ON_MACRO_ERROR, True]
       on_undefined: strict
-  - pdf-export:
-      enabled_if_env: DOCS_ENABLE_PDF_EXPORT
   - search
   - social:
       # yamllint disable-line rule:truthy

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
   mkdocs-htmlproofer-plugin
   mkdocs-macros-plugin
   mkdocs-material
-  mkdocs-pdf-export-plugin
   pillow
   cairosvg
 commands =


### PR DESCRIPTION
We've had PDF export disabled in our builds for a while now (since #111), and nobody appears to be missing it.
    
Thus, remove the PDF export plugin, which also means we no longer need to install the `weasyprint` package in the build environment (which, in turn, speeds up the CI build checks).

