### PR TITLE
Update Ceph service versions in Fra1, Dx1 and Tk1

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -19,6 +19,6 @@
 
 |                               | Kna1      | Sto2             | Fra1    | Dx1     | Tky1             |
 | --------------------------    | --------- | ------           | -----   | -----   | ------           |
-| Block storage (for OpenStack) | Pacific   | Pacific          | Pacific | Pacific | Pacific          |
-| Object storage (Swift API)    | Pacific   | :material-close: | Pacific | Pacific | :material-close: |
-| Object storage (S3 API)       | Pacific   | :material-close: | Pacific | Pacific | :material-close: |
+| Block storage (for OpenStack) | Pacific   | Pacific          | Quincy  | Quincy  | Quincy           |
+| Object storage (Swift API)    | Pacific   | :material-close: | Quincy  | Quincy  | :material-close: |
+| Object storage (S3 API)       | Pacific   | :material-close: | Quincy  | Quincy  | :material-close: |


### PR DESCRIPTION
After upgrades performed in several regions new versions of Ceph were introduced.