### PR TITLE
fix: Mention Ceph Quincy in version overview

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -32,4 +32,5 @@ releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
 {{brand}} currently runs Ceph
-[Pacific](https://docs.ceph.com/en/latest/releases/pacific/).
+[Pacific](https://docs.ceph.com/en/latest/releases/pacific/) and
+[Quincy](https://docs.ceph.com/en/latest/releases/quincy/).


### PR DESCRIPTION
We forgot to mention Ceph Quincy in one other place, when we merged 33536d76631aa0225142c7ed5261a483d8230d85. Fix that reference.