### PR TITLE
fix: Correct link to SSE-C from Compliant Cloud features reference

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -28,11 +28,11 @@
 
 ## Object storage
 
-|                                                         | Sto1HS           | Sto2HS           |
-| ------------------------------                          | ---------------- | ---------------- |
-| S3 API                                                  | :material-check: | :material-check: |
-| S3 [SSE-C](S3 [SSE-C](/howto/object-storage/s3/sse-c/)) | :material-check: | :material-check: |
-| Swift API                                               | :material-check: | :material-check: |
+|                                             | Sto1HS           | Sto2HS           |
+| ------------------------------              | ---------------- | ---------------- |
+| S3 API                                      | :material-check: | :material-check: |
+| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-check: |
+| Swift API                                   | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)


### PR DESCRIPTION
Fix the broken link to the S3 SSE-C howto from the Compliant Cloud feature reference page.