### PR TITLE
feat: Rewrite S3 SSE-C examples, add support for additional CLIs

### DIFF
--- a/docs/howto/object-storage/s3/.pages
+++ b/docs/howto/object-storage/s3/.pages
@@ -6,4 +6,4 @@ nav:
   - presign.md
   - expiry.md
   - versioning.md
-  - sse-c.md
+  - "Object encryption (SSE-C)": sse-c.md

--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -99,6 +99,19 @@ How exactly you do that depends on your preferred client:
 
     On subsequent invocations of the `s3cmd` CLI, always add the
     `-c ~/.s3cfg-<region>` option.
+=== "rclone"
+    Create or edit the configuration file named `~/.rclone.conf`, and insert a section named after your {{brand}} region.
+    That section should contain the following content:
+    ```ini
+    [<region>]
+    type = s3
+    provider = Ceph
+    env_auth = false
+    access_key_id = <access key id>
+    secret_access_key = <secret key>
+    endpoint = <region>.{{brand_domain}}:8080
+    acl = private
+    ```
 
 ## Deleting credentials
 

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -1,14 +1,12 @@
-# Client-side encryption (SSE-C)
+---
+description: SSE-C provides server-side S3 object encryption with pre-shared secrets.
+---
+# Server-side object encryption with customer-provided keys (SSE-C)
 
-You can use objects encryption via S3 API, according to the[Amazon
-SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
-specification. This means that you need to provide an encryption/decryption key
-with each request to the object.
+You can use object encryption via the S3 API, according to the [Amazon SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) specification.
+This means that you need to provide an encryption/decryption key with each request to the object.
 
-You can store the encryption key in Barbican, and provide it to the S3
-client at runtime. Below we will provide more detailed explanation
-regarding how to use this in your workloads.
-
+You can store the encryption key in [Barbican](../../openstack/barbican/index.md), and provide it to the S3 client at runtime.
 
 ## Requirements
 
@@ -16,76 +14,138 @@ This guide assumes familiarity with the following tools:
 
 * `python-openstackclient` (with the `python-barbicanclient` plugin),
 * `pwgen`,
-* `rclone` version 1.54 or later.
+* `rclone` version 1.54 or later, or the `aws` command-line interface (`awscli`) version 1.
+
+## Prerequisites
+
+In order to manipulate S3 objects using SSE-C, you must
+
+* configure the [OpenStack CLI](../../getting-started/enable-openstack-cli.md),
+* obtain [S3-compatible credentials](credentials.md).
 
 
-## Create encryption details
+## Creating encryption details
 
-According to SSE-C specification, in order to use server-side
-encryption, any S3 client needs to provide three pieces of
-information, which it includes in the request headers for each S3
-request being made:
+According to the SSE-C specification, in order to use server-side encryption, any S3 client needs to provide three pieces of information, which it includes in the request headers for each S3 request being made:
 
 * Encryption algorithm: the only valid option here is AES256.
-* Encryption key: a generated random key that we will store in
-  Barbican. It should be valid AES key, which means that key length
-  must be 32 bytes.
-* Encryption key checksum: MD5 checksum of the encryption key. It's
-  used for integrity checks.
+* Encryption key: a valid AES key, which means that key length must be 32 bytes.
+* Encryption key checksum: the MD5 checksum of the encryption key.
+  Your S3 API client uses this for integrity checks, and normally adds it automatically to your request.
 
-In order to generate encryption key and store it in Barbican, proceed
-as follows.
+In order to generate encryption key and store it in Barbican, proceed as follows.
 
-1. Generate secret:
+1. Generate an encryption secret:
+   ```bash
+   secret_raw=$(pwgen 32 1)
+   ```
 
-        secret_raw=$(pwgen 32 1)
+2. Store the secret in Barbican:
+   ```bash
+   barbican_secret_url=$(openstack secret store --name objectSecret --algorithm aes --bit-length 256 --payload ${secret_raw} -f value -c 'Secret href')
+   ```
 
-2. Store secret in Barbican:
+3. Then, whenever you need to upload or download encrypted objects, retrieve the secret from Barbican:
+   ```bash
+   secret=$(openstack secret get ${barbican_secret_url} -p -c Payload -f value)
+   ```
 
-        barbican_secret_url=$(openstack secret store --name objectSecret --algorithm aes --bit-length 256 --payload ${secret_raw} -f value -c 'Secret href')
+## Managing encrypted objects in S3
 
-3. Retrieve secret from Barbican:
+Once you have your encryption secret available, you can create or access enabled objects.
 
-        secret=$(openstack secret get ${barbican_secret_url} -p -c Payload -f value)
+=== "aws"
+    1. Create an S3 bucket:
+       ```bash
+       aws --profile <region> \
+         s3 mb s3://{{brand|lower|replace(' ','')}}-encrypted
+       ```
+    2. Sync a directory to the S3 bucket, encrypting the files it
+       contains on upload:
+       ```bash
+       aws --profile <region> \
+         s3 sync \
+         ~/media/ s3://{{brand|lower|replace(' ','')}}-encrypted \
+         --sse-c AES256 \
+         --sse-c-key ${secret}
+       ```
+    3. Retrieve a file from S3 and decrypt it:
+       ```bash
+       aws --profile <region> \
+         s3 cp \
+         s3://{{brand|lower|replace(' ','')}}-encrypted/file.png . \
+         --sse-c AES256 \
+         --sse-c-key ${secret}
+       ```
 
+    Note that attempting to download an encrypted file *without* providing an encryption key results in an immediate HTTP 400 ("Bad Request") error:
+    ```console
+    $ aws --profile <region> \
+      s3 cp \
+      s3://{{brand|lower|replace(' ','')}}-encrypted/file.png .
+    fatal error: An error occurred (400) when calling the HeadObject operation: Bad Request
+    ```
+=== "mc"
+    1. Create an S3 bucket:
+       ```bash
+       mc mb <region>/{{brand|lower|replace(' ','')}}-encrypted
+       ```
+    2. Sync a directory to the S3 bucket, encrypting the files it contains on upload.
+       Note that you must specify the encryption secret as the argument to the `--encrypt-key` option, using a syntax of `<minio-alias>/<bucket-name>=<encryption-key>`:
+       ```bash
+       mc cp \
+         --recursive \
+         --encrypt-key "<region>/{{brand|lower|replace(' ','')}}-encrypted=${secret}"
+         ~/media/ <region>/{{brand|lower|replace(' ','')}}-encrypted
+       ```
+    3. Retrieve a file from S3 and decrypt it.
+       Again, specify the encryption key in the same manner:
+       ```bash
+       mc cp \
+         --encrypt-key "<region>/{{brand|lower|replace(' ','')}}-encrypted=${secret}"
+         <region>/{{brand|lower|replace(' ','')}}-encrypted/file.png .
+       ```
 
-## Managing encrypted objects in S3 (with `rclone`)
+    Note that attempting to download an encrypted file *without* providing an encryption key results in an immediate HTTP 400 ("Bad Request") error:
+    ```console
+    $ mc cp \
+      <region>/{{brand|lower|replace(' ','')}}-encrypted/file.png .
+    mc: <ERROR> Unable to validate source `<region>/{{brand|lower|replace(' ','')}}-encrypted/file.png`.
+    ```
 
-SSE-C encryption has been implemented/fixed with version 1.54. Prior
-rclone versions won't work here.
+=== "s3cmd"
+    You cannot use `s3cmd` in combination with SSE-C.
 
-1. Download and install the latest rclone for your distribution:
-   <https://rclone.org/downloads/>
-2. Create or retrieve your [access key ID and secret
-   key](credentials.md).
-3. Create a configuration file named `~/.rclone.conf`, with the
-   following content:
+    > `s3cmd` does contain a *client* side encryption facility, using GnuPG for encryption.
+    > It also supports SSE-KMS, which is a different SSE flavor that is currently not available in {{brand}}.
+=== "rclone"
+    SSE-C encryption has been implemented/fixed with version 1.54. Earlier `rclone` versions won't work.
 
-        [{{brand|lower|replace(' ','')}}]
-        type = s3
-        provider = Ceph
-        env_auth = false
-        access_key_id = <access key id>
-        secret_access_key = <secret key>
-        endpoint = <region>.{{brand_domain}}:8080
-        acl = private
-        sse_customer_algorithm = AES256
+    1. To start with, modify the section in your configuration file that is named after your target region, adding the `sse_customer_algorithm` option:
+       ```ini
+       [<region>]
+       type = s3
+       provider = Ceph
+       env_auth = false
+       access_key_id = <access key id>
+       secret_access_key = <secret key>
+       endpoint = <region>.{{brand_domain}}:8080
+       acl = private
+       sse_customer_algorithm = AES256
+       ```
+    2. Create an S3 bucket:
+       ```bash
+       rclone mkdir {{brand|lower|replace(' ','')}}-encrypted
+       ```
+    3. Sync a directory to the S3 bucket, encrypting the files it contains on upload:
+       ```bash
+       rclone sync ~/media/ {{brand|lower|replace(' ','')}}-encrypted \
+         --s3-sse-customer-key=${secret}
+       ```
+    4. Retrieve a file from S3 and decrypt it:
+       ```bash
+       rclone copy {{brand|lower|replace(' ','')}}-encrypted/file.png \
+         --s3-sse-customer-key=${secret}
+       ```
 
-4. Create an S3 bucket:
-
-        rclone mkdir {{brand|lower|replace(' ','')}}:encrypted
-
-5. Sync a directory to the S3 bucket, encrypting the files it
-   contains on upload:
-
-        rclone sync ~/media/ {{brand|lower|replace(' ','')}}:encrypted \
-          --s3-sse-customer-key=${secret}
-
-6. Retrieve a file from S3 and decrypt it:
-
-        rclone copy {{brand|lower|replace(' ','')}}:encrypted/file.png \
-          --s3-sse-customer-key=${secret}
-
-
-For more examples on how to use rclone, please use its reference
-documentation: <https://rclone.org/docs/#subcommands>
+    For more examples on how to use rclone, please use its [reference documentation](https://rclone.org/docs/#subcommands).


### PR DESCRIPTION
* Besides `rclone`, also explain SSE-C for the `aws` and `mc` CLIs (and mention that you can't use SSE-C with `s3cmd`).
* Move information about setting up `rclone` into a content tab in the "Working with S3-compatible credentials" how-to guide.
* Change the page title (the "C" in "SSE-C" stands for "customer", not for "client").
* Fix the invalid bucket name in the example (bucket names cannot contain `:`).
* Shorten the page's navigation entry.
* Add a description to the YAML front matter.