### PR TITLE
fix: Mention "openstack server ssh"

### DIFF
--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -301,6 +301,12 @@ file first](/howto/getting-started/enable-openstack-cli).
     ssh ubuntu@198.51.100.12
     ```
 
+    Alternatively, you may also use the following command, which is more flexible though slightly longer:
+
+    ```bash
+    openstack server ssh --public zug -- -l ubuntu
+    ```
+
 ## Viewing information about the newly created server
 === "{{gui}}"
     From the {{gui}} you may, at any


### PR DESCRIPTION
In our "new server" how-to guide, we previously omitted the ability to connect to the new instance via SSH, using the `openstack server ssh` command.

Fix that omission.