### PR TITLE
chore: Shorten navigation entries for background pages

### DIFF
--- a/docs/background/.pages
+++ b/docs/background/.pages
@@ -1,6 +1,6 @@
 title: "Background"
 nav:
   - index.md
-  - gui-vs-api.md
+  - "CCMP vs. OpenStack API": gui-vs-api.md
+  - "Deleting projects": project-deletion.md
   - "Object storage": object-storage.md
-  - project-deletion.md


### PR DESCRIPTION
Rather than using the full title of the background explanation pages in the navigation menu, shorten them via the `.pages` file.