### PR TITLE
fix: Update Ceph service version for Sto2 and Tky1

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -26,9 +26,9 @@
 ## Object storage
 |                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | ------------------------------              | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| S3 API                                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
-| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
-| Swift API                                   | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
+| S3 API                                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| Swift API                                   | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -19,6 +19,6 @@
 
 |                               | Kna1      | Sto2             | Fra1    | Dx1     | Tky1             |
 | --------------------------    | --------- | ------           | -----   | -----   | ------           |
-| Block storage (for OpenStack) | Pacific   | Pacific          | Quincy  | Quincy  | Quincy           |
-| Object storage (Swift API)    | Pacific   | :material-close: | Quincy  | Quincy  | :material-close: |
-| Object storage (S3 API)       | Pacific   | :material-close: | Quincy  | Quincy  | :material-close: |
+| Block storage (for OpenStack) | Pacific   | Quincy           | Quincy  | Quincy  | Quincy           |
+| Object storage (Swift API)    | Pacific   | :material-close: | Quincy  | Quincy  | Quincy           |
+| Object storage (S3 API)       | Pacific   | :material-close: | Quincy  | Quincy  | Quincy           |


### PR DESCRIPTION
We now run Ceph Quincy in Sto2 and Swift/S3 are available in Tky1.