### PR TITLE
feat: Document S3 object lock availability on a per-region basis

### DIFF
--- a/docs/howto/object-storage/s3/object-lock.md
+++ b/docs/howto/object-storage/s3/object-lock.md
@@ -1,15 +1,20 @@
 ---
-description: Object lock enables you to keep S3 objects from being deleted or overwritten.
+description: Object lock, available in select regions, enables you to keep S3 objects from being deleted or overwritten.
 ---
 # Object lock
+
 
 Object lock is a feature in S3 that enables you to lock your objects
 to prevent them from being deleted or overwritten. This feature can be
 helpful when you want to maintain data integrity, comply with
 regulations, or retain data for a specific period.
 
-> Are you looking to set the expiration/retention time for your
-> objects? Then you should check our [Object expiry](expiry.md) guide.
+Note that this feature is distinct from *object expiry*, which is covered in a [separate guide](expiry.md).
+
+## Object lock availability
+
+Object lock is only available in select {{brand}} regions.
+Please consult the [feature reference](../../../../reference/features/) for details.
 
 ## Object lock modes
 

--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -28,11 +28,12 @@
 
 ## Object storage
 
-|                                             | Sto1HS           | Sto2HS           |
-| ------------------------------              | ---------------- | ---------------- |
-| S3 API                                      | :material-check: | :material-check: |
-| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-check: |
-| Swift API                                   | :material-check: | :material-check: |
+|                                                         | Sto1HS           | Sto2HS           |
+| ------------------------------                          | ---------------- | ---------------- |
+| S3 API                                                  | :material-check: | :material-check: |
+| S3 [SSE-C](/howto/object-storage/s3/sse-c/)             | :material-check: | :material-check: |
+| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-close: | :material-close: |
+| Swift API                                               | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -24,11 +24,12 @@
 
 
 ## Object storage
-|                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| ------------------------------              | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| S3 API                                      | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| S3 [SSE-C](/howto/object-storage/s3/sse-c/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| Swift API                                   | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+|                                                         | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
+| ------------------------------                          | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| S3 API                                                  | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| S3 [SSE-C](/howto/object-storage/s3/sse-c/)             | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| Swift API                                               | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)


### PR DESCRIPTION
Explain that S3 object lock is not available in all regions, and add it to the feature support matrix.