### PR TITLE
fix: Re-instate Gardener hibernation how-to navigation entry

### DIFF
--- a/docs/howto/kubernetes/gardener/.pages
+++ b/docs/howto/kubernetes/gardener/.pages
@@ -3,4 +3,5 @@ nav:
   - index.md
   - create-shoot-cluster.md
   - kubectl.md
+  - hibernate-shoot-cluster.md
 


### PR DESCRIPTION
The `.pages` file introduced in c3799e590f10323d50150819d8c76780f45c4187 accidentally hid the just-introduced Gardener hibernation howto.

Fix it to return the howto to the navigation menu.