### PR TITLE
fix: Update information on object lock availability

### DIFF
--- a/docs/howto/object-storage/s3/object-lock.md
+++ b/docs/howto/object-storage/s3/object-lock.md
@@ -1,5 +1,5 @@
 ---
-description: Object lock, available in select regions, enables you to keep S3 objects from being deleted or overwritten.
+description: Object lock enables you to keep S3 objects from being deleted or overwritten.
 ---
 # Object lock
 
@@ -10,11 +10,6 @@ helpful when you want to maintain data integrity, comply with
 regulations, or retain data for a specific period.
 
 Note that this feature is distinct from *object expiry*, which is covered in a [separate guide](expiry.md).
-
-## Object lock availability
-
-Object lock is only available in select {{brand}} regions.
-Please consult the [feature reference](../../../../reference/features/) for details.
 
 ## Object lock modes
 

--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -32,7 +32,7 @@
 | ------------------------------                          | ---------------- | ---------------- |
 | S3 API                                                  | :material-check: | :material-check: |
 | S3 [SSE-C](/howto/object-storage/s3/sse-c/)             | :material-check: | :material-check: |
-| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-close: | :material-close: |
+| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-check: | :material-check: |
 | Swift API                                               | :material-check: | :material-check: |
 
 


### PR DESCRIPTION
Update the feature reference, reflecting the fact that object lock is now available in Compliant Cloud regions.

Since this means that object lock is now available in all regions where we have object storage at all, it is also safe to remove the "available in select regions" caveat from the object lock how-to guide.