### PR TITLE
fix: Use macro instead of "Gardener"

### DIFF
--- a/docs/background/kubernetes/gardener/hibernation.md
+++ b/docs/background/kubernetes/gardener/hibernation.md
@@ -4,7 +4,7 @@ description: How hibernation of Gardener-based Kubernetes clusters works
 
 # Hibernation
 
-In {{brand}}, you have the option of putting a Gardener-based Kubernetes
+In {{brand}}, you have the option of putting a {{k8s_management_service}}-based Kubernetes
 [cluster in
 hibernation](../../../howto/kubernetes/gardener/hibernate-shoot-cluster.md).
 This is something you might want to do whenever you know you won't be
@@ -18,13 +18,13 @@ we have to explain how hibernation works.
 
 ## How hibernation works
 
-Learning about the logic of hibernation in Gardener, we immediately get
+Learning about the logic of hibernation in {{k8s_management_service}}, we immediately get
 a fresh perspective on the whole concept. When we hear about
 hibernation, we usually think of resources that are merely stopped or
 frozen, and their volatile information made persistent. This is **not**
-how Gardener hibernation works --- and here's why.
+how {{k8s_management_service}} hibernation works --- and here's why.
 
-When you put a Gardener cluster in hibernation, what really happens is
+When you put a {{k8s_management_service}} cluster in hibernation, what really happens is
 that all worker nodes are **removed.** So, as long as the cluster is in
 hibernation, you will not be paying for CPU, RAM, and boot volume
 storage utilization incurred by the worker nodes. But there might still
@@ -44,7 +44,7 @@ have a
 (or *PVC*). Floating IPs, on the other hand, are instantiated to
 be assigned to Kubernetes [Services](https://kubernetes.io/docs/concepts/services-networking/) that need a public IP. Those services
 have an external load balancer (i.e., a service of `Type:
-LoadBalancer`). When you hibernate a Gardener cluster, objects of any of
+LoadBalancer`). When you hibernate a {{k8s_management_service}} cluster, objects of any of
 those types are retained.
 
 ## Waking up clusters
@@ -57,7 +57,7 @@ nodes reappear. Since all information about cluster resources
 etc.) are still available on the control plane, these cluster
 resources *also* automatically reappear on the recreated worker nodes.
 
-However, to run your Pods, Gardener will have to re-fetch any
+However, to run your Pods, {{k8s_management_service}} will have to re-fetch any
 images they previously ran on. That is because the image cache of
 newly created worker nodes starts empty. Consequently, please keep in
 mind that a cluster whose resources were perfectly humming along

--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -47,7 +47,7 @@ Creating the cluster can take several minutes.
 
 ### A note on quotas
 
-Your Gardener worker nodes are subject to [quotas](../../../reference/quotas/openstack.md) applicable to your {{brand}} project.
+Your {{k8s_management_service}} worker nodes are subject to [quotas](../../../reference/quotas/openstack.md) applicable to your {{brand}} project.
 You should make sure that considering your selection of worker node [*flavor*](../../../reference/flavors/index.md) (which determines the number of virtual cores and virtual RAM allocated to each node), the _volume size_, and the _Autoscaler Max_ value, you are not at risk of violating any quota.
 
 For example, if your project is configured with the [default quotas](../../../reference/quotas/openstack.md), and you select the `b.4c16gb` flavor for your worker nodes, your cluster would be able to run with a maximum of 3 worker nodes (since their total memory footprint would be 3×16=48 GiB, just short of the default 50 GiB limit).

--- a/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
@@ -3,14 +3,14 @@ description: How to hibernate a Gardener-based Kubernetes cluster
 ---
 # Hibernating a Kubernetes cluster
 
-There will be times when you won't be using your Gardener-based cluster
+There will be times when you won't be using your {{k8s_management_service}}-based cluster
 much, if at all. To save on costs, you can put the whole cluster in
 hibernation. If you do, then from that time on (and until you wake the
 cluster again), you will be paying *less* for the cluster.
 
 ## Prerequisites
 
-We assume you have already used Gardener in {{brand}} to spin up a
+We assume you have already used {{k8s_management_service}} in {{brand}} to spin up a
 Kubernetes cluster, which is now humming away. If you've never done
 this before, please feel free to [follow this
 guide](../create-shoot-cluster).
@@ -21,12 +21,12 @@ Fire up your favorite web browser and navigate to
 <https://{{gui_domain}}>. Make sure the vertical pane at the left-hand
 side of the page is in full view, then choose
 *Containers → [{{k8s_management_service}}](https://{{gui_domain}}/containers/gardener)*.
-In the main pane, you will see your Gardener cluster.  Click anywhere
+In the main pane, you will see your {{k8s_management_service}} cluster.  Click anywhere
 on the corresponding row for a detailed view of the various cluster
 characteristics. Go to the *Status* tab and check if hibernation is
 possible.
 
-![Gardener cluster status](assets/garhiber-01.png)
+![{{k8s_management_service}} cluster status](assets/garhiber-01.png)
 
 If hibernation is indeed possible, this will be reflected in the
 *Constraints* section. To go ahead and actually hibernate the cluster,

--- a/docs/howto/kubernetes/gardener/kubectl.md
+++ b/docs/howto/kubernetes/gardener/kubectl.md
@@ -64,7 +64,7 @@ users:
 ```
 
 You will notice that the cluster API endpoint (the `server` entry in your kubeconfig) is a dynamically managed DNS address.
-Gardener in {{brand}} automatically created the DNS record upon shoot cluster creation.
+{{k8s_management_service}} in {{brand}} automatically created the DNS record upon shoot cluster creation.
 
 The DNS record will subsequently disappear when you delete the cluster.
 The DNS record *also* disappears when you [hibernate the shoot cluster](hibernate-shoot-cluster.md), and reappears when you wake it from hibernation.


### PR DESCRIPTION
In several places, the use of the string literal "Gardener" has slipped in where we should be using the `k8s_management_service` macro.

Replace the literal with the macro where applicable (this excludes the YAML front matter, and first-level headings).