### PR TITLE
refactor: Split kubeconfig information for Magnum into a separate page

### DIFF
--- a/docs/howto/kubernetes/gardener/kubectl.md
+++ b/docs/howto/kubernetes/gardener/kubectl.md
@@ -3,10 +3,16 @@ description: How to fetch, verify, and use your kubeconfig with kubectl.
 ---
 # Managing a Kubernetes cluster
 
+Once you [have launched a new cluster](create-shoot-cluster.md), you can interact with it using `kubectl` and a [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file.
+
+## Prerequisites
+
+You must install the Kubernetes command line tool, `kubectl`, on your local computer, and run commands against your cluster.
+To install `kubectl`, follow [the relevant Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
+
 ## Extracting the kubeconfig file
 
-Once you [have launched a new shoot cluster](create-shoot-cluster), you need to create a [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file to be able to access it.
-To do that, click on the cluster to expand its properties, and open *KubeConfig*.
+Click on the cluster to expand its properties, and open *KubeConfig*.
 
 ![KubeConfig tab in {{k8s_management_service}} Shoot view](assets/shoot_kubeconfig.png)
 

--- a/docs/howto/openstack/magnum/.pages
+++ b/docs/howto/openstack/magnum/.pages
@@ -1,3 +1,4 @@
 title: "Magnum (Kubernetes cluster management)"
 nav:
   - new-k8s-cluster.md
+  - kubectl.md

--- a/docs/howto/openstack/magnum/kubectl.md
+++ b/docs/howto/openstack/magnum/kubectl.md
@@ -1,0 +1,91 @@
+---
+description: How to fetch, verify, and use your kubeconfig with kubectl in a Magnum-managed Kubernetes cluster.
+---
+# Managing a Kubernetes cluster
+
+Once you [have launched a new cluster](new-k8s-cluster.md), you can interact with it using `kubectl` and a [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file.
+
+## Prerequisites
+
+You must install the Kubernetes command line tool, `kubectl`, on your local computer, and run commands against your cluster.
+To install `kubectl`, follow [the relevant Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
+
+## Extracting the kubeconfig file
+
+Due to Magnum's security policy configuration, you cannot use the OpenStack CLI for downloading the kubeconfig of a cluster that was created with {{gui}}, or vice versa.
+
+To fetch your kubeconfig, you must always use the same facility that you used to deploy the cluster.
+
+=== "{{gui}}"
+    In the left-hand side pane of the {{gui}}, select *Magnum* → *Clusters*.
+    Click on the cluster row to expand the details view, then click the
+    *KubeConfig* tab. In a second or two, you will see the contents of the
+    kubeconfig file. Click the blue *Download KubeConfig* button to download
+    it locally.
+
+    ![Kubeconfig view](assets/shot-07.png)
+
+    The kubeconfig file you get has a name similar to this one:
+
+    ```plain
+    kubeconfig--<cluster_name>--<region_name>--<alphanum_id>.yaml
+    ```
+
+    Feel free to rename it to something simpler, like `config`.
+=== "OpenStack CLI"
+    To download the kubeconfig file for your Kubernetes cluster, type
+    the following:
+
+    ```bash
+    openstack coe cluster config --dir=${PWD} <cluster-name>
+    ```
+
+After saving the kubeconfig file locally, set the value of variable
+`KUBECONFIG` to the full path of the file. Type, for example:
+
+```bash
+export KUBECONFIG=${PWD}/config
+```
+
+If you are currently managing only one cluster, and you already have its
+kubeconfig file stored as `~/.kube/config`, then you do not need to set
+the `KUBECONFIG` variable.
+
+## Accessing the Kubernetes cluster with kubectl
+
+You may now use `kubectl` to run commands against your cluster. See, for
+instance, all cluster nodes...
+
+```bash
+kubectl get nodes
+```
+
+```plain
+NAME                           STATUS   ROLES    AGE    VERSION
+bangor-id6nijycp2wy-master-0   Ready    master   113m   v1.18.6
+bangor-id6nijycp2wy-node-0     Ready    <none>   111m   v1.18.6
+```
+
+...or all running pods in every namespace:
+
+```bash
+kubectl get pods --all-namespaces
+```
+
+```plain
+NAMESPACE     NAME                                         READY   STATUS    RESTARTS   AGE
+kube-system   coredns-786ffb7797-tw2hg                     1/1     Running   0          167m
+kube-system   coredns-786ffb7797-vbqwn                     1/1     Running   0          167m
+kube-system   csi-cinder-controllerplugin-0                5/5     Running   0          167m
+kube-system   csi-cinder-nodeplugin-4nr69                  2/2     Running   0          166m
+kube-system   csi-cinder-nodeplugin-vtwqf                  2/2     Running   0          167m
+kube-system   dashboard-metrics-scraper-6b4884c9d5-4mlrg   1/1     Running   0          167m
+kube-system   k8s-keystone-auth-wk5v2                      1/1     Running   0          167m
+kube-system   kube-dns-autoscaler-75859754fd-2wsd9         1/1     Running   0          167m
+kube-system   kube-flannel-ds-7z9dp                        1/1     Running   0          167m
+kube-system   kube-flannel-ds-dmvk6                        1/1     Running   0          166m
+kube-system   kubernetes-dashboard-c98496485-stn42         1/1     Running   0          167m
+kube-system   magnum-metrics-server-79556d6999-xdlpm       1/1     Running   0          167m
+kube-system   npd-5p6gk                                    1/1     Running   0          165m
+kube-system   openstack-cloud-controller-manager-44rz9     1/1     Running   0          167m
+```

--- a/docs/howto/openstack/magnum/new-k8s-cluster.md
+++ b/docs/howto/openstack/magnum/new-k8s-cluster.md
@@ -1,4 +1,4 @@
-# Creating new Kubernetes clusters
+# Creating a Kubernetes cluster
 
 By employing OpenStack
 [Magnum](https://docs.openstack.org/magnum/latest) you can create
@@ -229,94 +229,6 @@ get detailed information about it.
     +----------------------+---------------------------------------------------------------------------+
     ```
 
-## Accessing the Kubernetes cluster with kubectl
+## Interacting with your cluster
 
-You may install the Kubernetes command line tool, `kubectl`, on your
-local computer, and run commands against your cluster. To install
-`kubectl`, use the package manager of your operating system.
-
-=== "Debian/Ubuntu"
-    ```bash
-    apt install kubectl
-    ```
-=== "Mac OS X with Homebrew"
-    ```bash
-    brew install kubectl
-    ```
-
-Before running commands against a specific cluster, you must have the
-corresponding
-[kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-file on your computer.
-
-=== "{{gui}}"
-    In the left-hand side pane of the {{gui}}, select *Magnum* → *Clusters*.
-    Click on the cluster row to expand the details view, then click the
-    *KubeConfig* tab. In a second or two, you will see the contents of the
-    kubeconfig file. Click the blue *Download KubeConfig* button to download
-    it locally.
-
-    ![Kubeconfig view](assets/shot-07.png)
-
-    The kubeconfig file you get has a name similar to this one:
-
-    ```plain
-    kubeconfig--<cluster_name>--<region_name>--<alphanum_id>.yaml
-    ```
-
-    Feel free to rename it to something simpler, like `config`.
-=== "OpenStack CLI"
-    To download the kubeconfig file for your Kubernetes cluster, type
-    the following:
-
-    ```bash
-    openstack coe cluster config --dir=${PWD} bangor
-    ```
-
-After saving the kubeconfig file locally, set the value of variable
-`KUBECONFIG` to the full path of the file. Type, for example:
-
-```bash
-export KUBECONFIG=${PWD}/config
-```
-
-If you are currently managing only one cluster, and you already have its
-kubeconfig file stored as `~/.kube/config`, then you do not need to set
-the `KUBECONFIG` variable.
-
-You may now use `kubectl` to run commands against your cluster. See, for
-instance, all cluster nodes...
-
-```bash
-kubectl get nodes
-```
-
-```plain
-NAME                           STATUS   ROLES    AGE    VERSION
-bangor-id6nijycp2wy-master-0   Ready    master   113m   v1.18.6
-bangor-id6nijycp2wy-node-0     Ready    <none>   111m   v1.18.6
-```
-
-...or all running pods in every namespace:
-
-```bash
-kubectl get pods --all-namespaces
-```
-
-```plain
-NAMESPACE     NAME                                         READY   STATUS    RESTARTS   AGE
-kube-system   coredns-786ffb7797-tw2hg                     1/1     Running   0          167m
-kube-system   coredns-786ffb7797-vbqwn                     1/1     Running   0          167m
-kube-system   csi-cinder-controllerplugin-0                5/5     Running   0          167m
-kube-system   csi-cinder-nodeplugin-4nr69                  2/2     Running   0          166m
-kube-system   csi-cinder-nodeplugin-vtwqf                  2/2     Running   0          167m
-kube-system   dashboard-metrics-scraper-6b4884c9d5-4mlrg   1/1     Running   0          167m
-kube-system   k8s-keystone-auth-wk5v2                      1/1     Running   0          167m
-kube-system   kube-dns-autoscaler-75859754fd-2wsd9         1/1     Running   0          167m
-kube-system   kube-flannel-ds-7z9dp                        1/1     Running   0          167m
-kube-system   kube-flannel-ds-dmvk6                        1/1     Running   0          166m
-kube-system   kubernetes-dashboard-c98496485-stn42         1/1     Running   0          167m
-kube-system   magnum-metrics-server-79556d6999-xdlpm       1/1     Running   0          167m
-kube-system   npd-5p6gk                                    1/1     Running   0          165m
-kube-system   openstack-cloud-controller-manager-44rz9     1/1     Running   0          167m
-```
+Once your new Magnum-managed Kubernetes cluster is operational, you can [start interacting with it](kubectl.md).


### PR DESCRIPTION
* Create a new page, `kubectl.md`, in the OpenStack Magnum how-to guides section (similar to what we already have for Gardener).
* Explain that one must use CCMP to download the kubeconfig of a CCMP-managed Magnum cluster, and the CLI for a CLI-managed one.
* Instead of specifically discussing how to install kubectl on Debian/Ubuntu and MacOS, point to the upstream documentation.