### PR TITLE
feat: Add a Legal page to the Reference section

### DIFF
--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -7,3 +7,4 @@ nav:
   - quotas
   - versions
   - api
+  - legal

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -26,3 +26,7 @@ information about {{brand}} services.
   information for accessing Application Programming Interfaces (APIs),
   getting information, and manipulating all sorts of {{brand}}
   objects.
+
+## Legal reference
+
+* The **[Legal reference](legal/index.md)** section contains information about the terms and agreements governing {{brand}} services.

--- a/docs/reference/legal/index.md
+++ b/docs/reference/legal/index.md
@@ -1,0 +1,22 @@
+---
+description: "The fine print: terms and agreements governing our services."
+---
+# Legal Reference
+
+This section contains links to the terms and agreements governing the {{brand}} services.
+
+## {{legal_docs.tos.name}}
+
+Our {{brand}} [{{legal_docs.tos.name}}]({{legal_docs.tos.url}}) are valid from 2023-04-05, provided you created your account on or after that date.
+
+If you [created your account](../../howto/getting-started/create-account.md) before that date, the prior {{legal_docs.tc.name}} still apply until 2023-05-05, after which the {{legal_docs.tos.name}} supersede them.
+
+## {{legal_docs.tc.name}}
+
+The legacy [{{legal_docs.tc.name}}]({{legal_docs.tc.url}}) apply until 2023-05-05, provided you created your account before 2023-04-05.
+
+If you created your account on or after that date, the updated {{legal_docs.tos.name}} apply from the date of account creation.
+
+## {{legal_docs.cdpa.name}}
+
+The {{brand}} [{{legal_docs.cdpa.name}}]({{legal_docs.cdpa.url}}) was most recently updated on 2020-06-09.


### PR DESCRIPTION
Create a page containing links to our legal documents.

Also, explain the relationship between the legacy GT&C and their replacement, the ToS.