### PR TITLE
fix: Inject full-stop and newline in account creation how-to guide

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -11,7 +11,8 @@ Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
 At your leisure, please read the [{{ legal_docs.tos.name}}]({{ legal_docs.tos.url}})
 and our
-[{{ legal_docs.cdpa.name}}]({{ legal_docs.cdpa.url}})
+[{{ legal_docs.cdpa.name}}]({{ legal_docs.cdpa.url}}).
+
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.
 


### PR DESCRIPTION
The sentence referring to the ToS and CDPA was missing punctuation. Fix the missing full-stop, and also inject a newline to break the paragraph.