### PR TITLE
fix: Make sure variable name is properly referenced

### DIFF
--- a/docs/howto/account-billing/change-billing-data.md
+++ b/docs/howto/account-billing/change-billing-data.md
@@ -1,29 +1,21 @@
 # Changing your account billing data
 
-Via [{{gui}}](https://{{gui_domain}}) you can change the contact
-person, address, company name, and purchase order number associated
-with your account.
+You may at any time change the contact person, address, company name, and purchase order number associated with your {{brand}} account.
 
-To get started, navigate to <https://{{gui_domain}}>. Log in and
-click on the _Profile_ button at the top right.
+To get started, navigate to the [{{gui}}](https://{{gui_domain}}).
+Log in and click the _Profile_ button at the top right.
 
-![Orange avatar person with white
-background.](assets/picture-profile.png)
+![Orange avatar person with white background.](assets/picture-profile.png)
 
-You will now see the _Account settings_ page. Choose the _Customer
-Info_ tab, in which you can change and manage your customer
-information.
+There, you will see the _Account settings_ page.
+Choose the _Customer Info_ tab, in which you can change and manage your customer information.
 
-![The "Customer Info" tab with a green "Update" button to complete the
-changes](assets/picture-changecustomerinfo2.png)
+![The "Customer Info" tab with a green "Update" button to complete the changes](assets/picture-changecustomerinfo2.png)
 
-Finish your changes by clicking the green _Update_ button at the
-bottom.
+Finalize your changes by clicking the green _Update_ button at the bottom.
 
 ## Changing an account's organization number
 
-You cannot change your organization number (for business accounts) or
-personal number (for individual accounts) in {{gui}}.
+Please note that you cannot readily change your organization number (for business accounts) or your personal number (for individual accounts) in the {{gui}}.
 
-This requires that you submit a [legal_docs.transfer_form.name]({{legal_docs.transfer_form.url}}) via our
-[{{support}}](https://{{support_domain}}/servicedesk).
+In case you do wish to change any of those, you will have to submit a [{{legal_docs.transfer_form.name}}]({{legal_docs.transfer_form.url}}) via our [{{support}}](https://{{support_domain}}/servicedesk).


### PR DESCRIPTION
Encase legal_docs.transfer_form.name in double curly brackets, so the variable value is used in the provided URL (legal_docs.transfer_form.url).

While we're at it, apply the one-sentence-per-line policy and introduce some minor changes to syntax and prose.