### PR TITLE
fix: Update Ceph version name in Kna1 region

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -32,5 +32,4 @@ releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
 {{brand}} currently runs Ceph
-[Pacific](https://docs.ceph.com/en/latest/releases/pacific/) and
-[Quincy](https://docs.ceph.com/en/latest/releases/quincy/).
+[Quincy](https://docs.ceph.com/en/latest/releases/quincy).

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -17,8 +17,8 @@
 
 ## Ceph Services
 
-|                               | Kna1      | Sto2             | Fra1    | Dx1     | Tky1             |
-| --------------------------    | --------- | ------           | -----   | -----   | ------           |
-| Block storage (for OpenStack) | Pacific   | Quincy           | Quincy  | Quincy  | Quincy           |
-| Object storage (Swift API)    | Pacific   | :material-close: | Quincy  | Quincy  | Quincy           |
-| Object storage (S3 API)       | Pacific   | :material-close: | Quincy  | Quincy  | Quincy           |
+|                               | Kna1   | Sto2             | Fra1   | Dx1    | Tky1   |
+| --------------------------    | ------ | ------           | -----  | -----  | ------ |
+| Block storage (for OpenStack) | Quincy | Quincy           | Quincy | Quincy | Quincy |
+| Object storage (Swift API)    | Quincy | :material-close: | Quincy | Quincy | Quincy |
+| Object storage (S3 API)       | Quincy | :material-close: | Quincy | Quincy | Quincy |


### PR DESCRIPTION
Ceph Quincy is now deployed and available in all public cloud regions, including Kna1.