### PR TITLE
fix: Drop :8080 port suffix from public S3 links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
-      - name: Test with tox
+      - env:
+          DOCS_ENABLE_HTMLPROOFER: false
+        name: Test with tox
         run: |
           tox -e gitlint
           tox

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,23 +25,23 @@ extra:
     cdpa:
       name: "Data Processing Agreement"
       # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf"
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf"
     tc:
       name: "General Terms and Conditions"
       # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf"
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf"
     termination_form:
       name: "Termination of Subscription Form"
       # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"
     tos:
       name: "Terms of Service"
       # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Terms_of_Service-Public_Cloud_v2023.4.5.pdf"
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Terms_of_Service-Public_Cloud_v2023.4.5.pdf"
     transfer_form:
       name: "Transfer Form"
       # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"
   rest_api: "Cleura Cloud REST API"
   rest_api_domain: "rest.cleura.cloud"
   support: "Service Center"


### PR DESCRIPTION
Our object storage services now support access via the standard HTTPS port, 443. This transition has not yet been completed in all regions, so we cannot update the S3 and Swift API how-to guides yet, but it has been completed in the Kna1 region so we can update the references to the publicly accessible legal documents.

Thus, drop the `:8080` port suffix from those macro definitions.