### PR TITLE
fix: Use shortcut for account registration

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -1,11 +1,13 @@
+---
+description: How to create a new Cleura Cloud account
+---
 # Creating a new account
 
-To gain access to the {{gui}}, you first
+To gain access to {{brand}}, you first
 have to create a new account. For that, navigate to
-<https://cleura.cloud>. At the bottom right-hand side of the page,
-click on the _Create account_ button.
+<https://{{gui_domain}}/register>.
 
-![Create new account](assets/01-login-page.png)
+![Type in necessary details](assets/02-type-email-country.png)
 
 Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
@@ -15,8 +17,6 @@ and our
 
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.
-
-![Type in necessary details](assets/02-type-email-country.png)
 
 This will redirect you to the {{gui}}, and
 since you are logging in from a new account for the first time, you


### PR DESCRIPTION
Rather than sending customers to the CCMP start page and then walking them to the account creation page, we can instead instruct them do drop directly on the registration page.

This saves one step, and removes the need for one screenshot.