### PR TITLE
fix: Re-mention Ceph Pacific in version overview

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -32,4 +32,5 @@ releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
 {{brand}} currently runs Ceph
-[Quincy](https://docs.ceph.com/en/latest/releases/quincy).
+[Pacific](https://docs.ceph.com/en/latest/releases/pacific/) and
+[Quincy](https://docs.ceph.com/en/latest/releases/quincy/).


### PR DESCRIPTION
Although all Public cloud regions now run Ceph Quincy, there is still Ceph Pacific in Compliant cloud. So re-instate the mention of Pacific in the version overview.