### PR TITLE
feat: Add reference information on object storage quotas

### DIFF
--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -53,7 +53,7 @@ You should make sure that considering your selection of worker node [*flavor*](.
 For example, if your project is configured with the [default quotas](../../../reference/quotas/openstack.md), and you select the `b.4c16gb` flavor for your worker nodes, your cluster would be able to run with a maximum of 3 worker nodes (since their total memory footprint would be 3×16=48 GiB, just short of the default 50 GiB limit).
 A 4th node would push your total memory allocation to 64 GiB, violating your quota.
 
-If necessary, be sure to request a quota increase via our [{{support}}](https://{{support_domain}}).
+If necessary, be sure to request a quota increase via our [{{support}}](https://{{support_domain}}/servicedesk).
 
 ## Interacting with your cluster
 

--- a/docs/howto/openstack/cinder/retype-volumes.md
+++ b/docs/howto/openstack/cinder/retype-volumes.md
@@ -16,7 +16,7 @@ As such, when you need to retype volumes, you should plan ahead well in advance.
 In order to retype volumes, you must use the OpenStack CLI, so make sure you [have it enabled](../../getting-started/enable-openstack-cli.md).
 
 If you are about to retype a large volume, or one that holds data associated with a critical service, you may be interested in an estimate of how long the retype operation will take.
-In that case, please file a support request with our [{{support}}](https://{{support_domain}}).
+In that case, please file a support request with our [{{support}}](https://{{support_domain}}/servicedesk).
 
 ## Checking the volume's state
 

--- a/docs/reference/quotas/.pages
+++ b/docs/reference/quotas/.pages
@@ -1,0 +1,4 @@
+---
+nav:
+  - "OpenStack": openstack.md
+  - "Object storage": object-storage.md

--- a/docs/reference/quotas/object-storage.md
+++ b/docs/reference/quotas/object-storage.md
@@ -1,0 +1,16 @@
+---
+description: Resource limits (quotas) for object storage
+---
+# Object storage quotas
+
+In {{brand}}, the following limits (quotas) apply to our object storage services.
+Quotas generally apply regardless of whether you are using the [S3](../../howto/object-storage/s3/index.md) or the [Swift](../../howto/object-storage/swift/index.md) API to access object storage.
+
+| Quota name         | Value     | Notes                                                                                                                                     |
+| -------------      | --------- | ---------------------                                                                                                                     |
+| Objects per bucket | 1,638,400 | Maximum number of objects per bucket (S3 API) or container (Swift API)                                                                    |
+| Data per bucket    | unlimited | Aggregate amount of data (total size of all objects) per bucket or container                                                              |
+
+## Requesting a quota increase
+
+If you find that you need to deploy more object storage data than the default quota allows, please file a support request with our [{{support}}](https://{{support_domain}}/servicedesk).

--- a/docs/reference/quotas/openstack.md
+++ b/docs/reference/quotas/openstack.md
@@ -1,7 +1,7 @@
 ---
 description: Resource limits (quotas) for OpenStack resources
 ---
-# OpenStack Quotas
+# OpenStack quotas
 
 Most of the OpenStack resources you create in {{brand}} are subject to quotas.
 Once you hit a quota limit, the creation of new resources of that type will fail, until you either reduce your resource utilization or your quota is raised.

--- a/docs/reference/quotas/openstack.md
+++ b/docs/reference/quotas/openstack.md
@@ -45,4 +45,4 @@ openstack quota show
 
 ## Requesting a quota increase
 
-If you find that you need to deploy more resources in one project than the default quota allows, or if you need to manage more than 3 projects in your account, please file a support request with our [{{support}}](https://{{support_domain}}).
+If you find that you need to deploy more resources in one project than the default quota allows, or if you need to manage more than 3 projects in your account, please file a support request with our [{{support}}](https://{{support_domain}}/servicedesk).


### PR DESCRIPTION
* Explain that the number of objects per bucket is limited.
* Add a .pages file so we get shorter headings in the navigation.
* Fix case in the title of the "OpenStack quotas" section.

Also, correct the path in our support URL (in several spots).
