### PR TITLE
fix: Remove references to the old General Terms and Conditions

### DIFF
--- a/docs/reference/legal/index.md
+++ b/docs/reference/legal/index.md
@@ -7,15 +7,7 @@ This section contains links to the terms and agreements governing the {{brand}} 
 
 ## {{legal_docs.tos.name}}
 
-Our {{brand}} [{{legal_docs.tos.name}}]({{legal_docs.tos.url}}) are valid from 2023-04-05, provided you created your account on or after that date.
-
-If you [created your account](../../howto/getting-started/create-account.md) before that date, the prior {{legal_docs.tc.name}} still apply until 2023-05-05, after which the {{legal_docs.tos.name}} supersede them.
-
-## {{legal_docs.tc.name}}
-
-The legacy [{{legal_docs.tc.name}}]({{legal_docs.tc.url}}) apply until 2023-05-05, provided you created your account before 2023-04-05.
-
-If you created your account on or after that date, the updated {{legal_docs.tos.name}} apply from the date of account creation.
+Our current [{{legal_docs.tos.name}}]({{legal_docs.tos.url}}) apply to all {{brand}} accounts since 2023-05-05.
 
 ## {{legal_docs.cdpa.name}}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,10 +26,6 @@ extra:
       name: "Data Processing Agreement"
       # yamllint disable-line rule:line-length
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_CDPA.pdf"
-    tc:
-      name: "General Terms and Conditions"
-      # yamllint disable-line rule:line-length
-      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/City_Network_General_Terms_And_Conditions_City_Cloud.pdf"
     termination_form:
       name: "Termination of Subscription Form"
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
The transition period, during which the old GT&C still applied to accounts created before 2023-04-05, ends on 2023-05-05. As of that date, the new ToS applies to all accounts.

Thus, remove the remaining references to the old terms.