### PR TITLE
build: Re-enable htmlproofer plugin in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
-      - env:
-          DOCS_ENABLE_HTMLPROOFER: false
-        name: Test with tox
+      - name: Test with tox
         run: |
           tox -e gitlint
           tox


### PR DESCRIPTION
This reverts commit b87ec4e9620ac6e8549a0d619d34fed1920aad2d.