### PR TITLE
fix: Update Ceph version in Sto2HS region

### DIFF
--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -17,8 +17,8 @@
 
 ## Ceph Services
 
-|                               | Sto1HS | Sto2HS  |
-| --------------------------    | ------ | ------  |
-| Block storage (for OpenStack) | Quincy | Pacific |
-| Object storage (Swift API)    | Quincy | Pacific |
-| Object storage (S3 API)       | Quincy | Pacific |
+|                               | Sto1HS | Sto2HS |
+| --------------------------    | ------ | ------ |
+| Block storage (for OpenStack) | Quincy | Quincy |
+| Object storage (Swift API)    | Quincy | Quincy |
+| Object storage (S3 API)       | Quincy | Quincy |

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -15,7 +15,7 @@ This section lists the cloud API service versions available in each
 
 ## OpenStack Services
 
-[OpenStack releases](https://releases.openstack.org/) are named, in
+[OpenStack releases](https://releases.openstack.org) are named, in
 alphabetical order, and occur on a six-month release schedule. In
 {{company}} Public Cloud we upgrade OpenStack releases annually; this
 means that we deploy every other OpenStack release and skip the
@@ -32,5 +32,4 @@ releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
 are also named, in alphabetical order, and occur on a roughly annual schedule.
 
 {{brand}} currently runs Ceph
-[Pacific](https://docs.ceph.com/en/latest/releases/pacific/) and
-[Quincy](https://docs.ceph.com/en/latest/releases/quincy/).
+[Quincy](https://docs.ceph.com/en/latest/releases/quincy).


### PR DESCRIPTION
Ceph Quincy is now deployed and available
in Sto2HS region, in the compliant cloud.