### PR TITLE
feat: Add support for CPU-intense flavors

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -13,6 +13,7 @@
 |                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- | ---------------- |
 | [Virtual GPU](../../howto/openstack/nova/new-vgpu-server.md) | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
+| [Physical CPUs](../../flavors/#compute-tiers)                | :material-close:      | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -48,6 +48,10 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
 * `g`: Virtual GPU. Instances launched with matching flavors have
   access to a
   [GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit).
+* `c`: Physical CPUs. Instances launched with matching flavors will be
+  assigned physical CPU cores, rather then virtual ones. These flavors
+  are recommended for CPU-intensive workloads, or when there is a
+  requirement for guaranteed CPU resources.
 
 Some tiers are only available in select {{brand}}
 regions. For details on tier availability, see the [Feature support


### PR DESCRIPTION
At the moment we do have publicly available flavors for CPU-intense compute
aggregate in STO2 region. It make sense to describe the feature and add
it's support to the matrix.