### PR TITLE
build: Add script for collecting and uploading troubleshooting data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,19 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
+      - name: Install packages needed for troubleshooting
+        run: |
+          sudo apt-get install curl bind9-dnsutils iputils-ping iputils-tracepath mtr-tiny tcpdump
+      - name: Run troubleshooting commands
+        run: |
+          mkdir -p troubleshooting-data
+          scripts/collect-troubleshooting-data.sh | \
+            tee troubleshooting-data/collect-troubleshooting-data.sh.txt 2>&1
+      - name: Upload troubleshooting data
+        uses: actions/upload-artifact@v3
+        with:
+          name: troubleshooting-data-${{ matrix.python-version }}-${{ github.sha }}
+          path: troubleshooting-data/
       - name: Test with tox
         run: |
           tox -e gitlint

--- a/scripts/collect-troubleshooting-data.sh
+++ b/scripts/collect-troubleshooting-data.sh
@@ -5,23 +5,16 @@ mkdir -p $DATADIR
 
 HOSTNAME=s3-kna1.citycloud.com
 IPADDRESSES=`dig +short $HOSTNAME | grep -v '\.$'`
-TIMEOUT=60
 URL="https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"
 
-curl -H "Accept: application/json" https://ifconfig.co/json > $DATADIR/ifconfig.co.json
-curl -H "Accept: text/plain" https://icanhazip.com > $DATADIR/client_ip.txt
 for ip in $IPADDRESSES; do
     echo "Testing $ip"
-    ping -D -c 5 -w 15 $ip > $DATADIR/ping.$ip.txt 2>&1
-    # timeout -v $TIMEOUT tracepath $ip > $DATADIR/tracepath.$ip.txt 2>&1
-    timeout -v $TIMEOUT mtr -Twzeb -P 8080 $ip > $DATADIR/mtr.$ip.txt 2>&1
-
-    sudo tcpdump -i any -w tcpdump.$ip.pcap ip host $ip and tcp port 8080 &
+    sudo tcpdump -i any -w $DATADIR/tcpdump.$ip.pcap ip host $ip and tcp port 8080 &
     tcpdump_pid=$!
     sleep 3s
-    curl -f -o /dev/null --resolve s3-kna1.citycloud.com:8080:$ip -vv $URL
+    for i in {000..099}; do
+        curl -f -o /dev/null --resolve s3-kna1.citycloud.com:8080:$ip -vv $URL 2> $DATADIR/curl.$ip.$i.txt || break
+    done
     sudo kill $tcpdump_pid
-    sleep 3s
-    sudo kill -9 $tcpdump_pid
     echo "Done with $ip"
 done

--- a/scripts/collect-troubleshooting-data.sh
+++ b/scripts/collect-troubleshooting-data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+DATADIR=troubleshooting-data
+mkdir -p $DATADIR
+
+HOSTNAME=s3-kna1.citycloud.com
+IPADDRESSES=`dig +short $HOSTNAME | grep -v '\.$'`
+TIMEOUT=60
+URL="https://s3-kna1.citycloud.com:8080/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"
+
+curl -H "Accept: application/json" https://ifconfig.co/json > $DATADIR/ifconfig.co.json
+curl -H "Accept: text/plain" https://icanhazip.com > $DATADIR/client_ip.txt
+for ip in $IPADDRESSES; do
+    echo "Testing $ip"
+    ping -D -c 5 -w 15 $ip > $DATADIR/ping.$ip.txt 2>&1
+    # timeout -v $TIMEOUT tracepath $ip > $DATADIR/tracepath.$ip.txt 2>&1
+    timeout -v $TIMEOUT mtr -Twzeb -P 8080 $ip > $DATADIR/mtr.$ip.txt 2>&1
+
+    sudo tcpdump -i any -w tcpdump.$ip.pcap ip host $ip and tcp port 8080 &
+    tcpdump_pid=$!
+    sleep 3s
+    curl -f -o /dev/null --resolve s3-kna1.citycloud.com:8080:$ip -vv $URL
+    sudo kill $tcpdump_pid
+    sleep 3s
+    sudo kill -9 $tcpdump_pid
+    echo "Done with $ip"
+done


### PR DESCRIPTION
In order to try to get to the bottom of our intermittent htmlproofer issues, create some troubleshooting data for later analysis.