### PR TITLE
feat: Mark vGPU feature as complete for kna1 and sto2

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -12,7 +12,7 @@
 ## Virtualization
 |                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Virtual GPU](../../flavors/#compute-tiers)   | :material-close: | :material-close:      | :material-close: | :material-close: | :material-close: |
+| [Virtual GPU](../../flavors/#compute-tiers)   | :material-check: | :material-check:      | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage


### PR DESCRIPTION
At the moment all infrastructure and bits are ready for
GPU-powered VM signups in kna1 and sto2 regions.