### PR TITLE
Bring back external link checking

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-export DOCS_ENABLE_HTMLPROOFER=true
 exec tox

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+---
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Python dependencies
+        run: |
+          pip install tox
+      - name: Test with tox
+        run: |
+          tox -e check
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: check-${{ github.sha }}
+          path: linkchecker-out.csv
+
+name: 'Check links'
+
+# We want to run this workflow every time we build the site.
+# In addition, we want to run it once a week on a schedule.
+'on':
+  page_build: {}
+  schedule:
+    - cron: '0 12 * * 3'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
-      - env:
-          DOCS_ENABLE_HTMLPROOFER: false
-        name: Deploy to gh-pages
+      - name: Deploy to gh-pages
         run: tox -e deploy-github
 
 name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 site/
 .cache/
 .tox/
+linkchecker-out.csv

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,0 +1,18 @@
+[checking]
+recursionlevel=2
+
+[filtering]
+# Check external links (i.e. ones not within the domain given as a
+# command-line argument).
+checkextern=1
+
+# Ignore the GitHub "Edit this page" links, and the pointers to
+# localhost in the contribution guide.
+ignore =
+  .*github\.com.*/edit/.*
+  .*localhost.*
+
+[output]
+# Create a CSV file containing all checked links, which can be
+# processed as a build artifact.
+fileoutput=csv

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,11 +69,6 @@ plugins:
       timezone: Etc/UTC
       type: iso_date
   - glightbox
-  - htmlproofer:
-      # yamllint disable-line rule:truthy
-      enabled: !ENV [DOCS_ENABLE_HTMLPROOFER, True]
-      raise_error: true
-      validate_external_urls: true
   - macros:
       # yamllint disable-line rule:truthy
       on_error_fail: !ENV [DOCS_FAIL_ON_MACRO_ERROR, True]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
   mkdocs-git-authors-plugin>=0.6.5
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox
-  mkdocs-htmlproofer-plugin
   mkdocs-macros-plugin
   mkdocs-material
   pillow
@@ -36,6 +35,11 @@ commands =
 [testenv:build]
 commands =
   mkdocs build --strict
+
+[testenv:check]
+deps = linkchecker
+commands =
+  linkchecker -f .linkcheckerrc https://docs.cleura.cloud/sitemap.xml
 
 [testenv:deploy-github]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = yamllint,bashate,markdownlint,build
 
 [testenv]
-envdir = {toxworkdir}/mkdocs
 skip_install = True
 passenv = DOCS_*
 deps =


### PR DESCRIPTION
Our automated checks for dead links haven't been functional, or at least not reliable as far as external links are concerned, for a while now. Since we can't really make them work reliably with the htmlproofer plugin because of https://github.com/manuzhang/mkdocs-htmlproofer-plugin/issues/63, try an alternate approach with linkchecker. 

- build: Drop envdir from testenv
- build: Replace htmlproofer plugin with linkchecker
