### PR TITLE
build: Add workflow_dispatch event trigger to check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,7 @@ name: 'Check links'
 # We want to run this workflow every time we build the site.
 # In addition, we want to run it once a week on a schedule.
 'on':
-  page_build: {}
+  page_build:
   schedule:
     - cron: '0 12 * * 3'
+  workflow_dispatch:


### PR DESCRIPTION
Adding this event trigger is necessary to allow us to invoke the
workflow run manually.

References:
https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
