### PR TITLE
build: Allow check job to continue when "tox -e check" fails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 ---
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -12,10 +12,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
-      - name: Test with tox
+      - continue-on-error: true
+        name: Test with tox
         run: |
           tox -e check
-      - name: Upload build
+      - name: Upload link check report
         uses: actions/upload-artifact@v3
         with:
           name: check-${{ github.sha }}


### PR DESCRIPTION
Without this change, the execution of the check job stops when `tox -e check` returns nonzero, meaning the report file is never uploaded.

Needless to say, we are very much interested in this artifact *particularly* when the link check fails, so use `continue‑on‑error: true` to make sure it is always uploaded.

Reference:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
