### PR TITLE
Final touchups to link checking

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,6 @@ name: 'Check links'
 # We want to run this workflow every time we build the site.
 # In addition, we want to run it once a week on a schedule.
 'on':
-  page_build:
   schedule:
     - cron: '0 12 * * 3'
   workflow_dispatch:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,15 +12,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install tox
-      - continue-on-error: true
-        name: Test with tox
+      - name: Test with tox
         run: |
           tox -e check
-      - name: Upload link check report
-        uses: actions/upload-artifact@v3
-        with:
-          name: check-${{ github.sha }}
-          path: linkchecker-out.csv
 
 name: 'Check links'
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 site/
 .cache/
 .tox/
-linkchecker-out.csv
+linkchecker-out.*

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -11,8 +11,3 @@ checkextern=1
 ignore =
   .*github\.com.*/edit/.*
   .*localhost.*
-
-[output]
-# Create a CSV file containing all checked links, which can be
-# processed as a build artifact.
-fileoutput=csv

--- a/docs/background/disaster-recovery.md
+++ b/docs/background/disaster-recovery.md
@@ -22,7 +22,7 @@ background, and why you should consider enabling it.
 ## What it is
 
 The *Disaster Recovery* (DR) feature is available via the {{gui}} and
-applies to servers and volumes that use our [Ceph](https://ceph.io/en/)
+applies to servers and volumes that use our [Ceph](https://ceph.io)
 backend. That would be **all** servers but the ones of the `s`
 [flavor](../../reference/flavors/#compute-tiers).
 

--- a/docs/background/disaster-recovery.md
+++ b/docs/background/disaster-recovery.md
@@ -22,7 +22,7 @@ background, and why you should consider enabling it.
 ## What it is
 
 The *Disaster Recovery* (DR) feature is available via the {{gui}} and
-applies to servers and volumes that use our [Ceph](https://ceph.io)
+applies to servers and volumes that use our [Ceph](https://ceph.io/en/)
 backend. That would be **all** servers but the ones of the `s`
 [flavor](../../reference/flavors/#compute-tiers).
 

--- a/docs/background/object-storage.md
+++ b/docs/background/object-storage.md
@@ -52,7 +52,7 @@ For example, if you [make a container public](../howto/object-storage/swift/publ
 You cannot simultaneously retain mandatory private (authenticated) access to the corresponding bucket via the S3 API.
 
 Object storage in {{brand}} also does *not* allow you to make competing feature settings on containers/buckets, based on the API used to access them.
-For example, it is not possible to create [a Swift container that enables versioning](../howto/object-storage/swift/versioning.md), while disabling [bucket versioning](../howto/object-storage/s3/versioning/) on the corresponding S3 bucket.
+For example, it is not possible to create [a Swift container that enables versioning](../howto/object-storage/swift/versioning.md), while disabling [bucket versioning](../howto/object-storage/s3/versioning.md) on the corresponding S3 bucket.
 
 Sometimes, this creates unavoidable conflicts if a specific feature is only available in one of the supported APIs.
 For example, if you [set a public read policy](../howto/object-storage/s3/public-bucket.md) on an S3 bucket, the corresponding Swift container will still show an empty Read ACL, making the Swift container *look* like it is private, even though its objects are accessible through simple public URLs.

--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -4,7 +4,7 @@ description: How to modernize old boot-from-image servers
 # Converting a boot-from-image server to boot-from-volume
 
 You can freely move any server [between {{brand}}
-regions](move-server-between-regions), provided it boots from a volume
+regions](move-server-between-regions.md), provided it boots from a volume
 (which we generally recommend, since it affords more flexibility than
 booting from an image). You may still have boot-from-image servers,
 though. To verify that a particular server is of that type, you can go
@@ -348,7 +348,7 @@ the OpenStack CLI.
     The most important parameter in the command above is `--volume`, which
     is used to specify the boot volume of the server. Regarding server
     creation in general, you might want to [check the corresponding
-    guide](new-server).
+    guide](new-server.md).
 
 ## Viewing the new server
 

--- a/docs/reference/api/cc/index.md
+++ b/docs/reference/api/cc/index.md
@@ -9,15 +9,15 @@ tool like `curl`. Regarding documentation, there is a detailed,
 which you turn to for advice on endpoints and how to use them.
 
 > To access the API, you need to have an
-[account in {{brand}}](../../howto/getting-started/create-account),
+[account in {{brand}}](../../../howto/getting-started/create-account.md),
 and also create
-[a valid access token](../../howto/getting-started/accessing-cc-rest-api).
+[a valid access token](../../../howto/getting-started/accessing-cc-rest-api.md).
 
 All actions exposed via the {{gui}} are also available through the
 {{rest_api}}. One of the most common use cases is taking advantage
 of it for programmatically pulling all sorts of information for
 further processing. For instance, see how you can
-[retrieve invoice data](../../howto/account-billing/rest-invoice-data)
+[retrieve invoice data](../../../howto/account-billing/rest-invoice-data.md)
 via the API. For any other use of the {{rest_api}}, please see
 the sections in the
 [documentation page](https://apidoc.cleura.cloud).

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 [testenv:check]
 deps = linkchecker
 commands =
-  linkchecker -f .linkcheckerrc https://docs.cleura.cloud/sitemap.xml
+  linkchecker -f .linkcheckerrc {posargs} https://docs.cleura.cloud/sitemap.xml
 
 [testenv:deploy-github]
 passenv =


### PR DESCRIPTION
The initial test runs with the `check` workflow seem to indicate that several dead links slipped through the `htmlproofer` plugin, meaning it was probably not very useful to begin with.

Also, the `page_build` trigger never seems to trip, even though [I think we were using it correctly](https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html#trigger-on-a-gh-pages-build), so remove it from the configuration. 