### PR TITLE
fix: Work around HTTP 500 at ceph.io (again)

### DIFF
--- a/docs/background/disaster-recovery.md
+++ b/docs/background/disaster-recovery.md
@@ -22,7 +22,7 @@ background, and why you should consider enabling it.
 ## What it is
 
 The *Disaster Recovery* (DR) feature is available via the {{gui}} and
-applies to servers and volumes that use our [Ceph](https://ceph.io)
+applies to servers and volumes that use our [Ceph](https://ceph.io/en/)
 backend. That would be **all** servers but the ones of the `s`
 [flavor](../../reference/flavors/#compute-tiers).
 


### PR DESCRIPTION
This was mixed up in two prior commits, and then missed in review.

This reverts commit ecb633f27b06557cee9162935e4d4c25a8328863.
