### PR TITLE
chore: Fix superfluous quotes in production link check

### DIFF
--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -6,7 +6,7 @@ if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"
 elif test `basename $0` = "linkcheck-production.sh"; then
     DOCS_SITE_URL="https://docs.cleura.cloud"
-    DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE '.*localhost.*'"
+    DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*localhost.*"
 fi
 
 # If invoked as just linkcheck.sh, must pass in DOCS_SITE_URL from the


### PR DESCRIPTION
The scheduled production link check had an extra set of single quotes.
It doesn't seem to actually break the link check, but it doesn't hurt
to remove the superfluous quotes.
