### PR TITLE
fix: Bump latest supported Kubernetes version for Gardener

### DIFF
--- a/docs/background/kubernetes/index.md
+++ b/docs/background/kubernetes/index.md
@@ -14,7 +14,7 @@ For more details on the relative merits of both options, refer to the sections b
 | -------------                                                   | ----------------             | ----------------                      |
 | Kubernetes Cloud Provider                                       | OpenStack                    | OpenStack                             |
 | Base operating system for nodes                                 | Garden Linux                 | Fedora CoreOS                         |
-| Latest installable Kubernetes minor release                     | 1.24                         | 1.21                                  |
+| Latest installable Kubernetes minor release                     | 1.26                         | 1.21                                  |
 
 
 ## API and CLI support

--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -33,7 +33,7 @@ You cannot use `ReadWriteOncePod` (`RWOP`), `ReadWriteMany` (`RWX`), or `ReadOnl
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.24.9.
+The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.26.5.
 
 ### IP version
 


### PR DESCRIPTION
The latest available Gardener-managed Kubernetes version in Cleura Cloud is no longer 1.24, but 1.26. Fix the relevant background and reference pages.
