### PR TITLE
build: Add s3-kna1.citycloud.com to the linkcheck ignore list

### DIFF
--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
+DOCS_LINKCHECK_IGNORE='.*s3-kna1\.citycloud\.com.* .*github\.com.*/edit/.*'
 
 if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"


### PR DESCRIPTION
Whatever gremlins there are that cause all of our link check facilities to choke on this one specific server we might not ever know.

But we can't keep having our builds break on this.