### PR TITLE
fix: Add a kna1 quota specifics

### DIFF
--- a/docs/reference/quotas/object-storage.md
+++ b/docs/reference/quotas/object-storage.md
@@ -10,6 +10,7 @@ Quotas generally apply regardless of whether you are using the [S3](../../howto/
 | -------------      | --------- | ---------------------                                                                                                                     |
 | Objects per bucket | 1,638,400 | Maximum number of objects per bucket (S3 API) or container (Swift API)                                                                    |
 | Data per bucket    | unlimited | Aggregate amount of data (total size of all objects) per bucket or container                                                              |
+> Currently this quota limit applies just to KNA1 region object storage service.
 
 ## Requesting a quota increase
 


### PR DESCRIPTION
Add a note about quota object storage being enforced just at KNA1 public region.