### PR TITLE
chore: Link to Markdown paths internally

### DIFF
--- a/docs/background/disaster-recovery.md
+++ b/docs/background/disaster-recovery.md
@@ -3,7 +3,7 @@ description: What is the Disaster Recovery feature and why you want it
 ---
 # Disaster recovery
 
-When you [create a new server](../../howto/openstack/nova/new-server) in
+When you [create a new server](../howto/openstack/nova/new-server.md) in
 {{brand}} you will notice an option named **Disaster recovery**, which
 is enabled by default.
 
@@ -24,7 +24,7 @@ background, and why you should consider enabling it.
 The *Disaster Recovery* (DR) feature is available via the {{gui}} and
 applies to servers and volumes that use our [Ceph](https://ceph.io/en/)
 backend. That would be **all** servers but the ones of the `s`
-[flavor](../../reference/flavors/#compute-tiers).
+[flavor](../reference/flavors/index.md#compute-tiers).
 
 ## How it works
 
@@ -45,7 +45,7 @@ Provided snapshots are available, you can restore a server or a single
 volume to any of those snapshots. For instance, you may discover that
 due to faulty application logic or simply a bug, you are now
 experiencing data corruption. Then, one of your options would be to [go
-back in time](/howto/openstack/nova/restore-srv-to-snap) by restoring
+back in time](../howto/openstack/nova/restore-srv-to-snap.md) by restoring
 one of the available snapshots and keep going from there.
 
 ## Restoration time

--- a/docs/background/gui-vs-api.md
+++ b/docs/background/gui-vs-api.md
@@ -3,7 +3,7 @@
 You can do many tasks in {{brand}} via the
 [{{gui}}](https://{{gui_domain}}) or via the OpenStack API, e.g., with
 the help of the
-[OpenStack CLI](../../howto/getting-started/enable-openstack-cli) tool.
+[OpenStack CLI](../howto/getting-started/enable-openstack-cli.md) tool.
 For some tasks, though, you *will need* the OpenStack API.
 
 But when does it make sense to prefer a particular way of working?
@@ -13,19 +13,19 @@ What are the reasons, if any, for choosing one method over the other?
 
 Ease of use is probably the main reason for choosing the {{gui}} over
 the OpenStack API. Provided you have an [account in
-{{brand}}](../../howto/getting-started/create-account), you can simply
+{{brand}}](../howto/getting-started/create-account.md), you can simply
 log in and then follow step-by-step guides to create entities such as
-[networks](../../howto/openstack/neutron/new-network),
-[servers](../../howto/openstack/nova/new-server), or even
-[Kubernetes clusters](../../howto/openstack/magnum/new-k8s-cluster).
+[networks](../howto/openstack/neutron/new-network.md),
+[servers](../howto/openstack/nova/new-server.md), or even
+[Kubernetes clusters](../howto/openstack/magnum/new-k8s-cluster.md).
 You can just as easily perform administrative tasks like creating
 [security
-groups](../../howto/openstack/neutron/create-security-groups), setting
-up [region-to-region VPN](../../howto/openstack/neutron/vpnaas)
+groups](../howto/openstack/neutron/create-security-groups.md), setting
+up [region-to-region VPN](../howto/openstack/neutron/vpnaas.md)
 connections, [deleting
-networks](../../howto/openstack/neutron/delete-network), modifying
-[billing data](../../howto/account-billing/change-billing-data), or
-[managing invoices](../../howto/account-billing/manage-invoices).
+networks](../howto/openstack/neutron/delete-network.md), modifying
+[billing data](../howto/account-billing/change-billing-data.md), or
+[managing invoices](../howto/account-billing/manage-invoices.md).
 
 All in all, there are many instances when the {{gui}} is all you want
 and, at the same time, is more than enough for what you want.
@@ -45,11 +45,11 @@ via the OpenStack API, for there is no counterpart tool in the {{gui}}
 toolbox.
 
 For instance, whenever you need to
-[move servers between regions](../../howto/openstack/nova/move-server-between-regions),
+[move servers between regions](../howto/openstack/nova/move-server-between-regions.md),
 then `openstack` is your only option. Another instance where you work
 with the OpenStack API and various CLI tools, is when you have to
-interact with the [S3 API](../../howto/object-storage/s3) or the
-[Swift API](../../howto/object-storage/swift).
+interact with the [S3 API](../howto/object-storage/s3/index.md) or the
+[Swift API](../howto/object-storage/swift/index.md).
 
 Even though the command syntax of `openstack` may sometimes look overly
 complicated, the potential for scripting can speed up many operations

--- a/docs/background/kubernetes/gardener/hibernation.md
+++ b/docs/background/kubernetes/gardener/hibernation.md
@@ -69,4 +69,4 @@ Last but not least, the act of waking a cluster up may temporarily fail,
 because while the cluster was hibernating, the tenant came close to its
 volume, RAM, CPU, etc. quota, and attempting to re-instantiate the
 worker nodes and re-activate the cluster would breach the [quota
-limit](/../../../reference/quotas/openstack).
+limit](../../../reference/quotas/openstack.md).

--- a/docs/background/project-deletion.md
+++ b/docs/background/project-deletion.md
@@ -31,6 +31,6 @@ required, and those are **not** available for {{brand}} users.
 
 If you wish to disable a project, you can do so via the {{rest_api}}.
 Make sure
-[you have access](/howto/getting-started/accessing-cc-rest-api)
+[you have access](../howto/getting-started/accessing-cc-rest-api.md)
 to it, and then consult the documentation to actually
 [disable a project](https://apidoc.cleura.cloud/#api-AccessControl_Openstack-OSEditOpenstackProject).

--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -5,7 +5,7 @@ simply be improved? There are multiple ways for you to help make this
 site better, and we welcome all of them.
 
 You can make modifications and contributions [using
-Git](modifications), and we apply certain [checks](quality) to ensure
+Git](modifications.md), and we apply certain [checks](quality.md) to ensure
 consistent documentation quality.
 
 ## Technical Writing Resources

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -82,7 +82,7 @@ git add <files-to-add>
 git commit
 ```
 
-Please see our [notes on commit messages](../quality).
+Please see our [notes on commit messages](quality.md).
 
 Finally, create a pull request (PR) from your changes:
 

--- a/docs/howto/account-billing/rest-invoice-data.md
+++ b/docs/howto/account-billing/rest-invoice-data.md
@@ -6,7 +6,7 @@ using the {{rest_api}}.
 ## Prerequisites
 
 Before retrieving any of your invoice data, you need to
-[create a token](/howto/getting-started/accessing-cc-rest-api)
+[create a token](../getting-started/accessing-cc-rest-api.md)
 for the current session.
 
 ## Saving invoice data

--- a/docs/howto/getting-started/accessing-cc-rest-api.md
+++ b/docs/howto/getting-started/accessing-cc-rest-api.md
@@ -3,7 +3,7 @@
 {{brand}} provides a REST API, which you can take advantage of with a
 tool like `curl`. But before you do, you must create a token for the
 current session. For that, you only need to have an
-[account in {{brand}}](/howto/getting-started/create-account).
+[account in {{brand}}](create-account.md).
 
 ## Creating a token
 

--- a/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
@@ -13,7 +13,7 @@ cluster again), you will be paying *less* for the cluster.
 We assume you have already used {{k8s_management_service}} in {{brand}} to spin up a
 Kubernetes cluster, which is now humming away. If you've never done
 this before, please feel free to [follow this
-guide](../create-shoot-cluster).
+guide](create-shoot-cluster.md).
 
 ## Hibernating a cluster
 

--- a/docs/howto/kubernetes/gardener/kubectl.md
+++ b/docs/howto/kubernetes/gardener/kubectl.md
@@ -90,7 +90,7 @@ NAME                                                STATUS   ROLES    AGE    VER
 shoot--p40698--test-cluster-czg4zf-z1-5d7b5-bfl7p   Ready    <none>   156m   v1.24.3
 ```
 
-> Please note that in contrast to an [OpenStack Magnum-managed Kubernetes cluster](../../../openstack/magnum/new-k8s-cluster) (where the output of `kubectl get nodes` includes control plane and worker nodes), in a {{k8s_management_service}} cluster the same command *only* lists the worker nodes.
+> Please note that in contrast to an [OpenStack Magnum-managed Kubernetes cluster](../../openstack/magnum/new-k8s-cluster.md) (where the output of `kubectl get nodes` includes control plane and worker nodes), in a {{k8s_management_service}} cluster the same command *only* lists the worker nodes.
 
 ## Deploying an application
 

--- a/docs/howto/kubernetes/gardener/rolling-upgrades.md
+++ b/docs/howto/kubernetes/gardener/rolling-upgrades.md
@@ -7,7 +7,7 @@ By default, Kubernetes clusters created with {{k8s_management_service}}
 in {{brand}} are upgraded automatically. Those upgrades take place
 during a specified maintenance window, and you may find out more about
 [what they involve and how they
-work](../../../../background/kubernetes/gardener/autoupgrades). Besides
+work](../../../background/kubernetes/gardener/autoupgrades.md). Besides
 the automatic upgrades, you can manually apply any upgrades available
 for your cluster.
 

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -4,8 +4,8 @@ In {{brand}}, you have several options for deploying and managing
 Kubernetes clusters.
 
 [{{gui}}](https://{{gui_domain}}) includes management interfaces for
-[{{k8s_management_service}}](gardener/) and [OpenStack Magnum](magnum/). To manage
+[{{k8s_management_service}}](gardener/index.md) and [OpenStack Magnum](magnum/index.md). To manage
 Magnum clusters, you can also use the [OpenStack command-line
-interface](../getting-started/enable-openstack-cli/).
+interface](../getting-started/enable-openstack-cli.md).
 
 To assess which facility is more suitable for your specific deployment scenario and use case, refer to [this summary](../../background/kubernetes/index.md).

--- a/docs/howto/kubernetes/magnum/index.md
+++ b/docs/howto/kubernetes/magnum/index.md
@@ -10,6 +10,6 @@ documentation](https://docs.openstack.org/magnum/latest/user/#clustertemplate).
 
 Once you have chosen your Cluster Template, you move on to [create a
 cluster based on that
-template](/howto/openstack/magnum/new-k8s-cluster).  When you create
+template](../../openstack/magnum/new-k8s-cluster.md).  When you create
 the cluster, you can define the number of nodes in your cluster, ask
 for multiple master nodes with a load balancer in front, etc.

--- a/docs/howto/object-storage/s3/index.md
+++ b/docs/howto/object-storage/s3/index.md
@@ -9,7 +9,7 @@ standard `aws` CLI.
 
 Either way, [in addition to installing and configuring the Python
 `openstackclient`
-module](../../getting-started/enable-openstack-cli/), you need to
+module](../../getting-started/enable-openstack-cli.md), you need to
 install one of the aforementioned utilities.
 
 === "Debian/Ubuntu"
@@ -28,5 +28,5 @@ install one of the aforementioned utilities.
 ## Availability
 
 The S3 API is available in select {{brand}} regions. Refer to [the
-feature support matrix](/reference/features/) for details on S3 API
+feature support matrix](../../../reference/features/index.md) for details on S3 API
 availability.

--- a/docs/howto/object-storage/swift/expiry.md
+++ b/docs/howto/object-storage/swift/expiry.md
@@ -7,7 +7,7 @@ be deleted, after they have passed an expiry threshold.
 ## Prerequisites
 
 In order to manage object expiry, be sure that you have [installed and
-configured](../) the `swift` command-line interface (CLI). There is
+configured](index.md) the `swift` command-line interface (CLI). There is
 presently no way to set object expiry with the `openstack` CLI.
 
 

--- a/docs/howto/object-storage/swift/index.md
+++ b/docs/howto/object-storage/swift/index.md
@@ -3,7 +3,7 @@
 [OpenStack Swift](https://docs.openstack.org/swift/) (not to be
 confused with [the programming language of the same
 name](https://en.wikipedia.org/wiki/Swift_(programming_language))) is
-an object-access API similar to, but distinct from, the [S3](../s3/) object
+an object-access API similar to, but distinct from, the [S3](../s3/index.md) object
 storage API.
 
 In {{brand}}, you interact with the Swift API using either the `swift`
@@ -11,7 +11,7 @@ command-line interface (CLI), or the standard `openstack` CLI.
 
 Either way, [in addition to installing and configuring the Python
 `openstackclient`
-module](../../getting-started/enable-openstack-cli/), you need to
+module](../../getting-started/enable-openstack-cli.md), you need to
 install the Python `swiftclient` module. Use either the package
 manager of your operating system, or `pip`:
 
@@ -30,5 +30,5 @@ manager of your operating system, or `pip`:
 ## Availability
 
 The OpenStack Swift API is available in select {{brand}}
-regions. Refer to [the feature support matrix](/reference/features/)
+regions. Refer to [the feature support matrix](../../../reference/features/index.md)
 for details on Swift API availability.

--- a/docs/howto/object-storage/swift/private-container.md
+++ b/docs/howto/object-storage/swift/private-container.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 In order to create a Swift container, be sure that you have
-[installed and configured](../) the required command-line interface
+[installed and configured](index.md) the required command-line interface
 (CLI) tools.
 
 

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -6,7 +6,7 @@ description: You can use the Swift API to configure a container with public read
 ## Prerequisites
 
 In order to create a Swift container, be sure that you have
-[installed and configured](../) the required command-line interface
+[installed and configured](index.md) the required command-line interface
 (CLI) tools.
 
 

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -7,7 +7,7 @@ to it. This is known as a *temporary* URL, or TempURL.
 ## Prerequisites
 
 In order to manage TempURLs, be sure that you have [installed and
-configured](../) the `swift` command-line interface (CLI). There is
+configured](index.md) the `swift` command-line interface (CLI). There is
 presently no way to create TempURLs with the `openstack` CLI.
 
 Also, ensure that you have configured a [private

--- a/docs/howto/object-storage/swift/versioning.md
+++ b/docs/howto/object-storage/swift/versioning.md
@@ -6,7 +6,7 @@ of an object, rather than overwriting it in place.
 ## Prerequisites
 
 In order to manage object versioning, be sure that you have [installed
-and configured](../) the `swift` command-line interface (CLI). There
+and configured](index.md) the `swift` command-line interface (CLI). There
 is presently no way to set object expiry with the `openstack` CLI.
 
 Also, ensure that you have configured a [private

--- a/docs/howto/openstack/magnum/new-k8s-cluster.md
+++ b/docs/howto/openstack/magnum/new-k8s-cluster.md
@@ -8,9 +8,9 @@ CLI.
 ## Prerequisites
 
 First and foremost, you need an [account in
-{{brand}}](/howto/getting-started/create-account). Should you choose to
+{{brand}}](../../getting-started/create-account.md). Should you choose to
 work from your terminal, you will also need to [enable the OpenStack
-CLI](/howto/getting-started/enable-openstack-cli). In that case, in
+CLI](../../getting-started/enable-openstack-cli.md). In that case, in
 addition to the Python `openstackclient` module, make sure you also
 install the corresponding plugin module for Magnum. Use either the
 package manager of your operating system or `pip`:

--- a/docs/howto/openstack/neutron/create-security-groups.md
+++ b/docs/howto/openstack/neutron/create-security-groups.md
@@ -11,7 +11,7 @@ the default rules for their group and add new rule sets."_
 Navigate to the [{{gui}}](https://{{gui_domain}}) page, and log into
 your {{brand}} account. On the other hand, if you prefer to work with
 the OpenStack CLI, please do not forget
-to [source the RC file first](/howto/getting-started/enable-openstack-cli).
+to [source the RC file first](../../getting-started/enable-openstack-cli.md).
 
 === "{{gui}}"
     To create a security group click on _Security Groups_ in the left-hand
@@ -72,7 +72,7 @@ destination (egress) is allowed by default.
 
 > For accounts created before 2022-11-16, the default security
 > group ingress rules allow all incoming traffic.
-> See [Adjust permissive default security group](/howto/openstack/neutron/create-security-groups/#adjust-permissive-default-security-group),
+> See [Adjust permissive default security group](#adjust-permissive-default-security-group),
 > to learn how to configure this security group according to
 > our recommendations.
 

--- a/docs/howto/openstack/neutron/delete-network.md
+++ b/docs/howto/openstack/neutron/delete-network.md
@@ -9,9 +9,9 @@ either the {{gui}} or the OpenStack CLI.
 ## Prerequisites
 
 Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](/howto/getting-started/create-account) in
+you need to [have an account](../../getting-started/create-account.md) in
 {{brand}}. Additionally, to use the OpenStack CLI, make sure to [enable
-it](/howto/getting-started/enable-openstack-cli) for the region you
+it](../../getting-started/enable-openstack-cli.md) for the region you
 will be working in.
 
 ## Selecting a network

--- a/docs/howto/openstack/neutron/new-network.md
+++ b/docs/howto/openstack/neutron/new-network.md
@@ -8,9 +8,9 @@ a new network using the {{gui}}, or using the OpenStack CLI.
 ## Prerequisites
 
 Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](/howto/getting-started/create-account)
+you need to [have an account](../../getting-started/create-account.md)
 in {{brand}}. Additionally, to use the OpenStack CLI make sure to
-[enable it first](/howto/getting-started/enable-openstack-cli).
+[enable it first](../../getting-started/enable-openstack-cli.md).
 
 ## Creating a network
 

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -10,9 +10,9 @@ CLI. Let us demonstrate the process following both approaches.
 ## Prerequisites
 
 Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](/howto/getting-started/create-account) in
+you need to [have an account](../../getting-started/create-account.md) in
 {{brand}}. If you prefer to work with the [OpenStack
-CLI](/howto/getting-started/enable-openstack-cli), then in addition to
+CLI](../../getting-started/enable-openstack-cli.md), then in addition to
 the Python `openstackclient` module, you need to install the
 Python `neutronclient` module also. Use either the package manager
 of your operating system or `pip`:
@@ -36,7 +36,7 @@ your favorite web browser, navigate to the
 [{{gui}}](https://{{gui_domain}}) start page, and log into your
 {{brand}} account. Should you decide to follow the OpenStack CLI route
 instead, please make sure you have the appropriate [RC
-file](/howto/getting-started/enable-openstack-cli) for each region
+file](../../getting-started/enable-openstack-cli.md) for each region
 involved.
 
 === "{{gui}}"

--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -28,7 +28,7 @@ the OpenStack CLI.
     account if you have to.
 === "OpenStack CLI"
     To work with the OpenStack CLI, make sure to properly [enable
-    it](/howto/getting-started/enable-openstack-cli) for the region your
+    it](../../getting-started/enable-openstack-cli.md) for the region your
     boot-from-image server resides in.
 
 ## Shutting down the server
@@ -316,7 +316,7 @@ the OpenStack CLI.
     ![Choosing a flavor](assets/bfi-to-bfv/shot12.png)
 
     Consider leaving the [*Disaster
-    recovery*](/background/disaster-recovery) option enabled, and see if you
+    recovery*](../../../background/disaster-recovery.md) option enabled, and see if you
     want an external IP address for the server.
 
     ![Enabling disaster recovery and asking for external IP](assets/bfi-to-bfv/shot13.png)

--- a/docs/howto/openstack/nova/move-server-between-regions.md
+++ b/docs/howto/openstack/nova/move-server-between-regions.md
@@ -20,7 +20,7 @@ In order to move a server from one region to another, you will need
 ## Finding a volume's ID
 
 To work with the OpenStack CLI, please do not forget to [source the RC
-file first](/howto/getting-started/enable-openstack-cli/).
+file first](../../getting-started/enable-openstack-cli.md).
 
 Use the ID of the server instead of using the server name. This will
 make sure that you are using the correct server.
@@ -345,7 +345,7 @@ openstack volume create --size <GB> --image <new_image_id> <new_volume_name>
 ## Creating a server from a volume
 
 Now you need to create the new server using the system volume. To
-create a new server, follow [this guide](../new-server/).
+create a new server, follow [this guide](new-server.md).
 
 === "{{gui}}"
     If you use the {{gui}}, when choosing a _boot source,_ select

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -1,7 +1,7 @@
 # Creating new servers
 
 Once you have an [account in
-{{brand}}](/howto/getting-started/create-account), you can create
+{{brand}}](../../getting-started/create-account.md), you can create
 virtual machines --- henceforth simply _servers_ --- using either the
 {{gui}} or the OpenStack CLI. Let us demonstrate the creation of a new
 server, following both approaches.
@@ -9,10 +9,10 @@ server, following both approaches.
 ## Prerequisites
 
 You need to [have at least one
-network](/howto/openstack/neutron/new-network) in the region you are
+network](../neutron/new-network.md) in the region you are
 interested in. Additionally, if you prefer to work with the OpenStack
 CLI, then make sure to properly [enable it
-first](/howto/getting-started/enable-openstack-cli).
+first](../../getting-started/enable-openstack-cli.md).
 
 ## Creating a server
 
@@ -20,7 +20,7 @@ To create a server from the {{gui}}, fire up your favorite web
 browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page,
 and log into your {{brand}} account. On the other hand, if you prefer
 to work with the OpenStack CLI, please do not forget to [source the RC
-file first](/howto/getting-started/enable-openstack-cli).
+file first](../../getting-started/enable-openstack-cli.md).
 
 === "{{gui}}"
     On the top right-hand side of the {{gui}}, click the
@@ -48,7 +48,7 @@ file first](/howto/getting-started/enable-openstack-cli).
 
     Next, make sure _Boot Target_ is set to _Volume (Recommended)_.
     Regarding the server's CPU core count and amount of memory, set the
-    [_Flavor_](/reference/flavors) accordingly.
+    [_Flavor_](../../../reference/flavors/index.md) accordingly.
     The default flavor specifies a server with 1 CPU core and 1GB of RAM.
     You can start with that or select a different configuration by clicking
     the dropdown menu at the right of _Flavor_. Please note that, depending on
@@ -129,7 +129,7 @@ file first](/howto/getting-started/enable-openstack-cli).
     for or, in the cases of `KEY_NAME` and `SERVER_NAME`, arbitrarily
     define.
 
-    Let us begin with the [_flavors_](/reference/flavors) (`FLAVOR_NAME`), which
+    Let us begin with the [_flavors_](../../../reference/flavors/index.md) (`FLAVOR_NAME`), which
     describe combinations of CPU core count and memory size. Each server has a
     distinct flavor, and to see all available flavors type:
 

--- a/docs/howto/openstack/nova/resize-server.md
+++ b/docs/howto/openstack/nova/resize-server.md
@@ -3,7 +3,7 @@
 This guide will walk you through the required steps to change the
 number of CPU cores and the amount of memory your server has access
 to, this is done by changing the server's
-[flavor](/reference/flavors/).
+[flavor](../../../reference/flavors/index.md).
 
 [Resize](https://docs.openstack.org/nova/latest/admin/configuration/resize.html)
 (or Server resize) is the ability to change the flavor of a server,
@@ -18,7 +18,7 @@ resize operation is a two-step process for the user:
 
 You need to have a server you wish to resize. Additionally, if you
 prefer to work with the OpenStack CLI, then make sure to properly
-[enable it first](/howto/getting-started/enable-openstack-cli/).
+[enable it first](../../getting-started/enable-openstack-cli.md).
 
 ## Listing available flavors
 
@@ -74,7 +74,7 @@ prefer to work with the OpenStack CLI, then make sure to properly
 
 Choose a new flavor that you want your server to use instead.
 
-> A resize is only possible with [flavors](/reference/flavors) using
+> A resize is only possible with [flavors](../../../reference/flavors/index.md) using
 > the same prefix letter. Most commonly you will have a `b.` flavor,
 > thus you must select another `b.` flavor.
 

--- a/docs/howto/openstack/nova/restore-srv-to-snap.md
+++ b/docs/howto/openstack/nova/restore-srv-to-snap.md
@@ -4,7 +4,7 @@ description: How to restore a server to a particular snapshot
 # Restoring server to a snapshot
 
 Servers in {{brand}} that have the [disaster
-recovery](/background/disaster-recovery) feature enabled can go back in
+recovery](../../../background/disaster-recovery.md) feature enabled can go back in
 time, meaning you may restore such a server to one of the available
 point-in-time snapshots. Here is how you can do that.
 

--- a/docs/howto/openstack/nova/server-group.md
+++ b/docs/howto/openstack/nova/server-group.md
@@ -7,7 +7,7 @@ In {{brand}}, you can use server groups to control the scheduling of a group of 
 
 ## Prerequisites
 
-In order to use server groups you must use the OpenStack CLI. Make sure you have [enabled it](/howto/getting-started/enable-openstack-cli).
+In order to use server groups you must use the OpenStack CLI. Make sure you have [enabled it](../../getting-started/enable-openstack-cli.md).
 
 ## Policies
 

--- a/docs/howto/openstack/octavia/lbaas-l7pol.md
+++ b/docs/howto/openstack/octavia/lbaas-l7pol.md
@@ -34,7 +34,7 @@ policy, and set of rules to an existing HTTPS-terminated load balancer.
 
 The {{gui}} does not support defining L7 policies and rules, so you
 will have to work with the OpenStack CLI. [Enable
-it](/howto/getting-started/enable-openstack-cli) for the region you
+it](../../getting-started/enable-openstack-cli.md) for the region you
 will be working in, and make sure you have the Python `octaviaclient`
 module installed. For that, use either the package manager of your
 operating system or `pip`:

--- a/docs/howto/openstack/octavia/lbaas-tcp.md
+++ b/docs/howto/openstack/octavia/lbaas-tcp.md
@@ -12,9 +12,9 @@ work using either the {{gui}} or the OpenStack CLI.
 ## Prerequisites
 
 Whether you choose the {{gui}} or the OpenStack CLI, you need to [have
-an account](/howto/getting-started/create-account) in {{brand}}.
+an account](../../getting-started/create-account.md) in {{brand}}.
 Additionally, to use the OpenStack CLI, make sure to [enable
-it](/howto/getting-started/enable-openstack-cli) for the region you
+it](../../getting-started/enable-openstack-cli.md) for the region you
 will be working in. Besides the Python `openstackclient` module, you
 will also have to install the Python `octaviaclient` module. For that,
 use either the package manager of your operating system or `pip`:

--- a/docs/reference/api/openstack/index.md
+++ b/docs/reference/api/openstack/index.md
@@ -8,8 +8,8 @@ Individual service APIs have their own detailed API reference documentation page
 
 You may also be interested in the [API Quick Start Guide](https://docs.openstack.org/api-quick-start/api-quick-start.html) for information about how to authenticate against the OpenStack API, and send API requests.
 
-> To access the OpenStack API in {{brand}}, you need to have an [account](../../../howto/getting-started/create-account), and also download a valid credentials file, as you would for
-[enabling the OpenStack CLI](../../../howto/getting-started/enable-openstack-cli).
+> To access the OpenStack API in {{brand}}, you need to have an [account](../../../howto/getting-started/create-account.md), and also download a valid credentials file, as you would for
+[enabling the OpenStack CLI](../../../howto/getting-started/enable-openstack-cli.md).
 > All actions exposed via the OpenStack CLI are also available by calling the API directly.
 
 ## OpenStack SDKs

--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -14,7 +14,7 @@
 
 |                                               | Sto1HS                | Sto2HS                |
 | -------------                                 | ----------------      | --------------------- |
-| [Virtual GPU](../../flavors/#compute-tiers)   | :material-timer-sand: | :material-timer-sand: |
+| [Virtual GPU](../flavors/index.md#compute-tiers)   | :material-timer-sand: | :material-timer-sand: |
 
 
 ## Block storage
@@ -22,8 +22,8 @@
 |                                                                 | Sto1HS           | Sto2HS           |
 | ------------------------------                                  | ---------------- | ---------------- |
 | Highly available storage                                        | :material-check: | :material-check: |
-| [High-performance local storage](../../flavors/#compute-tiers)  | :material-close: | :material-close: |
-| [Volume encryption](/howto/openstack/cinder/encrypted-volumes/) | :material-check: | :material-check: |
+| [High-performance local storage](../flavors/index.md#compute-tiers)  | :material-close: | :material-close: |
+| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: |
 
 
 ## Object storage
@@ -31,8 +31,8 @@
 |                                                         | Sto1HS           | Sto2HS           |
 | ------------------------------                          | ---------------- | ---------------- |
 | S3 API                                                  | :material-check: | :material-check: |
-| S3 [SSE-C](/howto/object-storage/s3/sse-c/)             | :material-check: | :material-check: |
-| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-check: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-check: |
 | Swift API                                               | :material-check: | :material-check: |
 
 
@@ -51,4 +51,4 @@
 | --------------------------------------------------------------------                                        | ---------------- | ---------------- |
 | Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: |
 | Application layer (HTTP)                                                                                    | :material-check: | :material-check: |
-| Application layer ([HTTPS, with secrets management for TLS certificates](/howto/openstack/octavia/tls-lb/)) | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: |

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -12,23 +12,23 @@
 ## Virtualization
 |                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Virtual GPU](../../flavors/#compute-tiers)   | :material-check: | :material-check:      | :material-close: | :material-close: | :material-close: |
+| [Virtual GPU](../flavors/index.md#compute-tiers)   | :material-check: | :material-check:      | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage
 |                                                                 | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | ------------------------------                                  | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | Highly available storage                                        | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| [High-performance local storage](../../flavors/#compute-tiers)  | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: |
-| [Volume encryption](/howto/openstack/cinder/encrypted-volumes/) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [High-performance local storage](../flavors/index.md#compute-tiers)  | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: |
+| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Object storage
 |                                                         | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
 | ------------------------------                          | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | S3 API                                                  | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| S3 [SSE-C](/howto/object-storage/s3/sse-c/)             | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| S3 [object lock](/howto/object-storage/s3/object-lock/) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
 | Swift API                                               | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
 
 
@@ -45,7 +45,7 @@
 | --------------------------------------------------------------------                                        | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
 | Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | Application layer (HTTP)                                                                                    | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer ([HTTPS, with secrets management for TLS certificates](/howto/openstack/octavia/tls-lb/)) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Kubernetes management

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -36,9 +36,9 @@ general-purpose compute instance with 4 cores and 32 GiB RAM.
   storage. This makes them flexible to migrate within the
   {{brand}} infrastructure, without interruption.
   Some
-  [limitations](../../howto/openstack/cinder/encrypted-volumes/#block-device-encryption-caveats)
+  [limitations](../../howto/openstack/cinder/encrypted-volumes.md#block-device-encryption-caveats)
   apply to instances with attached [encrypted
-  volumes](../../howto/openstack/cinder/encrypted-volumes/).
+  volumes](../../howto/openstack/cinder/encrypted-volumes.md).
 * `s`: High-performance local storage. Instances
   launched with matching flavors use local, directly-attached
   storage. This generally provides higher throughput and lower

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -17,7 +17,7 @@ We group these into two major categories:
 
 This section does *not* include detailed walkthroughs of specific
 technical tasks. For those, please see our [How-To
-Guides](../howto/) section.
+Guides](../howto/index.md) section.
 
 > If you find our tutorials helpful, you might also be interested in
 > our self-paced online training courses, available from [our course


### PR DESCRIPTION
Newer versions of MkDocs rightfully flag links that point to relative
or absolute URL paths in the rendered tree as issues. Update those
links to pointers to their respective Markdown sources instead, so
that MkDocs can on its own figure out the correct links when rendering.
