### PR TITLE
build: Post pull request comments on build check failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           - '3.9'
           - '3.10'
 
-name: Build
+name: build
 
 # We want to run this workflow on each push to a topic branch, and on
 # each pull request. Once we merge to main, we want to run the

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           tox -e check-prod
 
-name: 'Check links'
+name: check
 
 # We want to run this workflow every time we build the site.
 # In addition, we want to run it once a week on a schedule.

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,20 @@
+# Post a comment back on a PR thread, in case an associated workflow
+# failed. Note that comment-failure-action is a no-op in case the
+# workflow was not invoked in response to a PR. In other words, this
+# action only creates comments for workflows configured with
+# "on: pull_request".
+---
+jobs:
+  comment-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: quipper/comment-failure-action@v0.1.1
+
+name: comment
+
+'on':
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Deploy to gh-pages
         run: tox -e deploy-github
 
-name: Deploy
+name: deploy
 
 'on':
   push:


### PR DESCRIPTION
Without this change, when a PR results in a build failure, the onus is on the PR submitter to find the failed build, and the corresponding build log. That is somewhat tedious and not particularly intuituive.

Instead, use a separate GitHub Action that posts a comment back to the PR thread, containing a direct link to the failed build log. This should hopefully make it easier for PR submitters to find out what exactly their submitted change breaks.

Reference:
https://github.com/quipper/comment-failure-action/pull/6