### PR TITLE
Expand reference section on image metadata, add image inspection how-to

### DIFF
--- a/docs/howto/openstack/glance/.pages
+++ b/docs/howto/openstack/glance/.pages
@@ -1,4 +1,5 @@
 title: Glance (image service)
 nav:
   - index.md
+  - examine.md
   - filter.md

--- a/docs/howto/openstack/glance/examine.md
+++ b/docs/howto/openstack/glance/examine.md
@@ -1,0 +1,39 @@
+# Examining images
+
+You can use the `openstack` CLI in combination with the [`jq`](https://jqlang.github.io/jq/) command-line JSON processor to inspect an image's properties.
+
+## Default user
+
+The `image_original_user` property reflects the username of the default non-root user of the corresponding operating system -- and that piece of information may come in handy in various automation scenarios.
+So, to find out the username of the default non-root user in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image, you can type the following:
+
+```console
+$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
+    | jq '.properties.image_original_user'
+"ubuntu"
+```
+
+## Image update frequency
+
+Images in {{brand}} are updated regularly, and that is something you can deduce from the `replace_frequency` property.
+See, for example, the value of this property in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image:
+
+```console
+$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
+    | jq '.properties.replace_frequency'
+"monthly"
+```
+
+Per [the SCS reference](https://docs.scs.community/standards/scs-0102-v1-image-metadata/#image-updating), `monthly` here means that the image is replaced *at least once* per month.
+Newer images have operating systems with all the latest package updates and security fixes.
+
+
+## Image build date
+
+To find out when a particular image was most recently updated, inspect its `image_build_date` property:
+
+```console
+openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
+    | jq '.properties.image_build_date'
+"2023-08-11"
+```

--- a/docs/reference/images/index.md
+++ b/docs/reference/images/index.md
@@ -48,3 +48,27 @@ All public images available in {{brand}} support the following image properties:
 * `os_version=${VERSION_ID}`: operating system version, such as `os_version=22.04`
 
 [Other properties](https://docs.openstack.org/glance/latest/admin/useful-image-properties.html) may also be set on individual images.
+For instance, the `image_original_user` property reflects the username of the default non-root user of the corresponding operating system -- and that piece of information may come in handy in various automation scenarios.
+So, to find out the username of the default non-root user in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image, you can type the following:
+
+```console
+$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
+    | jq '.properties.image_original_user'
+"ubuntu"
+```
+
+## Image updates and automation
+
+Images in {{brand}} are updated regularly, and that is something you can deduce from the `replace_frequency` property.
+See, for example, the value of this property in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image:
+
+```console
+$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
+    | jq '.properties.replace_frequency'
+"monthly"
+```
+
+Per [the SCS reference](https://docs.scs.community/standards/scs-0102-v1-image-metadata/#image-updating), `monthly` here means that the image is replaced *at least once* per month.
+Newer images have operating systems with all the latest package updates and security fixes.
+Whenever a fresh version of an image is produced and made available, it has the exact same name as the previous version but a *different* UUID.
+That is why in Ansible Playbooks, Heat templates, Terraform configurations, or your automation in general, you should refrain from using UUIDs and refer to images by name instead.

--- a/docs/reference/images/index.md
+++ b/docs/reference/images/index.md
@@ -31,6 +31,7 @@ Image names in {{brand}} follow a convention, which can be summarized as `${NAME
 
 Each public image is assigned a specific set of tags and properties.
 You can use these tags to [filter and list](../../howto/openstack/glance/filter.md) images based on certain conditions.
+You may also use them to simply [examine](../../howto/openstack/glance/examine.md) how an image is configured.
 
 ### Tags
 
@@ -48,27 +49,4 @@ All public images available in {{brand}} support the following image properties:
 * `os_version=${VERSION_ID}`: operating system version, such as `os_version=22.04`
 
 [Other properties](https://docs.openstack.org/glance/latest/admin/useful-image-properties.html) may also be set on individual images.
-For instance, the `image_original_user` property reflects the username of the default non-root user of the corresponding operating system -- and that piece of information may come in handy in various automation scenarios.
-So, to find out the username of the default non-root user in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image, you can type the following:
-
-```console
-$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
-    | jq '.properties.image_original_user'
-"ubuntu"
-```
-
-## Image updates and automation
-
-Images in {{brand}} are updated regularly, and that is something you can deduce from the `replace_frequency` property.
-See, for example, the value of this property in the `Ubuntu 22.04 Jammy Jellyfish x86_64` image:
-
-```console
-$ openstack image show -f json "Ubuntu 22.04 Jammy Jellyfish x86_64" \
-    | jq '.properties.replace_frequency'
-"monthly"
-```
-
-Per [the SCS reference](https://docs.scs.community/standards/scs-0102-v1-image-metadata/#image-updating), `monthly` here means that the image is replaced *at least once* per month.
-Newer images have operating systems with all the latest package updates and security fixes.
-Whenever a fresh version of an image is produced and made available, it has the exact same name as the previous version but a *different* UUID.
-That is why in Ansible Playbooks, Heat templates, Terraform configurations, or your automation in general, you should refrain from using UUIDs and refer to images by name instead.
+In particular, {{brand}} aims to set image properties according to the [metadata standard](https://docs.scs.community/standards/scs-0102-v1-image-metadata/) defined by the [Sovereign Cloud Stack](https://scs.community/) (SCS) initiative.


### PR DESCRIPTION
This is the continuation of #220, created to avoid force-push issues.