### PR TITLE
fix: Insert missing article in heading

### DIFF
--- a/docs/howto/openstack/nova/restore-srv-to-snap.md
+++ b/docs/howto/openstack/nova/restore-srv-to-snap.md
@@ -1,7 +1,7 @@
 ---
 description: How to restore a server to a particular snapshot
 ---
-# Restoring server to a snapshot
+# Restoring a server to a snapshot
 
 Servers in {{brand}} that have the [disaster
 recovery](../../../background/disaster-recovery.md) feature enabled can go back in


### PR DESCRIPTION
Most how-to guides in the openstack/nova section use a heading along the lines of "Doing X to a server", rather than "Doing X to server".

The how-to guide on restoring from a snapshot was the only deviation from this. Inject the indefinite article into the heading, in order to be in line with the other headings.