### PR TITLE
fix: Revert vGPU support to "in deployment, not yet supported"

### DIFF
--- a/docs/howto/openstack/nova/new-vgpu-server.md
+++ b/docs/howto/openstack/nova/new-vgpu-server.md
@@ -1,8 +1,12 @@
 # Creating new servers with virtual GPU support
 
-In {{brand}}, you can instantiate virtual machines --- or simply
-_servers_ --- with virtual GPU (vGPU) support. For that, you use the
-`openstack` CLI utility.
+In select {{brand}}
+[Public Cloud](../../../reference/features/public.md#virtualization)
+and
+[Compliant Cloud](../../../reference/features/compliant.md#virtualization)
+regions, you can instantiate virtual machines --- or simply _servers_
+--- with virtual GPU (vGPU) support. For that, you use the `openstack`
+CLI utility.
 
 ## Prerequisites
 

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -10,9 +10,9 @@
 
 
 ## Virtualization
-|                                               | Kna1             | Sto2                  | Fra1             | Dx1              | Tky1             |
-| -------------                                 | ---------------- | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Virtual GPU](../flavors/index.md#compute-tiers)   | :material-check: | :material-check:      | :material-close: | :material-close: | :material-close: |
+|                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              | Tky1             |
+| -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- | ---------------- |
+| [Virtual GPU](../../howto/openstack/nova/new-vgpu-server.md) | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage


### PR DESCRIPTION
Given the fact that it is not yet possible to launch a vGPU-enabled server using CCMP, err on the side of caution and mark it as "in deployment, not yet supported" rather than "in production and fully supported".

However, now that we have a how-to guide for launching vGPU enabled servers, link that how-to rather than just the flavor reference. Also, update the how-to explaining that vGPU support is only available in select regions, and add a backlink to the feature support matrix.