### PR TITLE
build: Remove the test-theme testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,13 +27,6 @@ setenv =
 commands =
   mkdocs serve {posargs}
 
-[testenv:test-theme]
-deps =
-  {[testenv]deps}
-  mkdocs-{posargs}
-commands =
-  mkdocs serve -t {posargs}
-
 [testenv:build]
 commands =
   mkdocs build --strict


### PR DESCRIPTION
Using `{posargs}` in a `deps` variable breaks in the `tox` version that ships on Ubuntu Focal. It does work on later versions, but we are only using it in the `test-theme` testenv which we really don't need anymore. Thus, by dropping that testenv we can remove this breakage, and absolve people of having to `pip`-install `tox` on that platform.
