### PR TITLE
build: Add validation parameters to mkdocs.yml

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -13,7 +13,7 @@
 |                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              | Tky1             |
 | -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- | ---------------- |
 | [Virtual GPU](../../howto/openstack/nova/new-vgpu-server.md) | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
-| [Physical CPUs](../../flavors/#compute-tiers)                | :material-close:      | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
+| [Physical CPUs](../flavors/index.md#compute-tiers)           | :material-close:      | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
 
 
 ## Block storage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,3 +102,7 @@ theme:
       toggle:
         icon: material/lightbulb
         name: "Switch to light mode"
+validation:
+  absolute_links: warn
+  omitted_files: warn
+  unrecognized_links: warn


### PR DESCRIPTION
Since MkDocs 1.5, we can add a `validation` map to the configuration file, which we can use to upgrade validation `INFO` messages to the `WARNING` level — and this, in combination with the `--strict` setting in the `build` testenv, can flag such issues as errors. This is what we want, thus, set the values that MkDocs lists as "recommended settings for most sites (maximal strictness)".

Reference:
https://www.mkdocs.org/user-guide/configuration/#validation