### PR TITLE
fix: Add non-breaking spaces to brand names

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,11 +10,11 @@ extra:
   analytics:
     domain: docs.cleura.cloud
     provider: plausible
-  brand: "Cleura Cloud"
+  brand: "Cleura Cloud"
   brand_domain: "citycloud.com"
   company: "Cleura"
   company_domain: "cleura.com"
-  gui: "Cleura Cloud Management Panel"
+  gui: "Cleura Cloud Management Panel"
   gui_domain: "cleura.cloud"
   k8s_management_service: Gardener
   legal_docs:
@@ -38,9 +38,9 @@ extra:
       name: "Transfer Form"
       # yamllint disable-line rule:line-length
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"
-  rest_api: "Cleura Cloud REST API"
+  rest_api: "Cleura Cloud REST API"
   rest_api_domain: "rest.cleura.cloud"
-  support: "Service Center"
+  support: "Service Center"
   support_domain: "servicecenter.cleura.cloud"
   support_email: "support@cleura.com"
 extra_css:
@@ -78,7 +78,7 @@ plugins:
       # yamllint disable-line rule:truthy
       cards: !ENV [DOCS_ENABLE_SOCIAL_CARDS, True]
 repo_url: https://github.com/citynetwork/docs
-site_name: "Cleura Docs"
+site_name: "Cleura Docs"
 site_url: !ENV [DOCS_SITE_URL, "https://docs.cleura.cloud"]
 theme:
   custom_dir: theme


### PR DESCRIPTION
We generally want "Cleura Cloud" to not break across a newline, so update the extra variable to include a non-breaking space.  Also, ensure that "Cleura Cloud Management Panel" and "Cleura Cloud REST API" only break into two halves, as opposed to just randomly.