### PR TITLE
feat: Add Tutorials page

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -3,7 +3,7 @@
 nav:
   - index.md
   - howto
-#  - tutorials
+# - tutorials
   - background
   - reference
   - contrib

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,24 +1,41 @@
+---
+description: Our tutorials enable you to interactively explore specific cloud workloads in detail.
+search:
+  exclude: true
+---
+
 # About our tutorials
 
-Our tutorials are gentle introductions to {{brand}}. They
-generally require very little prior knowledge and assume only that you
-have access to a browser, or to a terminal.
+Our tutorials cover specific use cases in {{brand}}.
+We host them on our learning platform, [{{academy}}](https://{{academy_domain}}/).
 
-We group these into two major categories:
+Our tutorials generally require that you [have a {{brand}} account](../howto/getting-started/create-account.md), and that you are [registered](https://{{academy_domain}}/register) on {{academy}}.
+Access to our tutorials is free of charge, however any resources you create in a tutorial will be charged at [our normal rates](https://{{company_domain}}/pricing/).
+You may of course use your [free trial credit](https://{{company_domain}}/free-trial/) to run a tutorial.
 
-* **Browser-based tutorials** get you started on
-  {{brand}} using the
-  [{{gui}}](https://{{gui_domain}}/).
+> If you find our tutorials helpful, you might also be interested in our self-paced online training courses, available from [our course booking site](https://shop.{{company_domain}}).
 
-* **Terminal-based tutorials** introduce you to command-line
-  interfaces (CLIs) and their interaction with
-  {{brand}}’s web-based Application Programming
-  Interfaces (APIs).
+Our tutorials are grouped by general topics.
 
-This section does *not* include detailed walkthroughs of specific
-technical tasks. For those, please see our [How-To
-Guides](../howto/index.md) section.
+## Ansible tutorials
 
-> If you find our tutorials helpful, you might also be interested in
-> our self-paced online training courses, available from [our course
-> booking site](https://shop.{{company_domain}}).
+These tutorials cover how you can best automate virtual resources in {{brand}} using [Ansible](https://www.ansible.com/).
+
+* [Managing {{brand}} resources with Ansible](https://{{academy_domain}}/ct111): Use the `openstack.cloud` Ansible collection to create networks, routers, and servers in {{brand}}.
+* [Using an Ansible dynamic inventory to discover and manage {{brand}} servers](https://{{academy_domain}}/ct112): Use an Ansible dynamic inventory plugin to automate the discovery of your cloud resources, enabling the management of massively scalable virtual data centers in {{brand}}.
+
+## OpenStack Heat tutorials
+
+These tutorials cover the management of complex virtual resource assemblies ("stacks") in {{brand}} using the [OpenStack Heat](https://docs.openstack.org/heat/latest/) orchestration framework.
+
+* [Using OpenStack Heat to manage {{brand}} resources](https://{{academy_domain}}/ct113): Use OpenStack Heat to automate the creation, update, and configuration of {{brand}} resources.
+
+## Terraform tutorials
+
+These tutorials cover the deployment of virtual resources in {{brand}} using [Terraform](https://www.terraform.io/) configurations.
+
+* [Using Terraform to manage {{brand}} resources](https://{{academy_domain}}/ct114): Use Terraform to create and manage {{brand}} server and network resources.
+
+## Container tutorials
+
+* [Managing containerized workloads in {{brand}}](https://{{academy_domain}}/ct115): Deploy and manage Kubernetes clusters in {{brand}} with {{k8s_management_service}}.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ copyright: >
   </a>
 edit_uri: ./edit/main/docs
 extra:
+  academy: "Cleura Cloud Academy"
+  academy_domain: "academy.cleura.cloud"
   analytics:
     domain: docs.cleura.cloud
     provider: plausible

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ markdown_extensions:
   - tables
 plugins:
   - awesome-pages
+  - exclude-search
   - git-authors:
       enabled: true
       show_email_address: false

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv = DOCS_*
 deps =
   mkdocs
   mkdocs-awesome-pages-plugin
+  mkdocs-exclude-search
   mkdocs-git-authors-plugin>=0.6.5
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox


### PR DESCRIPTION
Add an index page to point to our tutorials on Cleura Cloud Academy.

Leave it hidden from the navigation and search for the time being.