### PR TITLE
fix: Mention limit of 25 concurrently attached volumes

### DIFF
--- a/docs/reference/limitations/openstack.md
+++ b/docs/reference/limitations/openstack.md
@@ -31,6 +31,11 @@ This means that you can run nested virtualization on servers booted from a CentO
 
 Furthermore, you must ensure that the Nova server [passes the `pcid` CPU feature flag](https://qemu-project.gitlab.io/qemu/system/qemu-cpu-models.html#important-cpu-features-for-intel-x86-hosts) to nested guests.
 
+### Maximum attached volumes per server
+
+A Nova [server](../../howto/openstack/nova/new-server.md) in {{brand}} can concurrently attach a maximum of 25 persistent volumes.
+This is a limitation of the `virtio-blk` storage driver that ships as part of the guest operating system's kernel.
+
 ## Neutron
 
 ### Dynamic routing

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands = yamllint {toxinidir}
 [testenv:markdownlint]
 envdir = {toxworkdir}/markdownlint
 deps =
-  pymarkdownlnt
+  pymarkdownlnt!=0.9.13
 commands = pymarkdown -c .pymarkdown.json scan -r docs
 
 [testenv:bumpversion]


### PR DESCRIPTION
When launching a Nova server in Cleura Cloud, using one of the images marked as public in Glance, the guest operating system gets VirtIO block (`virtio-blk`) devices to work with. In the guest operating system, these images are named `/dev/vda` for the boot block device, and `/dev/vdb`, `/dev/vdc` etc. for attached volumes. Since VirtIO only enumerates devices up to `/dev/vdz`, this means it can only handle 26 devices in total, and thus a single server can only ever attach 25 volumes concurrently.

Until we have the option of running from public images configured with `virtio-scsi` (which does not have this limitation), state that 25 is the maximum number of volumes that can be concurrently attached to a single server.