### PR TITLE
fix: Update version reference for Antelope

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -1,16 +1,12 @@
 # Service version matrix
 
-Services in {{brand}} are updated on a regular basis and
-on a rolling schedule.
+Services in {{brand}} are updated on a regular basis and on a rolling schedule.
 
-This section lists the cloud API service versions available in each
-{{brand}} region.
+This section lists the cloud API service versions available in each {{brand}} region.
 
-* [Public Cloud](public.md): versions running in our {{company}}
-  Public Cloud regions.
+* [Public Cloud](public.md): versions running in our {{company}} Public Cloud regions.
 
-* [Compliant Cloud](compliant.md): versions running in our
-  {{company}} Compliant Cloud regions.
+* [Compliant Cloud](compliant.md): versions running in our {{company}} Compliant Cloud regions.
 
 
 ## OpenStack Services
@@ -25,9 +21,6 @@ We return to the prior deployment schedule after the Antelope upgrade, and expec
 
 ## Ceph Services
 
-[Ceph major
-releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline)
-are also named, in alphabetical order, and occur on a roughly annual schedule.
+[Ceph major releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline) are also named in alphabetical order, and occur on a roughly annual schedule.
 
-{{brand}} currently runs Ceph
-[Quincy](https://docs.ceph.com/en/latest/releases/quincy).
+{{brand}} currently runs Ceph [Quincy](https://docs.ceph.com/en/latest/releases/quincy).

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -15,14 +15,12 @@ This section lists the cloud API service versions available in each
 
 ## OpenStack Services
 
-[OpenStack releases](https://releases.openstack.org) are named, in
-alphabetical order, and occur on a six-month release schedule. In
-{{company}} Public Cloud we upgrade OpenStack releases annually; this
-means that we deploy every other OpenStack release and skip the
-intervening one.
+[OpenStack releases](https://releases.openstack.org) are named in alphabetical order, and occur on a six-month release schedule.
+In {{company}} Public Cloud we upgrade OpenStack releases annually; this means that we normally deploy every other OpenStack release and skip the intervening one.
 
-{{brand}} currently runs OpenStack
-[Xena](https://releases.openstack.org/xena).
+{{brand}} currently runs OpenStack [Xena](https://releases.openstack.org/xena) and [Antelope](https://releases.openstack.org/antelope).
+The fact that {{brand}} has skipped the [Zed](https://releases.openstack.org/zed) release (in addition to [Yoga](https://releases.openstack.org/antelope), as we normally would have) is due to a one-time upstream release policy change.
+We return to the prior deployment schedule after the Antelope upgrade, and expect the next deployed release to be [Caracal](https://releases.openstack.org/caracal).
 
 
 ## Ceph Services

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1  | Sto2   | Fra1  | Dx1   | Tky1   |
-| ------------------------------ | ----- | ------ | ----- | ----- | ------ |
-| Barbican (secret storage)      | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Cinder (block storage)         | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Glance (image management)      | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Heat (orchestration)           | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Keystone (identity management) | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Magnum (container management)  | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Neutron (networking)           | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Nova (server virtualization)   | Xena  | Xena   | Xena  | Xena  | Xena   |
-| Octavia (load balancing)       | Xena  | Xena   | Xena  | Xena  | Xena   |
+|                                | Kna1  | Sto2   | Fra1  | Dx1   | Tky1     |
+| ------------------------------ | ----- | ------ | ----- | ----- | ------   |
+| Barbican (secret storage)      | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Cinder (block storage)         | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Glance (image management)      | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Heat (orchestration)           | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Keystone (identity management) | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Magnum (container management)  | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Neutron (networking)           | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Nova (server virtualization)   | Xena  | Xena   | Xena  | Xena  | Antelope |
+| Octavia (load balancing)       | Xena  | Xena   | Xena  | Xena  | Antelope |
 
 
 ## Ceph Services


### PR DESCRIPTION
* Mention that Public Cloud is transitioning to Antelope (from Xena).
* Explain why we skip both Yoga and Zed, as opposed to just Yoga.
* Update the OpenStack version for Tky1 to Antelope.