### PR TITLE
build: Fix link checks

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,0 +1,10 @@
+[checking]
+recursionlevel=2
+
+[filtering]
+# Check external links (i.e. ones not within the domain given as a
+# command-line argument).
+checkextern=1
+
+# Don't fail on links that result in HTTP 301 or 302, rather than 200.
+ignorewarnings=http-redirected

--- a/docs/background/kubernetes/gardener/autoscaling.md
+++ b/docs/background/kubernetes/gardener/autoscaling.md
@@ -35,7 +35,7 @@ This is by design: if the dip in resource utilization is only temporary, suffici
 
 Autoscaling may sometimes not occur when you expect it to, including the following situations:
 
-* If a Pod [spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#object-spec-and-status) contains a [request](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) that is impossible to meet even *with* scale-out, no autoscaling occurs.
+* If a Pod [spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/#object-spec-and-status) contains a [request](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) that is impossible to meet even *with* scale-out, no autoscaling occurs.
   For example, if a Pod were to request 1TiB of memory, and the configured worker node [flavor](../../../reference/flavors/index.md) has less than that, then scale-out would not help:
   to run such a Pod, you would instead have to add a new worker group (with a larger flavor) to the cluster.
 

--- a/docs/background/kubernetes/gardener/garden-linux.md
+++ b/docs/background/kubernetes/gardener/garden-linux.md
@@ -3,7 +3,7 @@ description: Gardener in Cleura Cloud runs its worker and control plane nodes on
 ---
 # Garden Linux
 
-In a {{k8s_management_service}} cluster, worker nodes run [Garden Linux](https://gardenlinux.io), which is a [Linux distribution](https://en.wikipedia.org/wiki/Linux_distribution) based on [Debian GNU/Linux](https://debian.org/).
+In a {{k8s_management_service}} cluster, worker nodes run [Garden Linux](https://gardenlinux.io), which is a [Linux distribution](https://en.wikipedia.org/wiki/Linux_distribution) based on [Debian GNU/Linux](https://www.debian.org/).
 
 ## Version scheme
 

--- a/docs/background/kubernetes/gardener/hibernation.md
+++ b/docs/background/kubernetes/gardener/hibernation.md
@@ -37,7 +37,7 @@ In Kubernetes, a
 [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 (or *PV*), is a piece of storage in the cluster that has been
 provisioned either dynamically (using [Storage
-Classes](https://kubernetes.io/docs/concepts/storage/storage-classes))
+Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/))
 or by an administrator. When a user makes a request for storage, then we
 have a
 [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)

--- a/docs/background/object-storage.md
+++ b/docs/background/object-storage.md
@@ -2,7 +2,7 @@
 
 Object storage in {{brand}} is implemented via the [Ceph Object Gateway](https://docs.ceph.com/en/latest/radosgw/index.html), also known as `radosgw` (commonly pronounced "[rados](https://ceph.io/assets/pdfs/weil-rados-pdsw07.pdf) gateway").
 
-This facility exposes access to objects via two RESTful APIs: the [Amazon S3 API](http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html), and the [OpenStack Swift API](https://docs.openstack.org/api-ref/object-store/).
+This facility exposes access to objects via two RESTful APIs: the [Amazon S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/), and the [OpenStack Swift API](https://docs.openstack.org/api-ref/object-store/).
 It is, however, important to understand that radosgw shares no code with Amazon S3, nor with OpenStack Swift.
 
 As such, object storage in {{brand}} is not expected to behave *exactly* as Amazon S3 or OpenStack Swift, although it tracks their behavior very closely.

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -3,7 +3,7 @@ description: SSE-C provides server-side S3 object encryption with pre-shared sec
 ---
 # Server-side object encryption with customer-provided keys (SSE-C)
 
-You can use object encryption via the S3 API, according to the [Amazon SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) specification.
+You can use object encryption via the S3 API, according to the [Amazon SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html) specification.
 This means that you need to provide an encryption/decryption key with each request to the object.
 
 You can store the encryption key in [Barbican](../../openstack/barbican/index.md), and provide it to the S3 client at runtime.

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -115,7 +115,7 @@ hello world
 
 If you (or someone else) were to attempt to fetch the same URL *after*
 its lifetime expired, they would be met with an [HTTP
-401](http://http.cat/401) error:
+401](https://http.cat/401) error:
 
 ```console
 $ curl -i 'https://swift-fra1.{{brand_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'

--- a/docs/howto/openstack/magnum/new-k8s-cluster.md
+++ b/docs/howto/openstack/magnum/new-k8s-cluster.md
@@ -1,7 +1,7 @@
 # Creating a Kubernetes cluster
 
 By employing OpenStack
-[Magnum](https://docs.openstack.org/magnum/latest) you can create
+[Magnum](https://docs.openstack.org/magnum) you can create
 Kubernetes clusters via OpenStack, using the {{gui}} or the OpenStack
 CLI.
 

--- a/docs/reference/limitations/object-storage.md
+++ b/docs/reference/limitations/object-storage.md
@@ -24,7 +24,7 @@ There is currently no support for [S3 bucket replication](https://docs.aws.amazo
 
 ### Bucket notifications
 
-There is currently no support for [S3 bucket notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/NotificationHowTo.html) in {{brand}}.
+There is currently no support for [S3 bucket notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html) in {{brand}}.
 
 ### Object lock retention modes
 

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -14,13 +14,13 @@ This section lists the cloud API service versions available in each {{brand}} re
 [OpenStack releases](https://releases.openstack.org) are named in alphabetical order, and occur on a six-month release schedule.
 In {{company}} Public Cloud we upgrade OpenStack releases annually; this means that we normally deploy every other OpenStack release and skip the intervening one.
 
-{{brand}} currently runs OpenStack [Xena](https://releases.openstack.org/xena) and [Antelope](https://releases.openstack.org/antelope).
-The fact that {{brand}} has skipped the [Zed](https://releases.openstack.org/zed) release (in addition to [Yoga](https://releases.openstack.org/antelope), as we normally would have) is due to a one-time upstream release policy change.
-We return to the prior deployment schedule after the Antelope upgrade, and expect the next deployed release to be [Caracal](https://releases.openstack.org/caracal).
+{{brand}} currently runs OpenStack [Xena](https://releases.openstack.org/xena/) and [Antelope](https://releases.openstack.org/antelope/).
+The fact that {{brand}} has skipped the [Zed](https://releases.openstack.org/zed/) release (in addition to [Yoga](https://releases.openstack.org/yoga/), as we normally would have) is due to a one-time upstream release policy change.
+We return to the prior deployment schedule after the Antelope upgrade, and expect the next deployed release to be [Caracal](https://releases.openstack.org/caracal/).
 
 
 ## Ceph Services
 
 [Ceph major releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline) are also named in alphabetical order, and occur on a roughly annual schedule.
 
-{{brand}} currently runs Ceph [Quincy](https://docs.ceph.com/en/latest/releases/quincy).
+{{brand}} currently runs Ceph [Quincy](https://docs.ceph.com/en/latest/releases/quincy/).

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -44,8 +44,7 @@ fi
 
 # Actually run the link check
 linkchecker \
-  --check-extern \
-  --recursion-level 2 \
+  --config .linkcheckerrc \
   $linkchecker_ignore_options \
   $* \
   $DOCS_SITE_URL/sitemap.xml 


### PR DESCRIPTION
With the release of linkchecker 10.3.0, `tox -e check` has started to fail on *external* links in the documentation that happen to point to a target that is being redirected. The fix included here makes linkchecker ignore, specifically, its new `http-redirected` warning.

It also does fix *some* of the links that linkchecker flags when configured *not* to ignore `http-redirected`, but it does not make sense to change all such links — for about half of them, the redirect exists for a good reason. 