### PR TITLE
fix: Prometheus listeners now available in Fra1

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -47,7 +47,7 @@
 | Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | Application layer (HTTP)                                                                                    | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-close: | :material-check: | :material-close: | :material-check: |
 
 
 ## Kubernetes management


### PR DESCRIPTION
Prometheus listeners are now available in the Fra1 region, so we update the corresponding matrix accordingly.