### PR TITLE
fix: Prometheus listeners now available in Sto1HS

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -52,4 +52,4 @@
 | Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: |
 | Application layer (HTTP)                                                                                    | :material-check: | :material-check: |
 | Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: |
-| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                | :material-close: | :material-close: |
+| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                | :material-check: | :material-close: |


### PR DESCRIPTION
Prometheus listeners are now available in the Sto1HS region of the
Compliant Cloud, so we update the corresponding matrix accordingly.