### PR TITLE
build: Re-include external Cleura links in link check

### DIFF
--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-DOCS_LINKCHECK_IGNORE='.*apidoc\.cleura\.cloud .*s3-kna1\.citycloud\.com.* .*github\.com.*/edit/.*'
+DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
 
 if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"


### PR DESCRIPTION
Apparently the issues causing spurious connection resets on some of our servers have been fixed, so remove those from the `linkchecker` ignore list.

Re-enable link checks for apidoc.cleura.cloud: this reverts commit 7144ce63eece81205309d0815d8d98cb9a862cb0.

Re-enable link checks for s3-kna1.citycloud.com: this reverts commit 43274d46a6610829e34b630700e76ad364e88c1e.
