### PR TITLE
fix: Update the OpenStack Services matrix

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1     | Sto2   | Fra1      | Dx1   | Tky1     |
-| ------------------------------ | -----    | ------ | -----     | ----- | ------   |
-| Barbican (secret storage)      | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Cinder (block storage)         | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Glance (image management)      | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Heat (orchestration)           | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Keystone (identity management) | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Magnum (container management)  | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Neutron (networking)           | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Nova (server virtualization)   | Antelope | Xena   | Antelope  | Xena  | Antelope |
-| Octavia (load balancing)       | Antelope | Xena   | Antelope  | Xena  | Antelope |
+|                                | Kna1     | Sto2     | Fra1      | Dx1   | Tky1     |
+| ------------------------------ | -----    | ------   | -----     | ----- | ------   |
+| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Cinder (block storage)         | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Glance (image management)      | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Heat (orchestration)           | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Keystone (identity management) | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Magnum (container management)  | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Neutron (networking)           | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Xena  | Antelope |
+| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Xena  | Antelope |
 
 
 ## Ceph Services


### PR DESCRIPTION
The Antelope has landed in the Sto2 region of the Public Cloud, so we update the corresponding support matrix accordingly.