### PR TITLE
fix: Update the OpenStack Services matrix

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1     | Sto2     | Fra1      | Dx1   | Tky1     |
-| ------------------------------ | -----    | ------   | -----     | ----- | ------   |
-| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Cinder (block storage)         | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Glance (image management)      | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Heat (orchestration)           | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Keystone (identity management) | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Magnum (container management)  | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Neutron (networking)           | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Xena  | Antelope |
-| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Xena  | Antelope |
+|                                | Kna1     | Sto2     | Fra1      | Dx1       | Tky1     |
+| ------------------------------ | -----    | ------   | -----     | -----     | ------   |
+| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Cinder (block storage)         | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Glance (image management)      | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Heat (orchestration)           | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Keystone (identity management) | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Magnum (container management)  | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Neutron (networking)           | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Antelope  | Antelope |
 
 
 ## Ceph Services


### PR DESCRIPTION
The Antelope has landed in the Dx1 region of the Public Cloud, so we update the corresponding support matrix accordingly.