### PR TITLE
refactor: Introduce extra variable for container engine

### DIFF
--- a/docs/background/kubernetes/gardener/autoupgrades.md
+++ b/docs/background/kubernetes/gardener/autoupgrades.md
@@ -3,7 +3,7 @@ description: How auto-upgrading works in Gardener-managed Kubernetes clusters
 ---
 # Automatic upgrades
 
-By default, Kubernetes clusters created with {{k8s_management_service}} in {{brand}} are upgraded automatically.
+By default, Kubernetes clusters created with {{brand_container_orchestration}} are upgraded automatically.
 
 More specifically, during the specified maintenance window, {{k8s_management_service}} checks for a new Kubernetes version, and a new version of the base image that runs on the control plane and worker nodes.
 If there is a new version of any of those, the cluster starts upgrading automatically.

--- a/docs/background/kubernetes/gardener/garden-linux.md
+++ b/docs/background/kubernetes/gardener/garden-linux.md
@@ -1,5 +1,5 @@
 ---
-description: Gardener in Cleura Cloud runs its worker and control plane nodes on Garden Linux.
+description: Gardener runs its worker and control plane nodes on Garden Linux.
 ---
 # Garden Linux
 

--- a/docs/background/kubernetes/index.md
+++ b/docs/background/kubernetes/index.md
@@ -2,7 +2,7 @@
 
 {{brand}} has two management facilities for Kubernetes clusters:
 
-* [{{k8s_management_service}} in {{brand}}](../../howto/kubernetes/gardener/index.md),
+* [{{brand_container_orchestration}}](../../howto/kubernetes/gardener/index.md),
 * [OpenStack Magnum](../../howto/kubernetes/magnum/index.md).
 
 In most scenarios, {{k8s_management_service}} is the preferred option, since it supports more recent Kubernetes versions and offers you a greater degree of "hands-off" management.

--- a/docs/howto/kubernetes/gardener/create-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/create-shoot-cluster.md
@@ -8,7 +8,7 @@ This guide shows you how to do that, and how to deploy a sample application on s
 
 ## Prerequisites
 
-* If this is your first time using {{k8s_management_service}} in {{brand}}, you need to [activate the service](index.md) from the {{gui}}.
+* If this is your first time using {{brand_container_orchestration}}, you need to [activate the service](index.md) from the {{gui}}.
 * To access the Kubernetes cluster from your computer, you will need to [install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) on your machine.
 
 ## Creating a Kubernetes cluster in {{gui}}

--- a/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
+++ b/docs/howto/kubernetes/gardener/hibernate-shoot-cluster.md
@@ -10,7 +10,7 @@ cluster again), you will be paying *less* for the cluster.
 
 ## Prerequisites
 
-We assume you have already used {{k8s_management_service}} in {{brand}} to spin up a
+We assume you have already used {{brand_container_orchestration}} to spin up a
 Kubernetes cluster, which is now humming away. If you've never done
 this before, please feel free to [follow this
 guide](create-shoot-cluster.md).

--- a/docs/howto/kubernetes/gardener/index.md
+++ b/docs/howto/kubernetes/gardener/index.md
@@ -1,13 +1,13 @@
 # Gardener
 
-{{k8s_management_service}} in {{brand}} is a Kubernetes-native system that provides automated management and operation of Kubernetes clusters as a service.
+{{brand_container_orchestration}} is a Kubernetes-native system that provides automated management and operation of Kubernetes clusters as a service.
 It allows you to create clusters and automatically handle their lifecycle operations, including configurable maintenance windows, hibernation schedules, and automatic updates to Kubernetes control plane and worker nodes.
 
 You can read more about {{k8s_management_service}} and its capabilities on its [documentation website](https://gardener.cloud/docs/gardener/).
 
 ## Activating the {{k8s_management_service}} service
 
-To use {{k8s_management_service}} in {{brand}}, you first need to *activate* the service. You can conveniently do this via the {{gui}}.
+To use {{brand_container_orchestration}}, you first need to *activate* the service. You can conveniently do this via the {{gui}}.
 
 To activate {{k8s_management_service}}, select Containers → [{{k8s_management_service}}](https://{{gui_domain}}/containers/gardener) in the side panel.
 Then, click the _Activate {{k8s_management_service}} Service_ button:

--- a/docs/howto/kubernetes/gardener/kubectl.md
+++ b/docs/howto/kubernetes/gardener/kubectl.md
@@ -70,7 +70,7 @@ users:
 ```
 
 You will notice that the cluster API endpoint (the `server` entry in your kubeconfig) is a dynamically managed DNS address.
-{{k8s_management_service}} in {{brand}} automatically created the DNS record upon shoot cluster creation.
+{{brand_container_orchestration}} automatically created the DNS record upon shoot cluster creation.
 
 The DNS record will subsequently disappear when you delete the cluster.
 The DNS record *also* disappears when you [hibernate the shoot cluster](hibernate-shoot-cluster.md), and reappears when you wake it from hibernation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ extra:
     provider: plausible
   brand: "Cleura Cloud"
   brand_compliant: "Cleura Compliant Cloud"
+  brand_container_orchestration: "Gardener in Cleura Cloud"
   brand_domain: "citycloud.com"
   brand_public: "Cleura Public Cloud"
   company: "Cleura"


### PR DESCRIPTION
Our container orchestration engine brand, "Gardener in Cleura Cloud", may conceivably change at some point in the future. If that does happen, being able to change a single variable would facilitate the brand update.

Thus, include a new such variable, `brand_container_orchestration`, and set it to "Gardener in Cleura Cloud".
