### PR TITLE
fix: Update the OpenStack Services matrix

### DIFF
--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Sto1HS    | Sto2HS |
-| ------------------------------ | --------- | ------ |
-| Barbican (secret storage)      | Antelope  | Xena   |
-| Cinder (block storage)         | Antelope  | Xena   |
-| Glance (image management)      | Antelope  | Xena   |
-| Heat (orchestration)           | Antelope  | Xena   |
-| Keystone (identity management) | Antelope  | Xena   |
-| Magnum (container management)  | Antelope  | Xena   |
-| Neutron (networking)           | Antelope  | Xena   |
-| Nova (server virtualization)   | Antelope  | Xena   |
-| Octavia (load balancing)       | Antelope  | Xena   |
+|                                | Sto1HS    | Sto2HS    |
+| ------------------------------ | --------- | --------- |
+| Barbican (secret storage)      | Antelope  | Antelope  |
+| Cinder (block storage)         | Antelope  | Antelope  |
+| Glance (image management)      | Antelope  | Antelope  |
+| Heat (orchestration)           | Antelope  | Antelope  |
+| Keystone (identity management) | Antelope  | Antelope  |
+| Magnum (container management)  | Antelope  | Antelope  |
+| Neutron (networking)           | Antelope  | Antelope  |
+| Nova (server virtualization)   | Antelope  | Antelope  |
+| Octavia (load balancing)       | Antelope  | Antelope  |
 
 
 ## Ceph Services

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -14,7 +14,7 @@ This section lists the cloud API service versions available in each {{brand}} re
 [OpenStack releases](https://releases.openstack.org) are named in alphabetical order, and occur on a six-month release schedule.
 In {{brand_public}} we upgrade OpenStack releases annually; this means that we normally deploy every other OpenStack release and skip the intervening one.
 
-{{brand}} currently runs OpenStack [Xena](https://releases.openstack.org/xena/) and [Antelope](https://releases.openstack.org/antelope/).
+{{brand}} currently runs OpenStack [Antelope](https://releases.openstack.org/antelope/) in all regions.
 The fact that {{brand}} has skipped the [Zed](https://releases.openstack.org/zed/) release (in addition to [Yoga](https://releases.openstack.org/yoga/), as we normally would have) is due to a one-time upstream release policy change.
 We return to the prior deployment schedule after the Antelope upgrade, and expect the next deployed release to be [Caracal](https://releases.openstack.org/caracal/).
 


### PR DESCRIPTION
The Antelope has landed in the Sto2HS region of the Compliant Cloud, so we update the corresponding support matrix accordingly.

We also remove any mention of Xena in the docs, since this upgrade retires Xena across the entire Cleura Cloud universe.