### PR TITLE
build: Restrict mkdocs-material to 9.4.x versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox
   mkdocs-macros-plugin
-  mkdocs-material>=9.4.0
+  mkdocs-material~=9.4.0
   mkdocs-redirects
   pillow
   cairosvg


### PR DESCRIPTION
In version 9.5.0, the mkdocs-material project introduced a new way of interacting with the git-authors plugin. Rather than relying on that plugin to render information about page authors, mkdocs-material now does that rendering by itself:

https://github.com/squidfunk/mkdocs-material/blob/9.5.0/src/templates/partials/source-file.html#L57

In doing so, it unfortunately provides no facility to render just the author name, without their email address (a facility that *is*
available with the git-authors plugin). 

This is problematic for two reasons:

1. It might be a privacy concern, opening documentation contributors to spam from someone who scrapes the docs site for email addresses.

2. It breaks link checking, since some of the email addresses thus rendered are purposefully bogus (specifically,   `users.noreply.github.com` is a non-existent email domain since it lacks an MX record in the DNS).

Until this is fixed (or we find a suitable workaround), restrict mkdocs-material to 9.4.x versions.

References:
https://github.com/squidfunk/mkdocs-material/pull/6447
https://github.com/timvink/mkdocs-git-authors-plugin/pull/66
