### PR TITLE
build: Use git-committers plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 ---
 jobs:
   build:
+    env:
+      DOCS_ENABLE_COMMITTERS_PLUGIN: true
+      MKDOCS_GIT_COMMITTERS_APIKEY: "${{ secrets.GITHUB_TOKEN }}"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,9 @@
 ---
 jobs:
   check:
+    env:
+      DOCS_ENABLE_COMMITTERS_PLUGIN: true
+      MKDOCS_GIT_COMMITTERS_APIKEY: "${{ secrets.GITHUB_TOKEN }}"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 ---
 jobs:
   deploy:
+    env:
+      DOCS_ENABLE_COMMITTERS_PLUGIN: true
+      MKDOCS_GIT_COMMITTERS_APIKEY: "${{ secrets.GITHUB_TOKEN }}"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,9 +62,10 @@ markdown_extensions:
   - tables
 plugins:
   - awesome-pages
-  - git-authors:
-      enabled: true
-      show_email_address: false
+  - git-committers:
+      branch: main
+      enabled: !ENV [DOCS_ENABLE_COMMITTERS_PLUGIN, false]
+      repository: citynetwork/docs
   - git-revision-date-localized:
       enable_creation_date: true
       enabled: true

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,17 @@ envlist = yamllint,bashate,markdownlint,build
 
 [testenv]
 skip_install = True
-passenv = DOCS_*
+passenv =
+  DOCS_*
+  MKDOCS_*
 deps =
   mkdocs
   mkdocs-awesome-pages-plugin
-  mkdocs-git-authors-plugin>=0.6.5
+  mkdocs-git-committers-plugin-2
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox
   mkdocs-macros-plugin
-  mkdocs-material~=9.4.0
+  mkdocs-material>=9.4.0
   mkdocs-redirects
   pillow
   cairosvg


### PR DESCRIPTION
Rather than using `git-authors` (whose rendering functionality is now [natively included in mkdocs-material](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#document-authors), and which always wants to display a `mailto:` link containing authors' email addresses), use the `git-committers` plugin which instead links to contributors' GitHub accounts.

Since this relies on GitHub API calls that are rate-limited and potentially quite time-consuming during a local build, enable the
plugin only when running from GitHub Actions workflows.
