### PR TITLE
fix: Add missing descriptions to Nova how-to guides

### DIFF
--- a/docs/howto/openstack/nova/config-drive.md
+++ b/docs/howto/openstack/nova/config-drive.md
@@ -1,3 +1,6 @@
+---
+description: How to launch a virtual server with config drive support
+---
 # Launching a server with a configuration drive
 
 

--- a/docs/howto/openstack/nova/move-server-between-regions.md
+++ b/docs/howto/openstack/nova/move-server-between-regions.md
@@ -1,3 +1,6 @@
+---
+description: How to transfer a virtual server between Cleura Cloud regions
+---
 # Moving a server from one region to another
 
 This guide will show you how to move a server to a different region in

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -1,3 +1,6 @@
+---
+description: How to create a new virtual server in Cleura Cloud
+---
 # Creating new servers
 
 Once you have an [account in

--- a/docs/howto/openstack/nova/new-vgpu-server.md
+++ b/docs/howto/openstack/nova/new-vgpu-server.md
@@ -1,3 +1,6 @@
+---
+description: How to create a virtual server with graphics processing unit (GPU) support in Cleura Cloud
+---
 # Creating new servers with virtual GPU support
 
 In select

--- a/docs/howto/openstack/nova/rescue-server.md
+++ b/docs/howto/openstack/nova/rescue-server.md
@@ -1,3 +1,6 @@
+---
+description: How to access a virtual server in rescue mode
+---
 # Rescuing a server
 
 This guide will walk you through the required steps to access a server

--- a/docs/howto/openstack/nova/resize-server.md
+++ b/docs/howto/openstack/nova/resize-server.md
@@ -1,3 +1,6 @@
+---
+description: How to adjust the number of CPU cores and amount of memory for a virtual server
+---
 # Resizing a server
 
 This guide will walk you through the required steps to change the


### PR DESCRIPTION
Several of the how-to guides for OpenStack Nova were missing front
matter with a description field. Add that as appropriate.
