### PR TITLE
fix: Drop :8080 port suffix from S3 how-to guides

### DIFF
--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -66,16 +66,16 @@ How exactly you do that depends on your preferred client:
       aws_secret_access_key <secret-key>
     aws configure set \
       --profile <region> \
-      s3.endpoint_url https://s3-<region>.{{brand_domain}}:8080
+      s3.endpoint_url https://s3-<region>.{{brand_domain}}
     aws configure set \
       --profile <region> \
-      s3api.endpoint_url https://s3-<region>.{{brand_domain}}:8080
+      s3api.endpoint_url https://s3-<region>.{{brand_domain}}
     ```
 === "mc"
     Create a new alias, named after your {{brand}} region:
     ```bash
     mc alias set <region> \
-      https://s3-<region>.{{brand_domain}}:8080 \
+      https://s3-<region>.{{brand_domain}} \
       <access-key> <secret-key>
     ```
     Once you have configured an alias like this, you are able to
@@ -90,9 +90,9 @@ How exactly you do that depends on your preferred client:
 
     * Set your `Access Key` and `Secret Key` when prompted.
     * Leave `Default Region` unchanged.
-    * Set `S3 Endpoint` to `s3-<region>.{{brand_domain}}:8080`.
+    * Set `S3 Endpoint` to `s3-<region>.{{brand_domain}}`.
     * Set `DNS-style bucket+hostname:port template for accessing a bucket`
-      to `s3-<region>.{{brand_domain}}:8080` as well.
+      to `s3-<region>.{{brand_domain}}` as well.
     * Set `Use HTTPS protocol` to `Yes` (the default).
     * Configure GnuPG encryption and your HTTP proxy server, if needed.
     * Test access with your supplied credentials.
@@ -109,7 +109,7 @@ How exactly you do that depends on your preferred client:
     env_auth = false
     access_key_id = <access key id>
     secret_access_key = <secret key>
-    endpoint = <region>.{{brand_domain}}:8080
+    endpoint = <region>.{{brand_domain}}
     acl = private
     ```
 

--- a/docs/howto/object-storage/s3/object-lock.md
+++ b/docs/howto/object-storage/s3/object-lock.md
@@ -264,7 +264,7 @@ To display the legal hold status for an object, use the following command:
     ```json
     {
       "legalhold": "ON",
-      "urlpath": "https://s3-<region>.{{brand_domain}}:8080/<bucket>/<object-name>",
+      "urlpath": "https://s3-<region>.{{brand_domain}}/<bucket>/<object-name>",
       "key": "<object-name>",
       "versionID": "",
       "status": "success"

--- a/docs/howto/object-storage/s3/presign.md
+++ b/docs/howto/object-storage/s3/presign.md
@@ -52,7 +52,7 @@ The command will return the valid pre-signed URL.
 To access an object in a public bucket from a web browser or a generic HTTP/HTTPS client like `curl`, open the URL that the pre-sign command returned:
 
 ```console
-curl -f -O https://s3-<region>.{{brand_domain}}:8080/<bucket-name>/<object-name>?AWSAccessKeyId=<access-key>&Signature=<signature>&Expires=<expiry>
+curl -f -O https://s3-<region>.{{brand_domain}}/<bucket-name>/<object-name>?AWSAccessKeyId=<access-key>&Signature=<signature>&Expires=<expiry>
 ```
 
 As long as the query parameters are correct and the signature has not yet expired, this command will succeed.
@@ -64,7 +64,7 @@ If the query parameters are incorrect or the pre-signed URL is past its expiry d
 For example, to retrieve an object named `bar.pdf` in a bucket named `foo` in the {{brand}} Kna1 region via its pre-signed URL, you would run:
 
 ```console
-$ curl -o bar.pdf https://s3-kna1.{{brand_domain}}:8080/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D
+$ curl -o bar.pdf https://s3-kna1.{{brand_domain}}/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 62703  100 62703    0     0   186k      0 --:--:-- --:--:-- --:--:--  186k
@@ -143,7 +143,7 @@ To ensure that an object named `bar.pdf` in a bucket named `foo` is always downl
 Once you have set the `Content-Disposition` header on an object and created a pre-signed URL for it, you can test its functionality with the `curl -OJ` command:
 
 ```console
-$ curl -f -OJ 'https://s3-kna1.{{brand_domain}}:8080/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D'
+$ curl -f -OJ 'https://s3-kna1.{{brand_domain}}/foo/bar.pdf?AWSAccessKeyId=07576783684248f7b2745e34356c6025&Expires=1673521496&Signature=%2Frm9nLV3moP%2FQz7aGCAnrESXjbk%3D'
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 58503  100 58503    0     0   178k      0 --:--:-- --:--:-- --:--:--  178k

--- a/docs/howto/object-storage/s3/public-bucket.md
+++ b/docs/howto/object-storage/s3/public-bucket.md
@@ -53,7 +53,7 @@ To apply this policy to a bucket such that read-only access is permitted for eve
 To access an object in a public bucket from a web browser or a generic HTTP/HTTPS client like `curl`, you must construct its URI as follows:
 
 ```plain
-https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>/object-name
+https://s3-<region>.{{brand_domain}}/<project-uuid>:<bucket-name>/object-name
 ```
 
 > Your project UUID is listed as the `project_id` field in the output of the `openstack ec2 credentials create` command you used to [create your S3-compatible credentials](credentials.md).
@@ -63,7 +63,7 @@ https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>/object-na
 For example, to retrieve an object named `bar.pdf` in a bucket named `foo` from the project with the UUID `07576783684248f7b2745e34356c6025` in the {{brand}} Kna1 region, you would run:
 
 ```console
-$ curl -O https://s3-kna1.{{brand_domain}}:8080/07576783684248f7b2745e34356c6025:foo/bar.pdf
+$ curl -O https://s3-kna1.{{brand_domain}}/07576783684248f7b2745e34356c6025:foo/bar.pdf
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 62703  100 62703    0     0   186k      0 --:--:-- --:--:-- --:--:--  186k
@@ -75,8 +75,8 @@ Once you make a bucket public via the S3 API, its objects also become accessible
 
 Thus, the following URL paths allow you to retrieve the same public object:
 
-* `https://s3-kna1.{{brand_domain}}:8080/07576783684248f7b2745e34356c6025:foo/bar.pdf`
-* `https://swift-kna1.{{brand_domain}}:8080/swift/v1/AUTH_07576783684248f7b2745e34356c6025/foo/bar.pdf`
+* `https://s3-kna1.{{brand_domain}}/07576783684248f7b2745e34356c6025:foo/bar.pdf`
+* `https://swift-kna1.{{brand_domain}}/swift/v1/AUTH_07576783684248f7b2745e34356c6025/foo/bar.pdf`
 
 ## Enabling bucket listing
 
@@ -112,7 +112,7 @@ You can then open a bucket path in your browser, to retrieve an XML document con
 You would construct the URL by the following schema:
 
 ```plain
-https://s3-<region>.{{brand_domain}}:8080/<project-uuid>:<bucket-name>
+https://s3-<region>.{{brand_domain}}/<project-uuid>:<bucket-name>
 ```
 
 ## Removing a public read policy from a bucket

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -129,7 +129,7 @@ Once you have your encryption secret available, you can create or access enabled
        env_auth = false
        access_key_id = <access key id>
        secret_access_key = <secret key>
-       endpoint = <region>.{{brand_domain}}:8080
+       endpoint = <region>.{{brand_domain}}
        acl = private
        sse_customer_algorithm = AES256
        ```


### PR DESCRIPTION
Now that all our object storage services are listening on the regular HTTPS port (443), we no longer need to list the `:8080` suffix in our how-to guides for S3.
    
We still do need to keep the suffix in the how-to guides for Swift, since our `object-storage` endpoints in our service catalogs still do contain the `:8080` suffix.

