### PR TITLE
fix: Update Limitations section for Gardener with Kubernetes 1.27

### DIFF
--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -33,7 +33,7 @@ You cannot use `ReadWriteOncePod` (`RWOP`), `ReadWriteMany` (`RWX`), or `ReadOnl
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.26.5.
+The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.27.8.
 
 ### IP version
 


### PR DESCRIPTION
In the Limitations subsection of the reference, update the maximum
Kubernetes version we support with Gardener (to 1.27.8).
