### PR TITLE
fix: Add region decommission notes

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -7,7 +7,13 @@
 > :material-logout: Feature is deprecated, being phased out
 >
 > :material-close: Feature is not available
-
+> ## Sunset dates
+>
+> Please note that sunset dates have been set for the following {{brand}} regions:
+>
+> * The **Tky1** region will no longer be available after 2024-04-30.
+>
+> * The **Dx1** region will no longer be available after 2024-06-30.
 
 ## Virtualization
 |                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              | Tky1             |

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -1,5 +1,13 @@
 # Public Cloud
 
+> ## Sunset dates
+>
+> Please note that sunset dates have been set for the following {{brand}} regions:
+>
+> * The **Tky1** region will no longer be available after 2024-04-30.
+>
+> * The **Dx1** region will no longer be available after 2024-06-30.
+
 ## OpenStack Services
 
 |                                | Kna1     | Sto2     | Fra1      | Dx1       | Tky1     |


### PR DESCRIPTION
There are two planned decommission events:
* 2024-04-30: region Tky1
* 2024-06-30: region Dx1