### PR TITLE
fix: Bump latest Gardener-installable Kubernetes release to 1.28.6

### DIFF
--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -33,7 +33,7 @@ You cannot use `ReadWriteOncePod` (`RWOP`), `ReadWriteMany` (`RWX`), or `ReadOnl
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.27.8.
+The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.28.6.
 
 ### IP version
 


### PR DESCRIPTION
Update the limitations reference to reflect that Gardener in Cleura Cloud supports Kubernetes releases up to 1.28.6.
