### PR TITLE
fix: Bump DPA version (and validity dates)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,10 +29,10 @@ extra:
       short_name: "CC BY-SA"
       url: "https://creativecommons.org/licenses/by-sa/4.0/"
     cdpa:
-      last_updated: 2023-10-02
+      last_updated: 2024-03-22
       name: "Data Processing Agreement"
-      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Data_Processing_Agreement_for_Public_Cloud-V23.10.2.pdf"
-      valid_from: 2023-10-03
+      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Data_Processing_Agreement_for_Public_Cloud-V24.03.25.pdf"
+      valid_from: 2024-03-25
     termination_form:
       name: "Termination of Subscription Form"
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"


### PR DESCRIPTION
We have a new version of the DPA, effective 2024-03-25. Update the
link, and also update the effective date and the date it was last
modified.
