### PR TITLE
chore: One-sentence-per-line in index page for reference section

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,31 +1,21 @@
 # Reference
 
-This is our reference section. It serves to provide general reference
-information about {{brand}} services.
+This is our reference section.
+It serves to provide general reference information about {{brand}} services.
 
 ## Feature and service availability
 
-* Our **[Feature Support Matrix](features/index.md)** lists cloud
-  features and their availability across {{brand}}
-  regions.
+* Our **[Feature Support Matrix](features/index.md)** lists cloud features and their availability across {{brand}} regions.
 
 * The **[Limitations](limitations/index.md)** section lists support limitations for specific {{brand}} services.
 
-* The **[Flavors](flavors/index.md)** reference explains our naming
-  convention for pre-defined CPU/RAM/disk configurations ("flavors")
-  for server instances, and their availability across
-  {{brand}} regions.
+* The **[Flavors](flavors/index.md)** reference explains our naming convention for pre-defined CPU/RAM/disk configurations ("flavors") for server instances, and their availability across {{brand}} regions.
 
-* Our **[Service Version Matrix](versions/index.md)** lists the
-  open source software versions running in our {{brand}}
-  regions.
+* Our **[Service Version Matrix](versions/index.md)** lists the open source software versions running in our {{brand}} regions.
 
 ## API reference
 
-* The **[API reference](api/index.md)** documentation provides useful
-  information for accessing Application Programming Interfaces (APIs),
-  getting information, and manipulating all sorts of {{brand}}
-  objects.
+* The **[API reference](api/index.md)** documentation provides useful information for accessing Application Programming Interfaces (APIs), getting information, and manipulating all sorts of {{brand}} objects.
 
 ## Legal reference
 


### PR DESCRIPTION
Implement the one-sentence-per line convention in the `index.md` page for the reference section.

(This was originally in PR #272, but since that hasn't moved forward in months we should probably just merge this one as-is.)