### PR TITLE
build: Support Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
       matrix:
         python-version:
           - '3.8'
-          - '3.9'
           - '3.10'
+          - '3.12'
 
 name: build
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install Python dependencies
         run: |
           pip install tox

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install Python dependencies
         run: |
           pip install tox


### PR DESCRIPTION
Make sure we can build on Python 3.8 (Ubuntu Focal), Python 3.10 (Ubuntu Jammy), and Python 3.12 (latest Python release):
    
* Use Python 3.12 for the `check` and `deploy` GitHub Actions workflows
* Add Python 3.12 to the test matrix for the `build` workflow
* Drop Python 3.9 from the test matrix for the `build` workflow