### PR TITLE
fix: Update Magnum Kubernetes version

### DIFF
--- a/docs/background/kubernetes/index.md
+++ b/docs/background/kubernetes/index.md
@@ -14,7 +14,7 @@ For more details on the relative merits of both options, refer to the sections b
 | -------------                                                   | ----------------             | ----------------                      |
 | Kubernetes Cloud Provider                                       | OpenStack                    | OpenStack                             |
 | Base operating system for nodes                                 | Garden Linux                 | Fedora CoreOS                         |
-| Latest installable Kubernetes minor release                     | 1.29                         | 1.21                                  |
+| Latest installable Kubernetes minor release                     | 1.29                         | 1.24                                  |
 
 
 ## API and CLI support

--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -10,7 +10,7 @@ The legacy `swarm` and `mesos` COEs are not supported.
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with OpenStack Magnum is 1.21.14.
+The latest Kubernetes version you can install in {{brand}} with OpenStack Magnum is 1.24.16.
 
 ### IP version
 

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
+DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.* .*conventionalcommits.org.*'
 
 if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"


### PR DESCRIPTION
The latest Kubernetes release we can install in Magnum clusters in Cleura Cloud is 1.24, not 1.21. Update the relevant mentions in the background info and version reference pages.