### PR TITLE
fix: Explain that Cinder QoS limits are only enforced in Public Cloud

### DIFF
--- a/docs/reference/volumes/index.md
+++ b/docs/reference/volumes/index.md
@@ -4,12 +4,12 @@ The following volume types are available in {{brand}} for persistent block stora
 
 If you create a volume without specifying a volume type, then the default volume type applies.
 
-The maximum IOPS specification is essentially a cap, which creates an upper bound for individual device performance under *ideal* conditions.
-Actual IOPS may vary based on system load and utilization.
 
-| Volume type name               | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) | max IOPS |
-| ------------------------------ | -----            | -----                                                           | -----    |
-| `cbs`                          | :material-check: | :material-close:                                                | 10000    |
-| `cbs-encrypted`                | :material-close: | :material-check:                                                | 10000    |
+| Volume type name               | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) | max IOPS[^iops] |
+| ------------------------------ | -----            | -----                                                           | -----           |
+| `cbs`                          | :material-check: | :material-close:                                                | 10000           |
+| `cbs-encrypted`                | :material-close: | :material-check:                                                | 10000           |
+
+[^iops]: The maximum IOPS specification is essentially a cap, which creates an upper bound for individual device performance under *ideal* conditions. Actual IOPS may vary based on system load and utilization. IOPS limits are only enforced in [{{brand_public}} regions](../features/public.md).
 
 It is possible --- though somewhat involved --- to [change the type of an existing volume](../../howto/openstack/cinder/retype-volumes.md) (also known as retyping).


### PR DESCRIPTION
The `cbs` and `cbs-encrypted` volume types only come with QoS limits in Cleura Public Cloud. Explain this fact more clearly.
