### PR TITLE
fix: Extend availability for the Dx1 region, drop Tky1

### DIFF
--- a/docs/howto/getting-started/accessing-cc-rest-api.md
+++ b/docs/howto/getting-started/accessing-cc-rest-api.md
@@ -125,22 +125,6 @@ All supported regions should be returned as objects in a JSON array:
   },
   {
     "area": {
-      "id": "3",
-      "name": "Japan",
-      "tag": "JP",
-      "regions": [
-        {
-          "zone_id": "7",
-          "name": "Tokyo \/ Japan",
-          "status": "active",
-          "region": "tky1"
-        }
-      ]
-    },
-    "status": "available"
-  },
-  {
-    "area": {
       "id": "7",
       "name": "Germany \/ Frankfurt",
       "tag": "DE",

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -9,54 +9,50 @@
 > :material-close: Feature is not available
 > ## Sunset dates
 >
-> Please note that sunset dates have been set for the following {{brand}} regions:
->
-> * The **Tky1** region will no longer be available after 2024-04-30.
->
-> * The **Dx1** region will no longer be available after 2024-06-30.
+> Please note that the **Dx1** region will no longer be available after 2024-07-21.
 
 ## Virtualization
-|                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              | Tky1             |
-| -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- | ---------------- |
-| [Physical CPUs](../flavors/index.md#compute-tiers)           | :material-close:      | :material-timer-sand: | :material-close: | :material-close: | :material-close: |
+|                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              |
+| -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- |
+| [Physical CPUs](../flavors/index.md#compute-tiers)           | :material-close:      | :material-timer-sand: | :material-close: | :material-close: |
 
 
 ## Block storage
-|                                                                 | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| ------------------------------                                  | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| Highly available storage                                        | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| [High-performance local storage](../flavors/index.md#compute-tiers)  | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: |
-| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+|                                                                        | Kna1             | Sto2             | Fra1             | Dx1              |
+| ------------------------------                                         | ---------------- | ---------------- | ---------------- | ---------------- |
+| Highly available storage                                               | :material-check: | :material-check: | :material-check: | :material-check: |
+| [High-performance local storage](../flavors/index.md#compute-tiers)    | :material-check: | :material-check: | :material-check: | :material-close: |
+| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Object storage
-|                                                         | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| ------------------------------                          | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| S3 API                                                  | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
-| Swift API                                               | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: |
+|                                                                | Kna1             | Sto2             | Fra1             | Dx1              |
+| ------------------------------                                 | ---------------- | ---------------- | ---------------- | ---------------- |
+| S3 API                                                         | :material-check: | :material-close: | :material-check: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: | :material-check: |
+| Swift API                                                      | :material-check: | :material-close: | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)
-|                      | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| -------------------- | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| IPv6                 | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| VPN (IPsec with PSK) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+|                      | Kna1             | Sto2             | Fra1             | Dx1              |
+| -------------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: | :material-check: |
+| IPv6                 | :material-check: | :material-check: | :material-check: | :material-check: |
+| VPN (IPsec with PSK) | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Load Balancers
-|                                                                                                             | Kna1             | Sto2             | Fra1             | Dx1              | Tky1             |
-| --------------------------------------------------------------------                                        | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer (HTTP)                                                                                    | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+|                                                                                                                    | Kna1             | Sto2             | Fra1             | Dx1              |
+| --------------------------------------------------------------------                                               | ---------------- | ---------------- | ---------------- | ---------------- |
+| Transport layer (TCP/UDP)                                                                                          | :material-check: | :material-check: | :material-check: | :material-check: |
+| Application layer (HTTP)                                                                                           | :material-check: | :material-check: | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: | :material-check: |
+| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-check: | :material-check: | :material-check: |
 
 
 ## Kubernetes management
-|                            | Kna1                  | Sto2                  | Fra1                  | Dx1              | Tky1             |
-| -----------------          | ----------------      | ----------------      | ----------------      | ---------------- | ---------------- |
-| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      | :material-check: | :material-check: |
-| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: | :material-close: |
+|                            | Kna1                  | Sto2                  | Fra1                  | Dx1              |
+| -----------------          | ----------------      | ----------------      | ----------------      | ---------------- |
+| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      | :material-check: |
+| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: |

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,31 +2,27 @@
 
 > ## Sunset dates
 >
-> Please note that sunset dates have been set for the following {{brand}} regions:
->
-> * The **Tky1** region will no longer be available after 2024-04-30.
->
-> * The **Dx1** region will no longer be available after 2024-06-30.
+> Please note that the **Dx1** region will no longer be available after 2024-07-21.
 
 ## OpenStack Services
 
-|                                | Kna1     | Sto2     | Fra1      | Dx1       | Tky1     |
-| ------------------------------ | -----    | ------   | -----     | -----     | ------   |
-| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Cinder (block storage)         | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Glance (image management)      | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Heat (orchestration)           | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Keystone (identity management) | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Magnum (container management)  | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Neutron (networking)           | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Antelope  | Antelope |
-| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Antelope  | Antelope |
+|                                | Kna1     | Sto2     | Fra1      | Dx1       |
+| ------------------------------ | -----    | ------   | -----     | -----     |
+| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Antelope  |
+| Cinder (block storage)         | Antelope | Antelope | Antelope  | Antelope  |
+| Glance (image management)      | Antelope | Antelope | Antelope  | Antelope  |
+| Heat (orchestration)           | Antelope | Antelope | Antelope  | Antelope  |
+| Keystone (identity management) | Antelope | Antelope | Antelope  | Antelope  |
+| Magnum (container management)  | Antelope | Antelope | Antelope  | Antelope  |
+| Neutron (networking)           | Antelope | Antelope | Antelope  | Antelope  |
+| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Antelope  |
+| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Antelope  |
 
 
 ## Ceph Services
 
-|                               | Kna1   | Sto2             | Fra1   | Dx1    | Tky1   |
-| --------------------------    | ------ | ------           | -----  | -----  | ------ |
-| Block storage (for OpenStack) | Quincy | Quincy           | Quincy | Quincy | Quincy |
-| Object storage (Swift API)    | Quincy | :material-close: | Quincy | Quincy | Quincy |
-| Object storage (S3 API)       | Quincy | :material-close: | Quincy | Quincy | Quincy |
+|                               | Kna1   | Sto2             | Fra1   | Dx1    |
+| --------------------------    | ------ | ------           | -----  | -----  |
+| Block storage (for OpenStack) | Quincy | Quincy           | Quincy | Quincy |
+| Object storage (Swift API)    | Quincy | :material-close: | Quincy | Quincy |
+| Object storage (S3 API)       | Quincy | :material-close: | Quincy | Quincy |


### PR DESCRIPTION
* The Dx1 region will remain available until 2024-07-21. Fix the reference information accordingly.
* The Tky1 region has been sunset. Remove all references to it.

