### PR TITLE
fix: Remove all references to Dx1 region

### DIFF
--- a/docs/howto/getting-started/accessing-cc-rest-api.md
+++ b/docs/howto/getting-started/accessing-cc-rest-api.md
@@ -144,22 +144,6 @@ All supported regions should be returned as objects in a JSON array:
   },
   {
     "area": {
-      "id": "2",
-      "name": "United Arab Emirates",
-      "tag": "AE",
-      "regions": [
-        {
-          "zone_id": "8",
-          "name": "Dubai \/ UAE",
-          "status": "active",
-          "region": "dx1"
-        }
-      ]
-    },
-    "status": "available"
-  },
-  {
-    "area": {
       "id": "1",
       "name": "Europe",
       "tag": "EU",

--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -7,52 +7,49 @@
 > :material-logout: Feature is deprecated, being phased out
 >
 > :material-close: Feature is not available
-> ## Sunset dates
->
-> Please note that the **Dx1** region will no longer be available after 2024-07-21.
 
 ## Virtualization
-|                                                              | Kna1                  | Sto2                  | Fra1             | Dx1              |
-| -------------                                                | ----------------      | --------------------- | ---------------- | ---------------- |
-| [Physical CPUs](../flavors/index.md#compute-tiers)           | :material-close:      | :material-timer-sand: | :material-close: | :material-close: |
+|                                                              | Kna1                  | Sto2                  | Fra1             |
+| -------------                                                | ----------------      | --------------------- | ---------------- |
+| [Physical CPUs](../flavors/index.md#compute-tiers)           | :material-close:      | :material-timer-sand: | :material-close: |
 
 
 ## Block storage
-|                                                                        | Kna1             | Sto2             | Fra1             | Dx1              |
-| ------------------------------                                         | ---------------- | ---------------- | ---------------- | ---------------- |
-| Highly available storage                                               | :material-check: | :material-check: | :material-check: | :material-check: |
-| [High-performance local storage](../flavors/index.md#compute-tiers)    | :material-check: | :material-check: | :material-check: | :material-close: |
-| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: | :material-check: |
+|                                                                        | Kna1             | Sto2             | Fra1             |
+| ------------------------------                                         | ---------------- | ---------------- | ---------------- |
+| Highly available storage                                               | :material-check: | :material-check: | :material-check: |
+| [High-performance local storage](../flavors/index.md#compute-tiers)    | :material-check: | :material-check: | :material-check: |
+| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: |
 
 
 ## Object storage
-|                                                                | Kna1             | Sto2             | Fra1             | Dx1              |
-| ------------------------------                                 | ---------------- | ---------------- | ---------------- | ---------------- |
-| S3 API                                                         | :material-check: | :material-close: | :material-check: | :material-check: |
-| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: | :material-check: |
-| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: | :material-check: |
-| Swift API                                                      | :material-check: | :material-close: | :material-check: | :material-check: |
+|                                                                | Kna1             | Sto2             | Fra1             |
+| ------------------------------                                 | ---------------- | ---------------- | ---------------- |
+| S3 API                                                         | :material-check: | :material-close: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: |
+| Swift API                                                      | :material-check: | :material-close: | :material-check: |
 
 
 ## Networking (Layer 2/3)
-|                      | Kna1             | Sto2             | Fra1             | Dx1              |
-| -------------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: | :material-check: |
-| IPv6                 | :material-check: | :material-check: | :material-check: | :material-check: |
-| VPN (IPsec with PSK) | :material-check: | :material-check: | :material-check: | :material-check: |
+|                      | Kna1             | Sto2             | Fra1             |
+| -------------------- | ---------------- | ---------------- | ---------------- |
+| IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: |
+| IPv6                 | :material-check: | :material-check: | :material-check: |
+| VPN (IPsec with PSK) | :material-check: | :material-check: | :material-check: |
 
 
 ## Load Balancers
-|                                                                                                                    | Kna1             | Sto2             | Fra1             | Dx1              |
-| --------------------------------------------------------------------                                               | ---------------- | ---------------- | ---------------- | ---------------- |
-| Transport layer (TCP/UDP)                                                                                          | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer (HTTP)                                                                                           | :material-check: | :material-check: | :material-check: | :material-check: |
-| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: | :material-check: |
-| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-check: | :material-check: | :material-check: |
+|                                                                                                                    | Kna1             | Sto2             | Fra1             |
+| --------------------------------------------------------------------                                               | ---------------- | ---------------- | ---------------- |
+| Transport layer (TCP/UDP)                                                                                          | :material-check: | :material-check: | :material-check: |
+| Application layer (HTTP)                                                                                           | :material-check: | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: |
+| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-check: | :material-check: |
 
 
 ## Kubernetes management
-|                            | Kna1                  | Sto2                  | Fra1                  | Dx1              |
-| -----------------          | ----------------      | ----------------      | ----------------      | ---------------- |
-| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      | :material-check: |
-| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: | :material-close: |
+|                            | Kna1                  | Sto2                  | Fra1                  |
+| -----------------          | ----------------      | ----------------      | ----------------      |
+| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      |
+| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: |

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -1,28 +1,24 @@
 # Public Cloud
 
-> ## Sunset dates
->
-> Please note that the **Dx1** region will no longer be available after 2024-07-21.
-
 ## OpenStack Services
 
-|                                | Kna1     | Sto2     | Fra1      | Dx1       |
-| ------------------------------ | -----    | ------   | -----     | -----     |
-| Barbican (secret storage)      | Antelope | Antelope | Antelope  | Antelope  |
-| Cinder (block storage)         | Antelope | Antelope | Antelope  | Antelope  |
-| Glance (image management)      | Antelope | Antelope | Antelope  | Antelope  |
-| Heat (orchestration)           | Antelope | Antelope | Antelope  | Antelope  |
-| Keystone (identity management) | Antelope | Antelope | Antelope  | Antelope  |
-| Magnum (container management)  | Antelope | Antelope | Antelope  | Antelope  |
-| Neutron (networking)           | Antelope | Antelope | Antelope  | Antelope  |
-| Nova (server virtualization)   | Antelope | Antelope | Antelope  | Antelope  |
-| Octavia (load balancing)       | Antelope | Antelope | Antelope  | Antelope  |
+|                                | Kna1     | Sto2     | Fra1      |
+| ------------------------------ | -----    | ------   | -----     |
+| Barbican (secret storage)      | Antelope | Antelope | Antelope  |
+| Cinder (block storage)         | Antelope | Antelope | Antelope  |
+| Glance (image management)      | Antelope | Antelope | Antelope  |
+| Heat (orchestration)           | Antelope | Antelope | Antelope  |
+| Keystone (identity management) | Antelope | Antelope | Antelope  |
+| Magnum (container management)  | Antelope | Antelope | Antelope  |
+| Neutron (networking)           | Antelope | Antelope | Antelope  |
+| Nova (server virtualization)   | Antelope | Antelope | Antelope  |
+| Octavia (load balancing)       | Antelope | Antelope | Antelope  |
 
 
 ## Ceph Services
 
-|                               | Kna1   | Sto2             | Fra1   | Dx1    |
-| --------------------------    | ------ | ------           | -----  | -----  |
-| Block storage (for OpenStack) | Quincy | Quincy           | Quincy | Quincy |
-| Object storage (Swift API)    | Quincy | :material-close: | Quincy | Quincy |
-| Object storage (S3 API)       | Quincy | :material-close: | Quincy | Quincy |
+|                               | Kna1   | Sto2             | Fra1   |
+| --------------------------    | ------ | ------           | -----  |
+| Block storage (for OpenStack) | Quincy | Quincy           | Quincy |
+| Object storage (Swift API)    | Quincy | :material-close: | Quincy |
+| Object storage (S3 API)       | Quincy | :material-close: | Quincy |


### PR DESCRIPTION
We are now past the final deadline for customers to move out of Dx1, so we proceed with removing all relevant references from the public-facing documentation.