### PR TITLE
fix: Update the limitations page to include volume backups

### DIFF
--- a/docs/reference/limitations/openstack.md
+++ b/docs/reference/limitations/openstack.md
@@ -20,6 +20,14 @@ It also means that you cannot use the following `openstack` CLI commands; they a
   > You can use `openstack project list`, but this will only list the project(s) that your user account has access to.
 * `openstack domain <subcommand>`
 
+## Cinder
+
+### Volume backup service
+
+{{brand}} does not support the OpenStack volume backup service (`cinder-backup`).
+
+For automated, scheduled volume *snapshots,* consider configuring your servers for [Disaster Recovery (DR)](../../background/disaster-recovery.md) via the {{gui}}.
+
 ## Nova
 
 ### Nested virtualization


### PR DESCRIPTION
The volume backup service is not configured in any of the Cleura Cloud regions, so we update the limitations page accordingly.

While at it, we suggest configuring servers for Disaster Recovery via the Cleura Cloud Management Panel.