### PR TITLE
Update OpenStack and Ceph releases in version reference

### DIFF
--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -19,6 +19,6 @@
 
 |                               | Sto1HS | Sto2HS |
 | --------------------------    | ------ | ------ |
-| Block storage (for OpenStack) | Quincy | Quincy |
-| Object storage (Swift API)    | Quincy | Quincy |
-| Object storage (S3 API)       | Quincy | Quincy |
+| Block storage (for OpenStack) | Reef   | Reef   |
+| Object storage (Swift API)    | Reef   | Reef   |
+| Object storage (S3 API)       | Reef   | Reef   |

--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Sto1HS    | Sto2HS    |
-| ------------------------------ | --------- | --------- |
-| Barbican (secret storage)      | Antelope  | Antelope  |
-| Cinder (block storage)         | Antelope  | Antelope  |
-| Glance (image management)      | Antelope  | Antelope  |
-| Heat (orchestration)           | Antelope  | Antelope  |
-| Keystone (identity management) | Antelope  | Antelope  |
-| Magnum (container management)  | Antelope  | Antelope  |
-| Neutron (networking)           | Antelope  | Antelope  |
-| Nova (server virtualization)   | Antelope  | Antelope  |
-| Octavia (load balancing)       | Antelope  | Antelope  |
+|                                | Sto1HS  | Sto2HS  |
+| ------------------------------ | ------- | ------- |
+| Barbican (secret storage)      | Caracal | Caracal |
+| Cinder (block storage)         | Caracal | Caracal |
+| Glance (image management)      | Caracal | Caracal |
+| Heat (orchestration)           | Caracal | Caracal |
+| Keystone (identity management) | Caracal | Caracal |
+| Magnum (container management)  | Caracal | Caracal |
+| Neutron (networking)           | Caracal | Caracal |
+| Nova (server virtualization)   | Caracal | Caracal |
+| Octavia (load balancing)       | Caracal | Caracal |
 
 
 ## Ceph Services

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -14,9 +14,7 @@ This section lists the cloud API service versions available in each {{brand}} re
 [OpenStack releases](https://releases.openstack.org) are named in alphabetical order, and occur on a six-month release schedule.
 In {{brand_public}} we upgrade OpenStack releases annually; this means that we normally deploy every other OpenStack release and skip the intervening one.
 
-{{brand}} currently runs OpenStack [Antelope](https://releases.openstack.org/antelope/) in all regions.
-The fact that {{brand}} has skipped the [Zed](https://releases.openstack.org/zed/) release (in addition to [Yoga](https://releases.openstack.org/yoga/), as we normally would have) is due to a one-time upstream release policy change.
-We return to the prior deployment schedule after the Antelope upgrade, and expect the next deployed release to be [Caracal](https://releases.openstack.org/caracal/).
+{{brand}} currently runs OpenStack [Caracal](https://releases.openstack.org/caracal/) in all regions.
 
 
 ## Ceph Services

--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -21,4 +21,4 @@ In {{brand_public}} we upgrade OpenStack releases annually; this means that we n
 
 [Ceph major releases](https://docs.ceph.com/en/latest/releases/index.html#release-timeline) are also named in alphabetical order, and occur on a roughly annual schedule.
 
-{{brand}} currently runs Ceph [Quincy](https://docs.ceph.com/en/latest/releases/quincy/).
+{{brand}} currently runs Ceph [Reef](https://docs.ceph.com/en/latest/releases/reef/).

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -17,8 +17,8 @@
 
 ## Ceph Services
 
-|                               | Kna1   | Sto2             | Fra1   |
-| --------------------------    | ------ | ------           | -----  |
-| Block storage (for OpenStack) | Quincy | Quincy           | Quincy |
-| Object storage (Swift API)    | Quincy | :material-close: | Quincy |
-| Object storage (S3 API)       | Quincy | :material-close: | Quincy |
+|                               | Kna1   | Sto2             | Fra1  |
+| --------------------------    | ------ | ------           | ----- |
+| Block storage (for OpenStack) | Reef   | Reef             | Reef  |
+| Object storage (Swift API)    | Reef   | :material-close: | Reef  |
+| Object storage (S3 API)       | Reef   | :material-close: | Reef  |

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1     | Sto2     | Fra1      |
-| ------------------------------ | -----    | ------   | -----     |
-| Barbican (secret storage)      | Antelope | Antelope | Antelope  |
-| Cinder (block storage)         | Antelope | Antelope | Antelope  |
-| Glance (image management)      | Antelope | Antelope | Antelope  |
-| Heat (orchestration)           | Antelope | Antelope | Antelope  |
-| Keystone (identity management) | Antelope | Antelope | Antelope  |
-| Magnum (container management)  | Antelope | Antelope | Antelope  |
-| Neutron (networking)           | Antelope | Antelope | Antelope  |
-| Nova (server virtualization)   | Antelope | Antelope | Antelope  |
-| Octavia (load balancing)       | Antelope | Antelope | Antelope  |
+|                                | Kna1    | Sto2    | Fra1    |
+| ------------------------------ | ------- | ------  | ------- |
+| Barbican (secret storage)      | Caracal | Caracal | Caracal |
+| Cinder (block storage)         | Caracal | Caracal | Caracal |
+| Glance (image management)      | Caracal | Caracal | Caracal |
+| Heat (orchestration)           | Caracal | Caracal | Caracal |
+| Keystone (identity management) | Caracal | Caracal | Caracal |
+| Magnum (container management)  | Caracal | Caracal | Caracal |
+| Neutron (networking)           | Caracal | Caracal | Caracal |
+| Nova (server virtualization)   | Caracal | Caracal | Caracal |
+| Octavia (load balancing)       | Caracal | Caracal | Caracal |
 
 
 ## Ceph Services


### PR DESCRIPTION
Mention Caracal for OpenStack, and Reef for Ceph.