### PR TITLE
fix: Update supported Kubernetes releases

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -49,7 +49,7 @@
 
 
 ## Kubernetes management
-|                            | Kna1                  | Sto2                  | Fra1                  |
-| -----------------          | ----------------      | ----------------      | ----------------      |
-| OpenStack Magnum           | :material-check:      | :material-check:      | :material-check:      |
-| {{k8s_management_service}} | :material-timer-sand: | :material-timer-sand: | :material-timer-sand: |
+|                            | Kna1             | Sto2             | Fra1             |
+| -----------------          | ---------------- | ---------------- | ---------------- |
+| OpenStack Magnum           | :material-check: | :material-check: | :material-check: |
+| {{k8s_management_service}} | :material-check: | :material-check: | :material-check: |

--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -10,7 +10,7 @@ The legacy `swarm` and `mesos` COEs are not supported.
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with OpenStack Magnum is 1.24.16.
+The latest Kubernetes version you can install in {{brand}} with OpenStack Magnum is 1.27.
 
 ### IP version
 
@@ -33,7 +33,7 @@ You cannot use `ReadWriteOncePod` (`RWOP`), `ReadWriteMany` (`RWX`), or `ReadOnl
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.29.3.
+The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.31.
 
 ### IP version
 


### PR DESCRIPTION
We currently support 1.27.8 (for Caracal) with Magnum, and 1.31.5 with Gardener.
