### PR TITLE
fix: List object storage in Sto2 as "in deployment"

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -23,12 +23,12 @@
 
 
 ## Object storage
-|                                                                | Kna1             | Sto2             | Fra1             |
-| ------------------------------                                 | ---------------- | ---------------- | ---------------- |
-| S3 API                                                         | :material-check: | :material-close: | :material-check: |
-| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-close: | :material-check: |
-| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-close: | :material-check: |
-| Swift API                                                      | :material-check: | :material-close: | :material-check: |
+|                                                                | Kna1             | Sto2                  | Fra1             |
+| ------------------------------                                 | ---------------- | ----------------      | ---------------- |
+| S3 API                                                         | :material-check: | :material-timer-sand: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-timer-sand: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-timer-sand: | :material-check: |
+| Swift API                                                      | :material-check: | :material-timer-sand: | :material-check: |
 
 
 ## Networking (Layer 2/3)


### PR DESCRIPTION
Object storage support in Sto2 is coming, though it's not ready for general consumption yet.
