### PR TITLE
fix: Exclude VPNaaS Howto from search

### DIFF
--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Creating a VPN connection between regions
 
 Thanks to the Openstack Neutron VPN as a Service (VPNaaS) feature, you

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -ex
 
-DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
+DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.* .*sto-com.cleura.cloud.*'
 
 if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"
 elif test `basename $0` = "linkcheck-production.sh"; then
-    DOCS_SITE_URL="https://docs.cleura.cloud"
+    DOCS_SITE_URL="https://docs-v2.cleura.cloud"
     DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*localhost.*"
 fi
 


### PR DESCRIPTION
Excluding the VPNaaS Howto guide from .pages only means it is not
being displayed in the nagivation, but can still be found using
full-text search.

Exclude the guide from search via the search frontmatter attribute.
