### PR TITLE
fix: Replace Legal page content with link to authoritative source

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -11,9 +11,7 @@ have to create a new account. For that, navigate to
 
 Select the new account type (that would be _Company_ or _Private_),
 carefully type in a valid email address, and choose your country.
-At your leisure, please read the [{{ legal_docs.tos.name}}]({{ legal_docs.tos.url}})
-and our
-[{{ legal_docs.cdpa.name}}]({{ legal_docs.cdpa.url}}).
+Please be sure to read the {{ legal_docs.tos.name}} and our {{ legal_docs.cdpa.name}}.
 
 Agree to these documents (select _Yes_), check the _I'm not a robot_
 box, and then click on the _Create_ button.

--- a/docs/reference/legal/index.md
+++ b/docs/reference/legal/index.md
@@ -3,14 +3,4 @@ description: "The fine print: terms and agreements governing our services."
 ---
 # Legal Reference
 
-This section contains links to the terms and agreements governing the {{brand_public}}[^compliant] services.
-
-[^compliant]: The use of {{brand_compliant}} may be governed by separate, individually negotiated agreements.
-
-## {{legal_docs.tos.name}}
-
-Our current {{brand_public}} [{{legal_docs.tos.name}}]({{legal_docs.tos.url}}) were most recently updated on {{legal_docs.tos.last_updated}}, and apply since {{legal_docs.tos.valid_from}}.
-
-## {{legal_docs.cdpa.name}}
-
-Our current {{brand_public}} [{{legal_docs.cdpa.name}}]({{legal_docs.cdpa.url}}) was most recently updated on {{legal_docs.cdpa.last_updated}}, and applies since {{legal_docs.cdpa.valid_from}}.
+For legal documentation, including our {{legal_docs.tos.name}} and {{legal_docs.cdpa.name}}, please refer to <https://cleura.com/resources/legal/terms/>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,18 +29,12 @@ extra:
       short_name: "CC BY-SA"
       url: "https://creativecommons.org/licenses/by-sa/4.0/"
     cdpa:
-      last_updated: 2024-03-22
       name: "Data Processing Agreement"
-      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Data_Processing_Agreement_for_Public_Cloud-V24.03.25.pdf"
-      valid_from: 2024-03-25
     termination_form:
       name: "Termination of Subscription Form"
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Termination-Of-Subscription.pdf"
     tos:
-      last_updated: 2023-09-08
       name: "Terms of Service"
-      url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura_Terms_of_Service-Public_Cloud_v2023.9.8.pdf"
-      valid_from: 2023-10-03
     transfer_form:
       name: "Transfer Form"
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"


### PR DESCRIPTION
All legally relevant documents are now at https://cleura.com/resources/legal/terms/. Thus, for avoidance of ambiguity, refer to just that page in the Legal Reference subsection.

Also, remove the extra variables containing direct links to the PDFs, and consequently also remove references to those variables from the account creation how-to guide.
