### PR TITLE
Clarify sharing volume encryption secrets

### DIFF
--- a/docs/howto/openstack/barbican/share-secret.md
+++ b/docs/howto/openstack/barbican/share-secret.md
@@ -14,20 +14,20 @@ To do so, you will need
 > openstack token issue -f value -c user_id
 > ```
 
-Once you have assembled this information, you can proceed with the `openstack acl user add` command:
+Once you have this information, you can proceed with the `openstack acl user add` command:
 
 ```bash
 openstack acl user add \
   --user <user_id> \
   --operation-type read \
-  https://region.{{brand_domain}}:9311/v1/secrets/<secret_id>
+  https://<region>.{{brand_domain}}:9311/v1/secrets/<secret_id>
 ```
 
-If you want to unshare the secret again, you simply use the corresponding `openstack acl user remove` command:
+If you want to unshare the secret again, you use the corresponding `openstack acl user remove` command:
 
 ```bash
 openstack acl user remove \
   --user <user_id> \
   --operation-type read \
-  https://region.{{brand_domain}}:9311/v1/secrets/<secret_id>
+  https://<region>.{{brand_domain}}:9311/v1/secrets/<secret_id>
 ```

--- a/docs/howto/openstack/barbican/share-secret.md
+++ b/docs/howto/openstack/barbican/share-secret.md
@@ -1,24 +1,20 @@
 # Sharing secrets via ACLs
 
-Normally, a Barbican secret is only available to the OpenStack API
-user that created it. However, under some circumstances it may be
-desirable to make a secret available to another user.
+Normally, a Barbican secret is only available to the OpenStack API user that created it.
+However, under some circumstances it may be desirable to make a secret available to another user.
 
 To do so, you will need
 
-* the secret’s
-  [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier),
+* the secret’s [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier),
 * the other user’s OpenStack API user ID.
 
-> Any {{brand}} user can always retrieve their own user ID
-> with the following command:
+> Any {{brand}} user can always retrieve their own user ID with the following command:
 >
 > ```bash
 > openstack token issue -f value -c user_id
 > ```
 
-Once you have assembled this information, you can proceed with the
-`openstack acl user add` command:
+Once you have assembled this information, you can proceed with the `openstack acl user add` command:
 
 ```bash
 openstack acl user add \
@@ -27,8 +23,7 @@ openstack acl user add \
   https://region.{{brand_domain}}:9311/v1/secrets/<secret_id>
 ```
 
-If you want to unshare the secret again, you simply use the
-corresponding `openstack acl user remove` command:
+If you want to unshare the secret again, you simply use the corresponding `openstack acl user remove` command:
 
 ```bash
 openstack acl user remove \

--- a/docs/howto/openstack/cinder/encrypted-volumes.md
+++ b/docs/howto/openstack/cinder/encrypted-volumes.md
@@ -5,15 +5,13 @@ description: Using Barbican secrets for block storage encryption, you can store 
 
 {{page.meta.description}}
 
-That encryption is transparent to virtual machines (instances) that
-you attach the volume to.
+That encryption is transparent to virtual machines (instances) that you attach the volume to.
 
 
 ## Creating an encrypted volume
 
-For the creation of an encrypted volume, you need to provide a
-specific *volume type.* You can retrieve the list of available volume
-types with the following command:
+For the creation of an encrypted volume, you need to provide a specific *volume type.*
+You can retrieve the list of available volume types with the following command:
 
 ```console
 $ openstack volume type list
@@ -26,13 +24,10 @@ $ openstack volume type list
 +--------------------------------------+-----------------------+-----------+
 ```
 
-> In {{brand}}, all volume types that support encryption use the
-> suffix `_encrypted`.
+> In {{brand}}, all volume types that support encryption use the suffix `_encrypted`.
 
-To create a volume with encryption, you need to explicitly specify the
-`--type` option to the `openstack volume create` command. The
-following example creates a volume using the `cbs-encrypted`
-type, naming it `enc_drive` and setting its size to 10 GiB:
+To create a volume with encryption, you need to explicitly specify the `--type` option to the `openstack volume create` command.
+The following example creates a volume using the `cbs-encrypted` type, naming it `enc_drive` and setting its size to 10 GiB:
 
 ```console
 $ openstack volume create \
@@ -64,17 +59,14 @@ $ openstack volume create \
 +---------------------+--------------------------------------+
 ```
 
-Upon volume creation, this will create a one-off encryption key, which
-is stored in Barbican and applies to this one volume only. In other
-words, the key created for this volume will be unable to decrypt any
-other volumes except the one it was created for.
+Upon volume creation, this will create a one-off encryption key, which is stored in Barbican and applies to this one volume only.
+In other words, the key created for this volume will be unable to decrypt any other volumes except the one it was created for.
 
 
 ## Retrieving a volume’s encryption key
 
-Once you have created an encrypted volume, you may retrieve a
-reference to the Barbican secret that represents its encryption
-key. You do this with the following command:
+Once you have created an encrypted volume, you may retrieve a reference to the Barbican secret that represents its encryption key.
+You do this with the following command:
 
 ```bash
 openstack volume show \
@@ -97,57 +89,33 @@ openstack volume show \
 
 ## Deleting an encrypted volume
 
-When you decide you no longer need an encrypted volume and want to
-delete it, you can do so with the `openstack volume delete`
-command. As long as you do this with the same user account as the one
-that created the volume, this will succeed without further
-intervention.
+When you decide you no longer need an encrypted volume and want to delete it, you can do so with the `openstack volume delete` command.
+As long as you do this with the same user account as the one that created the volume, this will succeed without further intervention.
 
-However, if you are trying to delete a volume that was created by a
-different user, you’ll run into the limitation that the *secret*
-associated with the volume is owned by that user. As a result, the
-deletion of the encrypted volume using your own user credentials will
-fail.
+However, if you are trying to delete a volume that was created by a different user, you’ll run into the limitation that the *secret* associated with the volume is owned by that user.
+As a result, the deletion of the encrypted volume using your own user credentials will fail.
 
 There are two options to work around this limitation:
 
-1. You can switch to the user credentials of the user that created the
-   volume (if you have access to them), and proceed with the deletion.
-2. You can ask the user that created the volume to [add you to the
-   Access Control List (ACL) for the
-   secret](../barbican/share-secret.md). This will enable you to read
-   the secret, and to delete the volume using your own credentials.
+1. You can switch to the user credentials of the user that created the volume (if you have access to them), and proceed with the deletion.
+2. You can ask the user that created the volume to [add you to the Access Control List (ACL) for the secret](../barbican/share-secret.md).
+   This will enable you to read the secret, and to delete the volume using your own credentials.
 
 
 ## Block device encryption caveats
 
-Once a volume is configured to use encryption and is also attached to
-an instance in {{brand}}, some caveats apply that you might want
-to keep in mind.
+Once a volume is configured to use encryption and is also attached to an instance in {{brand}}, some caveats apply that you might want to keep in mind.
 
-Sometimes, automatically or through administrator intervention, we
-move one of your instances to another physical machine. This process
-is known as *live migration,* and it normally does not interrupt the
-instance’s functionality at all — typically, neither you nor the
-application users notice that live migration has even happened. This
-is a very common occurrence when we do routine upgrades of the
-{{brand}} platform, during our pre-announced maintenance windows.
+Sometimes, automatically or through administrator intervention, we move one of your instances to another physical machine.
+This process is known as *live migration,* and it normally does not interrupt the instance’s functionality at all — typically, neither you nor the application users notice that live migration has even happened.
+This is a very common occurrence when we do routine upgrades of the {{brand}} platform, during our pre-announced maintenance windows.
 
-The same considerations apply to physical node failure. If the
-physical machine running your instance fails, we can automatically
-recover it onto another machine — an action known as *evacuation.*
+The same considerations apply to physical node failure.
+If the physical machine running your instance fails, we can automatically recover it onto another machine — an action known as *evacuation.*
 
-Live migration or evacuation *including encrypted volumes* does,
-however, require that whoever does the migration also has at least
-read access to the volume’s encryption secret.
+Live migration or evacuation *including encrypted volumes* does, however, require that whoever does the migration also has at least read access to the volume’s encryption secret.
 
 This means that you have two options:
 
-1. If you *do* trust us to include your instances in live migrations
-   and evacuations, even if they attach encrypted volumes, then you
-   can [add our administrative account to the Access Control List
-   (ACL) for your secrets](../barbican/share-secret.md).
-2. If you *don’t* want to share your secrets but you still want to use
-   encrypted volumes, you should build your own mechanism or process
-   (preferably automated) so that your instances recover in case they
-   become non-functional.
+1. If you *do* trust us to include your instances in live migrations and evacuations, even if they attach encrypted volumes, then you can [add our administrative account to the Access Control List (ACL) for your secrets](../barbican/share-secret.md).
+2. If you *don’t* want to share your secrets but you still want to use encrypted volumes, you should build your own mechanism or process (preferably automated) so that your instances recover in case they become non-functional.

--- a/docs/howto/openstack/cinder/encrypted-volumes.md
+++ b/docs/howto/openstack/cinder/encrypted-volumes.md
@@ -117,5 +117,5 @@ Live migration or evacuation *including encrypted volumes* does, however, requir
 
 This means that you have two options:
 
-1. If you *do* trust us to include your instances in live migrations and evacuations, even if they attach encrypted volumes, then you can [add our administrative account to the Access Control List (ACL) for your secrets](../barbican/share-secret.md).
+1. If you *do* trust us to include your instances in live migrations and evacuations, even if they attach encrypted volumes, then you can [add](../barbican/share-secret.md) our [administrative account](../../../reference/volumes/index.md) to the Access Control List (ACL) for your secrets.
 2. If you *don’t* want to share your secrets but you still want to use encrypted volumes, you should build your own mechanism or process (preferably automated) so that your instances recover in case they become non-functional.

--- a/docs/reference/volumes/index.md
+++ b/docs/reference/volumes/index.md
@@ -1,4 +1,6 @@
-# Volume types
+# Volume service reference
+
+## Volume types
 
 The following volume types are available in {{brand}} for persistent block storage devices ("volumes") managed by OpenStack Cinder.
 
@@ -13,3 +15,15 @@ If you create a volume without specifying a volume type, then the default volume
 [^iops]: The maximum IOPS specification is essentially a cap, which creates an upper bound for individual device performance under *ideal* conditions. Actual IOPS may vary based on system load and utilization. IOPS limits are only enforced in [{{brand_public}} regions](../features/public.md).
 
 It is possible --- though somewhat involved --- to [change the type of an existing volume](../../howto/openstack/cinder/retype-volumes.md) (also known as retyping).
+
+## Administrative access to volume encryption secrets
+
+If you want to enable {{brand}} support to administratively migrate virtual machines with attached [encrypted volumes](../../howto/openstack/cinder/encrypted-volumes.md), please [share your encryption secrets](../../howto/openstack/barbican/share-secret.md) with the following user IDs:
+
+| {{brand}} region | Administrative user UUID           |
+| ---------------- | ---------------------------------  |
+| Fra1             | `a3bee416cf67420995855d602d2bccd3` |
+| Kna1             | `a3bee416cf67420995855d602d2bccd3` |
+| Sto2             | `a3bee416cf67420995855d602d2bccd3` |
+| Sto1HS           | `ac35ff3bedf440fe8062a5ba7e17d590` |
+| Sto2HS           | `17c689c90f9549a3b30ac8ecbef9abb1` |


### PR DESCRIPTION
In relation to #239:

- chore: Apply one-sentence-per-line format to Encrypted Volumes guide
- chore: Apply one-sentence-per-line format to Sharing secrets via ACLs
- fix: Minor fixes to Sharing secrets via ACLs
- feat: Add administrative user UUIDs for encrypted volume secret sharing
