### PR TITLE
fix: Update OpenStack version information for Sto-Com

### DIFF
--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Sto1HS   | Sto2HS   | Sto-Com  |
-| ------------------------------ | -------- | -------- | -------- |
-| Barbican (secret storage)      | Caracal  | Caracal  | Antelope |
-| Cinder (block storage)         | Caracal  | Caracal  | Antelope |
-| Glance (image management)      | Caracal  | Caracal  | Antelope |
-| Heat (orchestration)           | Caracal  | Caracal  | Antelope |
-| Keystone (identity management) | Caracal  | Caracal  | Antelope |
-| Magnum (container management)  | Caracal  | Caracal  | Antelope |
-| Neutron (networking)           | Caracal  | Caracal  | Antelope |
-| Nova (server virtualization)   | Caracal  | Caracal  | Antelope |
-| Octavia (load balancing)       | Caracal  | Caracal  | Antelope |
+|                                | Sto1HS   | Sto2HS   | Sto-Com |
+| ------------------------------ | -------- | -------- | ------- |
+| Barbican (secret storage)      | Caracal  | Caracal  | Caracal |
+| Cinder (block storage)         | Caracal  | Caracal  | Caracal |
+| Glance (image management)      | Caracal  | Caracal  | Caracal |
+| Heat (orchestration)           | Caracal  | Caracal  | Caracal |
+| Keystone (identity management) | Caracal  | Caracal  | Caracal |
+| Magnum (container management)  | Caracal  | Caracal  | Caracal |
+| Neutron (networking)           | Caracal  | Caracal  | Caracal |
+| Nova (server virtualization)   | Caracal  | Caracal  | Caracal |
+| Octavia (load balancing)       | Caracal  | Caracal  | Caracal |
 
 
 ## Ceph Services


### PR DESCRIPTION
The Sto-Com region is running OpenStack Caracal, not Antelope.
Update the version reference accordingly.
