### PR TITLE
build: Deploy per-branch GitLab pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ test:
     - tox -e build
     - tox -e check
 
-pages:
+.pages:
   stage: deploy
   script:
     - tox -e build
@@ -29,3 +29,15 @@ pages:
   artifacts:
     paths:
       - public
+
+pages-main:
+  extends: .pages
+  only:
+    - main
+
+pages:
+  extends: .pages
+  pages:
+    path_prefix: "$CI_COMMIT_BRANCH"
+  except:
+    - main


### PR DESCRIPTION
For building from a GitLab CI/CD pipeline, deploy a separate Pages build for each topic branch.

Retain the bare Pages URL for the main branch.

References:
* https://docs.gitlab.com/ci/yaml/#pagespath_prefix
* https://docs.gitlab.com/user/project/pages/#parallel-deployments