### PR TITLE
build: Keep per-branch GitLab Pages builds for 4 weeks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,5 +39,6 @@ pages:
   extends: .pages
   pages:
     path_prefix: "$CI_COMMIT_BRANCH"
+    expire_in: 4 weeks
   except:
     - main


### PR DESCRIPTION
By default, GitLab Pages parallel deployments expire after just 24 hours.

That's too short for our purposes, and keeping additional deployments should be cheap, so extend the expiry period to 4 weeks.

Reference:
https://docs.gitlab.com/user/project/pages/parallel_deployments/#create-a-parallel-deployment