### PR TITLE
Fix/cleura palette

### DIFF
--- a/theme/assets/stylesheets/cleura-palette.css
+++ b/theme/assets/stylesheets/cleura-palette.css
@@ -1,9 +1,5 @@
-[data-md-color-scheme="default"] {
-    --md-primary-fg-color: #FF6600;
-    --md-accent-fg-color:  #2643FF;
-}
-
+[data-md-color-scheme="default"],
 [data-md-color-scheme="slate"] {
-    --md-primary-fg-color: #FF6600;
+    --md-primary-fg-color: #FF6633;
     --md-accent-fg-color:  #2643FF;
 }


### PR DESCRIPTION
This PR updates the custom Cleura palette CSS to be aligned with recent gradient change.

I also took the liberty to merge `[data-md-color-scheme="default"]` & `[data-md-color-scheme="slate"]` selectors as the properties were duplicated.