### PR TITLE
Update volume type reference

### DIFF
--- a/docs/reference/volumes/index.md
+++ b/docs/reference/volumes/index.md
@@ -7,10 +7,12 @@ The following volume types are available in {{brand}} for persistent block stora
 If you create a volume without specifying a volume type, then the default volume type applies.
 
 
-| Volume type    | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) |
-| -----------    | -------          | ------------                                                    |
-| `cbs-standard` | :material-close: | :material-check:                                                |
-| `cbs-premium`  | :material-check: | :material-check:                                                |
+| Volume type              | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) |
+| -----------              | -------          | ------------                                                    |
+| `cbs-standard`           | :material-close: | :material-close:                                                |
+| `cbs-premium`            | :material-check: | :material-close:                                                |
+| `cbs-standard-encrypted` | :material-close: | :material-check:                                                |
+| `cbs-premium-encrypted`  | :material-close: | :material-check:                                                |
 
 It is possible --- though somewhat involved --- to [change the type of an existing volume](../../howto/openstack/cinder/retype-volumes.md) (also known as retyping).
 


### PR DESCRIPTION
Updated the volume type reference to more accurately represent the types exposed in the API. Specifically made sure that the separate volume types with (`-encrypted`) is represented in this table, and that the default type is not encrypted. I am assuming that since there are volume types specifically ending in `-encrypted` the ones without the suffix is unencrypted.