### PR TITLE
fix: Update volume type reference

### DIFF
--- a/docs/reference/volumes/index.md
+++ b/docs/reference/volumes/index.md
@@ -6,11 +6,12 @@ The following volume types are available in {{brand}} for persistent block stora
 
 If you create a volume without specifying a volume type, then the default volume type applies.
 
-
-| Volume type    | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) |
-| -----------    | -------          | ------------                                                    |
-| `cbs-standard` | :material-close: | :material-check:                                                |
-| `cbs-premium`  | :material-check: | :material-check:                                                |
+| Volume type              | Default          | [Encryption](../../howto/openstack/cinder/encrypted-volumes.md) |
+| -----------              | -------          | ------------                                                    |
+| `cbs-standard`           | :material-check: | :material-close:                                                |
+| `cbs-premium`            | :material-close: | :material-close:                                                |
+| `cbs-standard-encrypted` | :material-close: | :material-check:                                                |
+| `cbs-premium-encrypted`  | :material-close: | :material-check:                                                |
 
 It is possible --- though somewhat involved --- to [change the type of an existing volume](../../howto/openstack/cinder/retype-volumes.md) (also known as retyping).
 


### PR DESCRIPTION
Update the volume type reference to more accurately represent the types exposed in the API.

Specifically, make sure that the separate volume types with (`-encrypted`) are represented in this table, and that the default type is not encrypted.

(Clean version of #330 which we didn't hear back on.)