### PR TITLE
feat: Enable the "tutorials" section

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,9 +1,7 @@
-# TODO: We'll enable the disabled sections as we migrate/create
-# content.
 nav:
   - index.md
   - howto
-# - tutorials
+  - tutorials
   - background
   - reference
   - contrib

--- a/docs/tutorials/.pages
+++ b/docs/tutorials/.pages
@@ -1,0 +1,6 @@
+nav:
+  - index.md
+  - Ansible: ansible.md
+  - Containers: containers.md
+  - Heat: heat.md
+  - OpenTofu: tf.md

--- a/docs/tutorials/ansible.md
+++ b/docs/tutorials/ansible.md
@@ -1,0 +1,10 @@
+---
+description: Tutorials covering orchestration with Ansible.
+---
+
+# Ansible tutorials
+
+These tutorials cover how you can best automate virtual resources in {{brand}} using [Ansible](https://www.ansible.com/).
+
+* [Managing {{brand}} resources with Ansible](https://{{academy_domain}}/ct111): Use the `openstack.cloud` Ansible collection to create networks, routers, and servers in {{brand}}.
+* [Using an Ansible dynamic inventory to discover and manage {{brand}} servers](https://{{academy_domain}}/ct112): Use an Ansible dynamic inventory plugin to automate the discovery of your cloud resources, enabling the management of massively scalable virtual data centers in {{brand}}.

--- a/docs/tutorials/containers.md
+++ b/docs/tutorials/containers.md
@@ -1,0 +1,9 @@
+---
+description: Tutorials covering container orchestration.
+---
+
+# Container tutorials
+
+These tutorials cover the deployment of containerized applications in {{brand}}, using Kubernetes.
+
+* [Managing containerized workloads in {{brand}}](https://{{academy_domain}}/ct115): Deploy and manage Kubernetes clusters in {{brand}} with {{k8s_management_service}}.

--- a/docs/tutorials/heat.md
+++ b/docs/tutorials/heat.md
@@ -1,0 +1,9 @@
+---
+description: Tutorials covering orchestration with OpenStack Heat.
+---
+
+# OpenStack Heat tutorials
+
+These tutorials cover the management of complex virtual resource assemblies ("stacks") in {{brand}} using the [OpenStack Heat](https://docs.openstack.org/heat/latest/) orchestration framework.
+
+* [Using OpenStack Heat to manage {{brand}} resources](https://{{academy_domain}}/ct113): Use OpenStack Heat to automate the creation, update, and configuration of {{brand}} resources.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,7 +1,5 @@
 ---
 description: Our tutorials enable you to interactively explore specific cloud workloads in detail.
-search:
-  exclude: true
 ---
 
 # About our tutorials
@@ -9,33 +7,17 @@ search:
 Our tutorials cover specific use cases in {{brand}}.
 We host them on our learning platform, [{{academy}}](https://{{academy_domain}}/).
 
-Our tutorials generally require that you [have a {{brand}} account](../howto/getting-started/create-account.md), and that you are [registered](https://{{academy_domain}}/register) on {{academy}}.
-Access to our tutorials is free of charge, however any resources you create in a tutorial will be charged at [our normal rates](https://{{company_domain}}/pricing/).
-You may of course use your [free trial credit](https://{{company_domain}}/free-trial/) to run a tutorial.
+Our tutorials generally require that you [have a {{brand}} account](../howto/getting-started/create-account.md), and that you are registered on [shop.cleura.com](https://shop.{{company_domain}}).
+Once you are registered, you may go to our [Cloud Course Catalog](https://shop.{{company_domain}}/course-category/tutorials/), pick any of the tutorials, and put them in your cart for free.
 
-> If you find our tutorials helpful, you might also be interested in our self-paced online training courses, available from [our course booking site](https://shop.{{company_domain}}).
+Although access to our tutorials is free of charge, please keep in mind that any resources you create in a tutorial will be charged at [our normal rates](https://{{company_domain}}/pricing/).
+You may, of course, run a tutorial using your [free trial credit](https://{{company_domain}}/free-trial/).
 
-Our tutorials are grouped by general topics.
+> If you find our tutorials helpful, you might also be interested in our self-paced online training courses, available for a fee from [our course booking site](https://shop.{{company_domain}}).
 
-## Ansible tutorials
+Our tutorials are grouped by general topics:
 
-These tutorials cover how you can best automate virtual resources in {{brand}} using [Ansible](https://www.ansible.com/).
-
-* [Managing {{brand}} resources with Ansible](https://{{academy_domain}}/ct111): Use the `openstack.cloud` Ansible collection to create networks, routers, and servers in {{brand}}.
-* [Using an Ansible dynamic inventory to discover and manage {{brand}} servers](https://{{academy_domain}}/ct112): Use an Ansible dynamic inventory plugin to automate the discovery of your cloud resources, enabling the management of massively scalable virtual data centers in {{brand}}.
-
-## OpenStack Heat tutorials
-
-These tutorials cover the management of complex virtual resource assemblies ("stacks") in {{brand}} using the [OpenStack Heat](https://docs.openstack.org/heat/latest/) orchestration framework.
-
-* [Using OpenStack Heat to manage {{brand}} resources](https://{{academy_domain}}/ct113): Use OpenStack Heat to automate the creation, update, and configuration of {{brand}} resources.
-
-## Terraform tutorials
-
-These tutorials cover the deployment of virtual resources in {{brand}} using [Terraform](https://www.terraform.io/) configurations.
-
-* [Using Terraform to manage {{brand}} resources](https://{{academy_domain}}/ct114): Use Terraform to create and manage {{brand}} server and network resources.
-
-## Container tutorials
-
-* [Managing containerized workloads in {{brand}}](https://{{academy_domain}}/ct115): Deploy and manage Kubernetes clusters in {{brand}} with {{k8s_management_service}}.
+* [Ansible tutorials](ansible.md)
+* [Container tutorials](containers.md)
+* [OpenStack Heat tutorials](heat.md)
+* [OpenTofu tutorials](tf.md)

--- a/docs/tutorials/tf.md
+++ b/docs/tutorials/tf.md
@@ -1,0 +1,9 @@
+---
+description: Tutorials covering orchestration with OpenTofu.
+---
+
+# OpenTofu tutorials
+
+These tutorials cover the deployment of virtual resources in {{brand}} using [OpenTofu](https://opentofu.org/) configurations.
+
+* [Using OpenTofu to manage {{brand}} resources](https://{{academy_domain}}/ct114): Use OpenTofu to create and manage {{brand}} server and network resources.


### PR DESCRIPTION
Said section was included in navigation but commented out, in 5d10acbe79e215ebd8d09461bb9b5feb3e27038b.

- Update information on picking up tutorials,
- split up the monolithic page into multiple sections,
- replace all mentions of Terraform with OpenTofu,
- introduce minor modifications for syntax and emphasis,
- ensure the tutorials index page can be included in site-wide search results.