### PR TITLE
build: Add a facility to disable the linkcheck script

### DIFF
--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -ex
 
+if [ -n "$DOCS_DISABLE_LINKCHECK" ]; then
+    echo "Linkcheck disabled, unset DOCS_DISABLE_LINKCHECK to enable" >&2
+    exit 0
+fi
+
 DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
 
 if test `basename $0` = "linkcheck-local.sh"; then


### PR DESCRIPTION
When `DOCS_DISABLE_LINKCHECK` is set to any non-empty value in the environment, abort `linkcheck.sh` with a warning.