### PR TITLE
build: Remove exclude-search plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,6 @@ markdown_extensions:
   - tables
 plugins:
   - awesome-pages
-  - exclude-search
   - git-authors:
       enabled: true
       show_email_address: false

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ passenv = DOCS_*
 deps =
   mkdocs
   mkdocs-awesome-pages-plugin
-  mkdocs-exclude-search
   mkdocs-git-authors-plugin>=0.6.5
   mkdocs-git-revision-date-localized-plugin
   mkdocs-glightbox


### PR DESCRIPTION
We've been using mkdocs-material's native search exclusion functionality for a while, and haven't had any use for the separate
`exclude-search` plugin.

Thus, remove it from `tox.ini` and `mkdocs.yml`.

References:
* https://github.com/chrieke/mkdocs-exclude-search
* https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-exclusion
