### PR TITLE
build: Use deploy-gitlab testenv for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,7 @@ test:
 .pages:
   stage: deploy
   script:
-    - tox -e build
-    - mv site public
+    - tox -e deploy-gitlab
   artifacts:
     paths:
       - public


### PR DESCRIPTION
Rather than using the `build` testenv for the pages build from GitLab CI, use the `deploy-gitlab` testenv which we have for just that purpose.

See also: 31cc8e121da9f1da0912779b8e78b51cba9c396f
