### PR TITLE
chore: One sentence per line for How-to guides index 

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,26 +1,16 @@
 # About our How-To guides
 
-In this section you’ll find details about how you can accomplish
-specific tasks in {{brand}} and the services we support.
+In this section you’ll find details about how you can accomplish specific tasks in {{brand}} and the services we support.
 
-There are several categories of How-To guides, and they tend to be
-focused on a specific cloud technology.
+There are several categories of How-To guides, and they tend to be focused on a specific cloud technology.
 
-* **Getting Started** How-Tos help you create an account in {{brand}},
-  and start using our services.
+* **Getting Started** How-Tos help you create an account in {{brand}}, and start using our services.
 
-* **Kubernetes** How-Tos cover how you can create and manage your
-  Kubernetes deployments using {{gui}}.
+* **Kubernetes** How-Tos cover how you can create and manage your Kubernetes deployments using {{gui}}.
 
-* **Object storage** How-Tos deal with the S3 and Swift object storage
-  APIs, and how you can use them for object storage in
-  {{brand}}.
+* **Object storage** How-Tos deal with the S3 and Swift object storage APIs, and how you can use them for object storage in {{brand}}.
 
-* **OpenStack CLI/API** How-Tos cover tasks that you can accomplish
-  with the OpenStack command line interfaces and application
-  programming interfaces. They generally do not depend on any adjacent
-  services or tools, just your {{brand}} OpenStack
-  credentials, the `openstack` client, and/or the native OpenStack
-  APIs.
+* **OpenStack CLI/API** How-Tos cover tasks that you can accomplish with the OpenStack command line interfaces and application programming interfaces.
+  They generally do not depend on any adjacent services or tools, just your {{brand}} OpenStack credentials, the `openstack` client, and/or the native OpenStack APIs.
 
 * **{{brand}} Marketplace** How-Tos cover deploying applications or services available in the {{brand}} Marketplace.


### PR DESCRIPTION
Reformat the "About our How-To guides" page to one sentence per line.