### PR TITLE
build: Allow long body lines in commit messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,7 @@
 [general]
 contrib=contrib-title-conventional-commits
 regex-style-search=true
+ignore=body-max-line-length
 
 # When invoked as just "gitlint" without any other arguments, Gitlint
 # processes the most recent commit message *unless* it's being fed


### PR DESCRIPTION
Since we're doing one sentence per line in Markdown sources, it makes no sense to not also allow that in commit messages.

Thus, disable (ignore) the gitlint body-max-line-length rule that enforces a maximum line length for the commit message body.

Retaining the corresponding rule for commit message subjects (title-max-length) is still a good idea because it promotes brevity in those.
