### PR TITLE
chore: Apply the one sentence per line policy in the Kubernetes category

### DIFF
--- a/docs/howto/kubernetes/gardener/index.md
+++ b/docs/howto/kubernetes/gardener/index.md
@@ -7,7 +7,8 @@ You can read more about {{k8s_management_service}} and its capabilities on its [
 
 ## Activating the {{k8s_management_service}} service
 
-To use {{brand_container_orchestration}}, you first need to *activate* the service. You can conveniently do this via the {{gui}}.
+To use {{brand_container_orchestration}}, you first need to *activate* the service.
+You can conveniently do this via the {{gui}}.
 
 To activate {{k8s_management_service}}, select Containers → [{{k8s_management_service}}](https://{{gui_domain}}/containers/gardener) in the side panel.
 Then, click the _Activate {{k8s_management_service}} Service_ button:

--- a/docs/howto/kubernetes/index.md
+++ b/docs/howto/kubernetes/index.md
@@ -1,11 +1,8 @@
 # Kubernetes in Cleura Cloud
 
-In {{brand}}, you have several options for deploying and managing
-Kubernetes clusters.
+In {{brand}}, you have several options for deploying and managing Kubernetes clusters.
 
-[{{gui}}](https://{{gui_domain}}) includes management interfaces for
-[{{k8s_management_service}}](gardener/index.md) and [OpenStack Magnum](magnum/index.md). To manage
-Magnum clusters, you can also use the [OpenStack command-line
-interface](../getting-started/enable-openstack-cli.md).
+[{{gui}}](https://{{gui_domain}}) includes management interfaces for [{{k8s_management_service}}](gardener/index.md) and [OpenStack Magnum](magnum/index.md).
+To manage Magnum clusters, you can also use the [OpenStack command-line interface](../getting-started/enable-openstack-cli.md).
 
 To assess which facility is more suitable for your specific deployment scenario and use case, refer to [this summary](../../background/kubernetes/index.md).

--- a/docs/howto/kubernetes/magnum/index.md
+++ b/docs/howto/kubernetes/magnum/index.md
@@ -1,15 +1,10 @@
 # Magnum
 
-Magnum lets you create clusters via the OpenStack APIs. To do that,
-you base your configuration on a Cluster Template. The template
-defines parameters, such as worker flavors, which describe how the
-cluster will be constructed. In each region, we offer predefined public
-Cluster Templates with ready-to-use configurations. To learn more
-about Cluster Templates, check out the [Magnum
-documentation](https://docs.openstack.org/magnum/latest/user/#clustertemplate).
+Magnum lets you create clusters via the OpenStack APIs.
+To do that, you base your configuration on a Cluster Template.
+The template defines parameters, such as worker flavors, which describe how the cluster will be constructed.
+In each region, we offer predefined public Cluster Templates with ready-to-use configurations.
+To learn more about Cluster Templates, check out the [Magnum documentation](https://docs.openstack.org/magnum/latest/user/#clustertemplate).
 
-Once you have chosen your Cluster Template, you move on to [create a
-cluster based on that
-template](../../openstack/magnum/new-k8s-cluster.md). When you create
-the cluster, you can define the number of nodes, ask
-for multiple masters behind a load balancer, etc.
+Once you have chosen your Cluster Template, you move on to [create a cluster based on that template](../../openstack/magnum/new-k8s-cluster.md).
+When you create the cluster, you can define the number of nodes, ask for multiple masters behind a load balancer, etc.


### PR DESCRIPTION
We reformat all index files in the Kubernetes category to follow the one sentence per line policy.