### PR TITLE
chore: Apply the one sentence per line policy in the s3 subcategory

### DIFF
--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -1,31 +1,22 @@
 # Working with S3-compatible credentials
 
-When you want to interact with object storage in {{brand}} using
-tools that support an Amazon S3 compatible API (such as `s3cmd`,
-`rclone`, the `aws` CLI, or the Python `boto3` library), you need an
-S3-compatible access key ID and secret key.
+When you want to interact with object storage in {{brand}} using tools that support an Amazon S3 compatible API (such as `s3cmd`, `rclone`, the `aws` CLI, or the Python `boto3` library), you need an S3-compatible access key ID and secret key.
 
 ## Creating credentials
 
-You can create a set of S3-compatible credentials with the following
-command:
+You can create a set of S3-compatible credentials with the following command:
 
 ```bash
 openstack ec2 credentials create
 ```
 
-This will return an `Access` and `Secret` key that you can use to
-populate the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-environment variables (or whichever configuration options your
-application requires).
+This will return an `Access` and `Secret` key that you can use to populate the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables (or whichever configuration options your application requires).
 
-> Your S3-compatible credentials are always scoped to your
-> {{brand}} *region* and *project*. You cannot reuse an access
-> and secret key across multiple regions or projects.
+> Your S3-compatible credentials are always scoped to your {{brand}} *region* and *project*.
+> You cannot reuse an access and secret key across multiple regions or projects.
 >
-> Also, your credentials are only “S3-compatible” in the sense that
-> they use the same *format* as AWS S3 does. They are never valid against
-> AWS S3 itself.
+> Also, your credentials are only “S3-compatible” in the sense that they use the same *format* as AWS S3 does.
+> They are never valid against AWS S3 itself.
 
 ## Listing credentials
 
@@ -37,8 +28,7 @@ openstack ec2 credentials list
 
 ## Configuring your S3 API client
 
-Once you have obtained your S3-compatible access and secret key, you
-need to configure your S3 client with it.
+Once you have obtained your S3-compatible access and secret key, you need to configure your S3 client with it.
 
 How exactly you do that depends on your preferred client:
 
@@ -105,12 +95,9 @@ How exactly you do that depends on your preferred client:
       https://s3-<region>.{{brand_domain}} \
       <access-key> <secret-key>
     ```
-    Once you have configured an alias like this, you are able to
-    run bucket operations with `mc` using the `alias/bucket` syntax.
+    Once you have configured an alias like this, you are able to run bucket operations with `mc` using the `alias/bucket` syntax.
 === "s3cmd"
-    `s3cmd` does not support configuration profiles, so you need to use
-    a separate configuration file for each {{brand}} region you
-    want to use:
+    `s3cmd` does not support configuration profiles, so you need to use a separate configuration file for each {{brand}} region you want to use:
     ```bash
     s3cmd -c ~/.s3cfg-<region> --configure
     ```
@@ -118,14 +105,12 @@ How exactly you do that depends on your preferred client:
     * Set your `Access Key` and `Secret Key` when prompted.
     * Leave `Default Region` unchanged.
     * Set `S3 Endpoint` to `s3-<region>.{{brand_domain}}`.
-    * Set `DNS-style bucket+hostname:port template for accessing a bucket`
-      to `s3-<region>.{{brand_domain}}` as well.
+    * Set `DNS-style bucket+hostname:port template for accessing a bucket` to `s3-<region>.{{brand_domain}}` as well.
     * Set `Use HTTPS protocol` to `Yes` (the default).
     * Configure GnuPG encryption and your HTTP proxy server, if needed.
     * Test access with your supplied credentials.
 
-    On subsequent invocations of the `s3cmd` CLI, always add the
-    `-c ~/.s3cfg-<region>` option.
+    On subsequent invocations of the `s3cmd` CLI, always add the `-c ~/.s3cfg-<region>` option.
 === "rclone"
     Create or edit the configuration file named `~/.rclone.conf`, and insert a section named after your {{brand}} region.
     That section should contain the following content:
@@ -142,12 +127,10 @@ How exactly you do that depends on your preferred client:
 
 ## Deleting credentials
 
-If at any time you need to delete a set of AWS-compatible credentials,
-you can do so with the following command:
+If at any time you need to delete a set of AWS-compatible credentials, you can do so with the following command:
 
 ```bash
 openstack ec2 credentials delete <access-key-id>
 ```
 
-> Deleting a set of S3-compatible credentials will *immediately*
-> revoke access for any applications that were using it.
+> Deleting a set of S3-compatible credentials will *immediately* revoke access for any applications that were using it.

--- a/docs/howto/object-storage/s3/expiry.md
+++ b/docs/howto/object-storage/s3/expiry.md
@@ -3,16 +3,14 @@ description: You can set a bucket’s lifecycle configuration such that it autom
 ---
 # Object expiry
 
-> Object expiry requires that you configure your environment with
-> [working S3-compatible credentials](credentials.md).
+> Object expiry requires that you configure your environment with [working S3-compatible credentials](credentials.md).
 
 {{page.meta.description}}
 
 ## Enabling object expiry
 
-First, you need to create a JSON file, `lifecycle.json`, that contains
-the lifecycle configuration rule. Be sure to set `Days` to your
-desired value:
+First, you need to create a JSON file, `lifecycle.json`, that contains the lifecycle configuration rule.
+Be sure to set `Days` to your desired value:
 
 ```json
 {
@@ -27,8 +25,7 @@ desired value:
 }
 ```
 
-Then, apply this lifecycle configuration to your bucket using one of
-the following commands:
+Then, apply this lifecycle configuration to your bucket using one of the following commands:
 
 === "aws"
     ```bash
@@ -48,28 +45,23 @@ the following commands:
 
 ## Removing object expiry
 
-At some point, you might want to remove the object expiry
-functionality configuration from a bucket, so that objects in it no
-longer auto-delete after a period.
+At some point, you might want to remove the object expiry functionality configuration from a bucket, so that objects in it no longer auto-delete after a period.
 
 === "aws"
-    With the `aws s3api` command, you can remove the lifecycle
-    configuration from a bucket:
+    With the `aws s3api` command, you can remove the lifecycle configuration from a bucket:
     ```bash
     aws --profile <region> \
       s3api delete-bucket-lifecycle \
       --bucket <bucket-name>
     ```
 === "mc"
-    With `mc`, you are able to remove just an individual bucket
-    lifecycle rule. Assuming your rule uses the ID `cleanup`, here is
-    how you remove it:
+    With `mc`, you are able to remove just an individual bucket lifecycle rule.
+    Assuming your rule uses the ID `cleanup`, here is how you remove it:
     ```bash
     mc ilm rm --id "cleanup" <region>/<bucket-name>
     ```
 === "s3cmd"
-    With `s3cmd`, you can remove the lifecycle configuration from a
-    bucket:
+    With `s3cmd`, you can remove the lifecycle configuration from a bucket:
     ```bash
     s3cmd -c ~/.s3cfg-<region> dellifecycle s3://<bucket-name>
     ```

--- a/docs/howto/object-storage/s3/index.md
+++ b/docs/howto/object-storage/s3/index.md
@@ -1,16 +1,10 @@
 # S3 API
 
-[S3](https://en.wikipedia.org/wiki/Amazon_S3) is an object-access API
-based on HTTP and HTTPS.
+[S3](https://en.wikipedia.org/wiki/Amazon_S3) is an object-access API based on HTTP and HTTPS.
 
-In {{brand}}, you interact with the S3 API using either the `s3cmd`
-command-line interface (CLI), the MinIO client CLI (`mc`), or the
-standard `aws` CLI.
+In {{brand}}, you interact with the S3 API using either the `s3cmd` command-line interface (CLI), the MinIO client CLI (`mc`), or the standard `aws` CLI.
 
-Either way, [in addition to installing and configuring the Python
-`openstackclient`
-module](../../getting-started/enable-openstack-cli.md), you need to
-install one of the aforementioned utilities.
+Either way, [in addition to installing and configuring the Python `openstackclient` module](../../getting-started/enable-openstack-cli.md), you need to install one of the aforementioned utilities.
 
 === "Debian/Ubuntu"
     ```bash
@@ -27,6 +21,5 @@ install one of the aforementioned utilities.
 
 ## Availability
 
-The S3 API is available in select {{brand}} regions. Refer to [the
-feature support matrix](../../../reference/features/index.md) for details on S3 API
-availability.
+The S3 API is available in select {{brand}} regions.
+Refer to [the feature support matrix](../../../reference/features/index.md) for details on S3 API availability.

--- a/docs/howto/object-storage/s3/object-lock.md
+++ b/docs/howto/object-storage/s3/object-lock.md
@@ -4,10 +4,8 @@ description: Object lock enables you to keep S3 objects from being deleted or ov
 # Object lock
 
 
-Object lock is a feature in S3 that enables you to lock your objects
-to prevent them from being deleted or overwritten. This feature can be
-helpful when you want to maintain data integrity, comply with
-regulations, or retain data for a specific period.
+Object lock is a feature in S3 that enables you to lock your objects to prevent them from being deleted or overwritten.
+This feature can be helpful when you want to maintain data integrity, comply with regulations, or retain data for a specific period.
 
 Note that this feature is distinct from *object expiry*, which is covered in a [separate guide](expiry.md).
 
@@ -43,8 +41,7 @@ Note that this will enable [bucket versioning](versioning.md) as well.
 
 ## Configure the default object lock mode and retention period for a bucket
 
-To configure your bucket to use the **Compliance** mode,
-use one of the following commands:
+To configure your bucket to use the **Compliance** mode, use one of the following commands:
 
 === "aws"
     ```bash
@@ -62,18 +59,13 @@ use one of the following commands:
     ```
     > The `--default` parameter sets the default object lock settings for new objects, and is optional.
 
-    > To specify a duration, use a string formatted as `Nd`
-    > for days or `Ny` for years.
-    > For example, use `30d` to indicate 30 days after
-    > the object creation, or use `1y` to indicate 1 year
-    > after the object creation.
+    > To specify a duration, use a string formatted as `Nd` for days or `Ny` for years.
+    > For example, use `30d` to indicate 30 days after the object creation, or use `1y` to indicate 1 year after the object creation.
 
 ## Configure the object lock mode and retention period for a single object
 
-If you want to set a specific retention period for an object,
-instead of using the default retention period, use one of the
-following commands. You can also use these commands to update
-the retention period for an object:
+If you want to set a specific retention period for an object, instead of using the default retention period, use one of the following commands.
+You can also use these commands to update the retention period for an object:
 
 === "aws"
     ```bash
@@ -83,27 +75,21 @@ the retention period for an object:
       --key <object-name> \
       --retention '{ "Mode": "COMPLIANCE", "RetainUntilDate": "2023-01-01T12:00:00.00Z" }'
     ```
-    > For the value of the `RetainUntilDate` parameter, use the
-    > [ISO 8601 date-time representation](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
-    > format.
+    > For the value of the `RetainUntilDate` parameter, use the [ISO 8601 date-time representation](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) format.
 === "mc"
     ```bash
     mc retention set \
       COMPLIANCE 30d \
       <region>/<bucket>/<object-name>
     ```
-    > To specify a duration, use a string formatted as `Nd`
-    > for days or `Ny` for years.
-    > For example, use `30d` to indicate 30 days after
-    > the object creation, or use `1y` to indicate 1 year
-    > after the object creation.
+    > To specify a duration, use a string formatted as `Nd` for days or `Ny` for years.
+    > For example, use `30d` to indicate 30 days after the object creation, or use `1y` to indicate 1 year after the object creation.
 
 ## Retrieve the object lock mode and retention period
 
 ### Bucket-level
 
-To view the default object lock mode and retention period set on
-a bucket, use the following command:
+To view the default object lock mode and retention period set on a bucket, use the following command:
 
 === "aws"
     ```bash
@@ -142,8 +128,7 @@ a bucket, use the following command:
 
 ### Object-level
 
-To view the default object lock mode and retention period set on
-an object, use the following command:
+To view the default object lock mode and retention period set on an object, use the following command:
 
 === "aws"
     ```bash
@@ -161,9 +146,7 @@ an object, use the following command:
       }
     }
     ```
-    > For the value of the `RetainUntilDate` parameter, use the
-    > [ISO 8601 date-time representation](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
-    > format.
+    > For the value of the `RetainUntilDate` parameter, use the [ISO 8601 date-time representation](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) format.
 === "mc"
     ```bash
     mc retention info --json <region>/<bucket>/<object-name>
@@ -183,20 +166,15 @@ an object, use the following command:
 
 ## Configure the object lock legal hold for an object
 
-**Legal hold** requires that the specified bucket
-has object locking enabled.
+**Legal hold** requires that the specified bucket has object locking enabled.
 
 ### Per bucket
 
-To configure the legal hold for all objects in a bucket,
-use the following command:
+To configure the legal hold for all objects in a bucket, use the following command:
 
 === "aws"
-    The `aws s3api`
-    command **can only set the legal hold for a single object**
-    at a time. However, you can use the `ls` command along with
-    `--recursive` to list all objects in a bucket, and then
-    set the legal hold for each object in your bucket.
+    The `aws s3api` command **can only set the legal hold for a single object** at a time.
+    However, you can use the `ls` command along with `--recursive` to list all objects in a bucket, and then set the legal hold for each object in your bucket.
 
     ```bash
     aws --profile <region> \
@@ -214,8 +192,7 @@ use the following command:
 
 ### Per object
 
-To configure the legal hold for a single object,
-use the following command:
+To configure the legal hold for a single object, use the following command:
 
 === "aws"
     ```bash
@@ -226,8 +203,7 @@ use the following command:
       --version-id <version-id> \
       --legal-hold Status=ON
     ```
-    > Note that if you don't specify a version ID, the legal hold
-    > will be applied to the latest version of the object.
+    > Note that if you don't specify a version ID, the legal hold will be applied to the latest version of the object.
 === "mc"
     ```bash
     mc legalhold set \

--- a/docs/howto/object-storage/s3/sse-c.md
+++ b/docs/howto/object-storage/s3/sse-c.md
@@ -60,8 +60,7 @@ Once you have your encryption secret available, you can create or access enabled
        aws --profile <region> \
          s3 mb s3://{{brand|lower|replace(' ','')}}-encrypted
        ```
-    2. Sync a directory to the S3 bucket, encrypting the files it
-       contains on upload:
+    2. Sync a directory to the S3 bucket, encrypting the files it contains on upload:
        ```bash
        aws --profile <region> \
          s3 sync \
@@ -119,7 +118,8 @@ Once you have your encryption secret available, you can create or access enabled
     > `s3cmd` does contain a *client* side encryption facility, using GnuPG for encryption.
     > It also supports SSE-KMS, which is a different SSE flavor that is currently not available in {{brand}}.
 === "rclone"
-    SSE-C encryption has been implemented/fixed with version 1.54. Earlier `rclone` versions won't work.
+    SSE-C encryption has been implemented/fixed with version 1.54.
+    Earlier `rclone` versions won't work.
 
     1. To start with, modify the section in your configuration file that is named after your target region, adding the `sse_customer_algorithm` option:
        ```ini

--- a/docs/howto/object-storage/s3/versioning.md
+++ b/docs/howto/object-storage/s3/versioning.md
@@ -24,8 +24,7 @@ To enable versioning in a bucket, use one of the following commands:
 
 ## Checking bucket versioning status
 
-To check whether object versioning is enabled on a bucket, use one of
-the following commands:
+To check whether object versioning is enabled on a bucket, use one of the following commands:
 
 === "aws"
     ```bash
@@ -42,8 +41,7 @@ the following commands:
 
 ## Suspending bucket versioning
 
-To suspend versioning on a bucket (versioning cannot be completely
-disabled once enabled), use one of the following commands:
+To suspend versioning on a bucket (versioning cannot be completely disabled once enabled), use one of the following commands:
 
 === "aws"
     ```bash
@@ -59,9 +57,7 @@ disabled once enabled), use one of the following commands:
 
 ## Creating a versioned object
 
-Once object versioning is enabled on a bucket, the normal object
-creation and replacement commands behave in a manner different from
-that in unversioned buckets:
+Once object versioning is enabled on a bucket, the normal object creation and replacement commands behave in a manner different from that in unversioned buckets:
 
 * If the object does not already exist, it is created (as in an unversioned bucket).
 * If the object does exist, it is not replaced.
@@ -88,8 +84,7 @@ that in unversioned buckets:
 
 ## Listing object versions
 
-In a bucket that has versioning enabled, you may list the versions
-available for an object:
+In a bucket that has versioning enabled, you may list the versions available for an object:
 
 === "aws"
     ```bash
@@ -102,15 +97,13 @@ available for an object:
     ```bash
     mc stat --versions <region>/<bucket-name>
     ```
-    This functionality may be impacted by bugs in several versions of
-    the `mc` client.
+    This functionality may be impacted by bugs in several versions of the `mc` client.
 === "s3cmd"
     This functionality is not available with the `s3cmd` command.
 
 ## Retrieving a versioned object
 
-To download a specific version of an object in a bucket, use one of
-the following commands:
+To download a specific version of an object in a bucket, use one of the following commands:
 
 === "aws"
     ```bash
@@ -131,18 +124,14 @@ the following commands:
 === "s3cmd"
     This functionality is not available with the `s3cmd` command.
 
-When you download an object from a versioned bucket *without*
-specifying a version identifier, your S3 client will download the
-latest version of that object.
+When you download an object from a versioned bucket *without* specifying a version identifier, your S3 client will download the latest version of that object.
 
 ## Deleting a versioned object
 
-Like the commands to *create* objects, the commands to *delete* them
-behave differently once object versioning is enabled on a bucket.
+Like the commands to *create* objects, the commands to *delete* them behave differently once object versioning is enabled on a bucket.
 
-The command to delete an object will not delete it, but
-put a delete marker on it instead. This will keep all the versions
-but return a "Not found" 404 on any request not specifying a valid version id.
+The command to delete an object will not delete it, but put a delete marker on it instead.
+This will keep all the versions but return a "Not found" 404 on any request not specifying a valid version id.
 
 === "aws"
     ```bash
@@ -161,8 +150,7 @@ but return a "Not found" 404 on any request not specifying a valid version id.
     s3cmd -c ~/.s3cfg-<region> del s3://<bucket-name>/<object-name>
     ```
 
-You also have the option of deleting not the latest version, but a
-specific object version:
+You also have the option of deleting not the latest version, but a specific object version:
 
 === "aws"
     ```bash


### PR DESCRIPTION
We reformat all How-Tos and index files in the s3 subcategory of the object-storage category, to follow the one sentence per line policy.