### PR TITLE
chore: Apply the 1 sentence per line policy in the barbican subcategory

### DIFF
--- a/docs/howto/openstack/barbican/generic-secret.md
+++ b/docs/howto/openstack/barbican/generic-secret.md
@@ -1,13 +1,11 @@
 # Generic secret storage
 
-The simplest way to use Barbican is to create and retrieve a securely
-stored, generic secret.
+The simplest way to use Barbican is to create and retrieve a securely stored, generic secret.
 
 ## How to store a generic secret
 
-It is possible to store any secret data with Barbican. The command
-below will create a secret of the type `passphrase`, named `mysecret`,
-which contains the passphrase `my very secret passphrase`.
+It is possible to store any secret data with Barbican.
+The command below will create a secret of the type `passphrase`, named `mysecret`, which contains the passphrase `my very secret passphrase`.
 
 ```bash
 openstack secret store \
@@ -16,10 +14,8 @@ openstack secret store \
   -n mysecret
 ```
 
-> The example output below uses {{brand}}'s `Fra1` region. In
-> other regions, the secret
-> [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-> will differ.
+> The example output below uses {{brand}}'s `Fra1` region.
+> In other regions, the secret [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) will differ.
 
 
 ```console
@@ -39,16 +35,13 @@ openstack secret store \
 +---------------+--------------------------------------------------------------------------------+
 ```
 
-Note that `passphrase` type secrets are symmetrically encrypted, using
-the [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
-encryption algorithm with a 256-bit key length. You can select other
-bit lengths and algorithms with the `-b` and `-a` command line
-options, if desired.
+Note that `passphrase` type secrets are symmetrically encrypted, using the [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) encryption algorithm with a 256-bit key length.
+You can select other bit lengths and algorithms with the `-b` and `-a` command line options, if desired.
 
 ## How to retrieve secrets
 
-Secrets are stored in Barbican in an encrypted format. You can see
-a list of secrets created for your user with the following command:
+Secrets are stored in Barbican in an encrypted format.
+You can see a list of secrets created for your user with the following command:
 
 ```console
 $ openstack secret list
@@ -60,8 +53,7 @@ $ openstack secret list
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 ```
 
-You can retrieve the decrypted secret with the `openstack secret get`
-command, adding the `-p` (or `--payload`) option:
+You can retrieve the decrypted secret with the `openstack secret get` command, adding the `-p` (or `--payload`) option:
 
 ```console
 $ openstack secret get -p \
@@ -73,9 +65,5 @@ $ openstack secret get -p \
 +---------+---------------------------+
 ```
 
-> Unlike many other OpenStack services, which allow you to retrieve
-> object references by name or UUID, Barbican only lets you retrieve
-> secrets by their full
-> [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
-> That URI must include the
-> `https://<region>.{{brand_domain}}:9311/v1/secrets/` prefix.
+> Unlike many other OpenStack services, which allow you to retrieve object references by name or UUID, Barbican only lets you retrieve secrets by their full [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
+> That URI must include the `https://<region>.{{brand_domain}}:9311/v1/secrets/` prefix.

--- a/docs/howto/openstack/barbican/index.md
+++ b/docs/howto/openstack/barbican/index.md
@@ -1,25 +1,21 @@
 # Using Barbican for secret storage
 
-**[Barbican](https://docs.openstack.org/barbican/latest/)** is
-OpenStack's secret storage facility. In {{brand}}, Barbican is
-supported for the following purposes:
+**[Barbican](https://docs.openstack.org/barbican/latest/)** is OpenStack's secret storage facility.
+In {{brand}}, Barbican is supported for the following purposes:
 
 * [Generic secret storage](generic-secret.md),
 * [encryption for persistent volumes](../cinder/encrypted-volumes.md),
 * [certificate storage for HTTPS load balancers](../octavia/tls-lb.md).
 
-To manage secrets with Barbican, you will need the `openstack` command
-line interface (CLI), and its Barbican plugin. You can install them
-both with the following commands:
+To manage secrets with Barbican, you will need the `openstack` command line interface (CLI), and its Barbican plugin.
+You can install them both with the following commands:
 
 ```bash
 pip install python-openstackclient python-barbicanclient
 ```
 
-On Debian/Ubuntu platforms, you may also install these utilities via
-their APT packages:
+On Debian/Ubuntu platforms, you may also install these utilities via their APT packages:
 
 ```bash
 apt install python3-openstackclient python3-barbicanclient
 ```
-


### PR DESCRIPTION
We reformat all How-Tos and index files in the barbican subcategory of the openstack category, to follow the one sentence per line policy.