### PR TITLE
chore: Apply the one sentence per line policy in the neutron subcategory

### DIFF
--- a/docs/howto/openstack/neutron/create-security-groups.md
+++ b/docs/howto/openstack/neutron/create-security-groups.md
@@ -1,17 +1,12 @@
 # Creating security groups
 
-[By definition](https://docs.openstack.org/nova/latest/admin/security-groups.html),
-security groups are _"[...] sets of IP filter rules that are applied
-to all project instances, which define networking access to the
-instance. Group rules are project specific; project members can edit
-the default rules for their group and add new rule sets."_
+[By definition](https://docs.openstack.org/nova/latest/admin/security-groups.html), security groups are _"[...] sets of IP filter rules that are applied to all project instances, which define networking access to the instance.
+Group rules are project specific; project members can edit the default rules for their group and add new rule sets."_
 
 ## Creating a security group
 
-Navigate to the [{{gui}}](https://{{gui_domain}}) page, and log into
-your {{brand}} account. On the other hand, if you prefer to work with
-the OpenStack CLI, please do not forget
-to [source the RC file first](../../getting-started/enable-openstack-cli.md).
+Navigate to the [{{gui}}](https://{{gui_domain}}) page, and log into your {{brand}} account.
+On the other hand, if you prefer to work with the OpenStack CLI, please do not forget to [source the RC file first](../../getting-started/enable-openstack-cli.md).
 
 === "{{gui}}"
     To create a security group, first make sure the left-hand side vertical pane is fully visible.
@@ -33,8 +28,7 @@ to [source the RC file first](../../getting-started/enable-openstack-cli.md).
     openstack security group create <name>
     ```
 
-    When the command is executed successfully, you will get
-    information regarding your new security group:
+    When the command is executed successfully, you will get information regarding your new security group:
 
     ```plain
     +-----------------+--------------------------------------------------------------------------------+
@@ -64,11 +58,8 @@ By default, a security group named `default` has already been created for you.
 Its rules block all traffic from any source (ingress), except from servers and ports in the same security group.
 All traffic to any destination (egress) is allowed by default.
 
-> For accounts created before 2022-11-16, the default security
-> group ingress rules allow all incoming traffic.
-> See [Adjusting a permissive default security group](#adjusting-a-permissive-default-security-group),
-> to learn how to configure this security group according to
-> our recommendations.
+> For accounts created before 2022-11-16, the default security group ingress rules allow all incoming traffic.
+> See [Adjusting a permissive default security group](#adjusting-a-permissive-default-security-group), to learn how to configure this security group according to our recommendations.
 
 === "{{gui}}"
     Navigate to the _Security&nbsp;Groups_ page.
@@ -77,8 +68,7 @@ All traffic to any destination (egress) is allowed by default.
     ![List of rules in the default security group](assets/create-security-groups/default-rules.png)
 
 === "OpenStack CLI"
-    View the details of the `default` security group using the
-    following command:
+    View the details of the `default` security group using the following command:
 
     ```bash
     openstack security group show default
@@ -116,9 +106,7 @@ All traffic to any destination (egress) is allowed by default.
     +-----------------+--------------------------------------------------------------------------------+
     ```
 
-If you want to restrict the ingress rules to disallow access from
-other servers and ports in the group, you need to
-**remove the default two ingress rules.**
+If you want to restrict the ingress rules to disallow access from other servers and ports in the group, you need to **remove the default two ingress rules.**
 
 === "{{gui}}"
     Click each of the red :material-delete-circle: buttons on the right-hand side of the **IPv4 ingress** and also of the **IPv6 ingress** rows.
@@ -362,8 +350,7 @@ Next, create the rules that allow anyone to access a server on **port 80** and *
 
 All the rules for a simple web server are now in place.
 
-For any additional protocol or ingress rule, simply follow the same
-procedure as above.
+For any additional protocol or ingress rule, simply follow the same procedure as above.
 
 ## Adjusting a permissive default security group
 
@@ -427,9 +414,8 @@ We recommend either creating and using a new security group, other than the `def
 
     If the ingress rules have `::/0` and `0.0.0.0/0` values in the `IP Range` column, and `None` in the `Remote Security Group`, then incoming traffic from _any_ source is allowed.
 
-    The IDs of the two ingress rules, one for IPv4 traffic and one for
-    IPv6, are: `5e5e9f4d-1faa-492d-91f1-c105b464072b` and
-    `86b9413a-ad23-46c4-a35e-9306945dc63c` respectively.
+    The IDs of the two ingress rules, one for IPv4 traffic and one for IPv6, are:
+    `5e5e9f4d-1faa-492d-91f1-c105b464072b` and `86b9413a-ad23-46c4-a35e-9306945dc63c` respectively.
 
     Delete them by using the following command:
 

--- a/docs/howto/openstack/neutron/delete-network.md
+++ b/docs/howto/openstack/neutron/delete-network.md
@@ -1,39 +1,28 @@
 # Deleting networks
 
-Deleting a network in {{brand}} may sound like a pretty straightforward
-task --- and it is. It's just that before deleting a network, there are
-some steps we almost always need to take. In what follows we show, step
-by step and through specific examples, how we delete networks using
-either the {{gui}} or the OpenStack CLI.
+Deleting a network in {{brand}} may sound like a pretty straightforward task --- and it is.
+It's just that before deleting a network, there are some steps we almost always need to take.
+In what follows we show, step by step and through specific examples, how we delete networks using either the {{gui}} or the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](../../getting-started/create-account.md) in
-{{brand}}. Additionally, to use the OpenStack CLI, make sure to [enable
-it](../../getting-started/enable-openstack-cli.md) for the region you
-will be working in.
+Whether you choose to work from the {{gui}} or with the OpenStack CLI, you need to [have an account](../../getting-started/create-account.md) in {{brand}}.
+Additionally, to use the OpenStack CLI, make sure to [enable it](../../getting-started/enable-openstack-cli.md) for the region you will be working in.
 
 ## Selecting a network
 
-Unless you already have the ID or know the name of the network you wish
-to delete, you may first list all available networks.
+Unless you already have the ID or know the name of the network you wish to delete, you may first list all available networks.
 
 === "{{gui}}"
-    Fire up your favorite web browser, navigate to the
-    [{{gui}}](https://{{gui_domain}}) start page, and log into your
-    {{brand}} account.
+    Fire up your favorite web browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log into your {{brand}} account.
 
-    In the vertical pane on the left-hand side of the dashboard, expand the
-    _Networking_ section and click _Networks_. In the central pane of the
-    page, you will see all networks in all regions you have access to. For
-    the purposes of this guide, let us assume you no longer need network
-    `carmacks`, so now you want to delete it.
+    In the vertical pane on the left-hand side of the dashboard, expand the _Networking_ section and click _Networks_.
+    In the central pane of the page, you will see all networks in all regions you have access to.
+    For the purposes of this guide, let us assume you no longer need network `carmacks`, so now you want to delete it.
 
     ![Listing networks](assets/del-net/shot-01.png)
 === "OpenStack CLI"
-    To list all available networks in the region you are currently in, type
-    the following:
+    To list all available networks in the region you are currently in, type the following:
 
     ```bash
     openstack network list --internal
@@ -53,22 +42,16 @@ Let us assume you wish to delete the network named `carmacks`.
 
 ## Determining component dependencies
 
-If the network to be deleted has a subnet component --- and most likely
-it will have ---, you will first have to delete the subnet before
-deleting the network. If, in addition, the network is behind a router
-(figurately speaking), then before deleting the subnet, you will have
-to disconnect it from the router. Finally, you will have the option to
-delete the router also. Let us see what the situation is with network
-`carmacks`.
+If the network to be deleted has a subnet component --- and most likely it will have ---, you will first have to delete the subnet before deleting the network.
+If, in addition, the network is behind a router (figurately speaking), then before deleting the subnet, you will have to disconnect it from the router.
+Finally, you will have the option to delete the router also.
+Let us see what the situation is with network `carmacks`.
 
 === "{{gui}}"
-    For more information on `carmacks`, click the three-dot icon
-    (right-hand side of the network row) and select _View details_. Four
-    tabs immediately appear below; _Details_, _Ports_, _Subnets_, and
-    _Routers_. Looking at the _Details_ tab, it is clear that network
-    `carmacks` has a subnet and is behind a router. You may click on tabs
-    _Subnets_ and _Routers_, to see more information regarding the network
-    subnet and the router in front of the network.
+    For more information on `carmacks`, click the three-dot icon (right-hand side of the network row) and select _View details_.
+    Four tabs immediately appear below; _Details_, _Ports_, _Subnets_, and _Routers_.
+    Looking at the _Details_ tab, it is clear that network `carmacks` has a subnet and is behind a router.
+    You may click on tabs _Subnets_ and _Routers_, to see more information regarding the network subnet and the router in front of the network.
 
     ![Network details](assets/del-net/shot-02.png)
 === "OpenStack CLI"
@@ -85,17 +68,14 @@ delete the router also. Let us see what the situation is with network
     +---------+--------------------------------------+
     ```
 
-    If the value for the field `subnets` is non-empty, like in the example
-    output above, that means the network has a subnet indeed, and the value
-    is the ID of that subnet. At this point, it helps to assign the subnet
-    ID to an environment variable, like so:
+    If the value for the field `subnets` is non-empty, like in the example output above, that means the network has a subnet indeed, and the value is the ID of that subnet.
+    At this point, it helps to assign the subnet ID to an environment variable, like so:
 
     ```bash
     SUBNET_ID="7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5"
     ```
 
-    What about a router in front of `carmacks`? You might try checking the
-    output of this command:
+    What about a router in front of `carmacks`? You might try checking the output of this command:
 
     ```bash
     openstack network show carmacks
@@ -135,12 +115,9 @@ delete the router also. Let us see what the situation is with network
     +---------------------------+--------------------------------------+
     ```
 
-    While it usually pays off to use `openstack` commands with the verb
-    `show` on various objects, in this case, you don't get what you're
-    looking for --- which is an indication of the presence or absence of a
-    router in front of `carmacks`. In cases like this, try looking at
-    things from a different vantage point. Try, in particular, to list all
-    routers:
+    While it usually pays off to use `openstack` commands with the verb `show` on various objects, in this case, you don't get what you're looking for --- which is an indication of the presence or absence of a router in front of `carmacks`.
+    In cases like this, try looking at things from a different vantage point.
+    Try, in particular, to list all routers:
 
     ```bash
     openstack router list
@@ -156,8 +133,7 @@ delete the router also. Let us see what the situation is with network
     +------------------------+-----------------+--------+-------+------------------------+------+
     ```
 
-    The name of the second router says it all, but since it is just a name,
-    it doesn't hurt to verify the role of this router:
+    The name of the second router says it all, but since it is just a name, it doesn't hurt to verify the role of this router:
 
     ```bash
     openstack router show carmacks-router -c interfaces_info
@@ -171,13 +147,11 @@ delete the router also. Let us see what the situation is with network
     +-----------------+--------------------------------------------------------------------------------+
     ```
 
-    Looking at the value of `interfaces_info`, it is easy to see that
-    `subnet_id` has the value of the variable `SUBNET_ID` you just
-    instantiated. In other words, router `carmacks-router` is indeed in
-    front of network `carmacks`.
+    Looking at the value of `interfaces_info`, it is easy to see that `subnet_id` has the value of the variable `SUBNET_ID` you just instantiated.
+    In other words, router `carmacks-router` is indeed in front of network `carmacks`.
 
-    > There will be times when router names won't help much. Then, try a
-    more exhaustive search approach:
+    > There will be times when router names won't help much.
+    > Then, try a more exhaustive search approach:
     >
     > ```bash
     > for i in $(openstack router list -f value -c Name); \
@@ -194,72 +168,61 @@ delete the router also. Let us see what the situation is with network
 
 ## Tearing down networks
 
-Now that you know you're dealing with a full-blown network and a
-router, you start by disconnecting the subnet from the router. Then,
-you will move on to deleting the subnet and the network, and after
-that, you can finish up with deleting the router.
+Now that you know you're dealing with a full-blown network and a router, you start by disconnecting the subnet from the router.
+Then, you will move on to deleting the subnet and the network, and after that, you can finish up with deleting the router.
 
 === "{{gui}}"
-    Go to the _Subnets_ tab of the `carmacks` network, and click the gray
-    notepad-and-pen icon (at the left of the red circle-with-trashcan icon).
+    Go to the _Subnets_ tab of the `carmacks` network, and click the gray notepad-and-pen icon (at the left of the red circle-with-trashcan icon).
 
     ![Network subnets](assets/del-net/shot-03.png)
 
-    A vertical pane titled _Modify Subnet_ will slide over from the
-    right-hand side of the page. Pay attention to the _Router Connections_
-    section. You will notice an active connection to the router. Click the
-    red circle-with-line-over-chainlink icon to deactivate the connection,
-    effectively disconnecting the subnet from the router.
+    A vertical pane titled _Modify Subnet_ will slide over from the right-hand side of the page. Pay attention to the _Router Connections_ section.
+    You will notice an active connection to the router.
+    Click the red circle-with-line-over-chainlink icon to deactivate the connection, effectively disconnecting the subnet from the router.
 
     ![Disconnect subnet](assets/del-net/shot-04.png)
 
-    A pop-up window will appear, asking if you really want to go ahead with
-    the disconnection. Just click the red _Yes, Remove interface_ button.
+    A pop-up window will appear, asking if you really want to go ahead with the disconnection.
+    Just click the red _Yes, Remove interface_ button.
 
     ![Remove interface](assets/del-net/shot-05.png)
 
-    After disconnecting the subnet, click the red circle-and-trashcan icon
-    to delete it. Once more, a pop-up will appear asking for confirmation.
+    After disconnecting the subnet, click the red circle-and-trashcan icon to delete it.
+    Once more, a pop-up will appear asking for confirmation.
     Click the red _Yes, Delete_ button.
 
     ![Delete subnet](assets/del-net/shot-06.png)
 
-    As soon as you delete the subnet, in the _Subnets_ tab you will see the
-    message _No subnets found_.
+    As soon as you delete the subnet, in the _Subnets_ tab you will see the message _No subnets found_.
 
     ![No subnets](assets/del-net/shot-07.png)
 
-    You can now delete the network. Click the three-dot icon (right-hand
-    side of the network row) and select _Delete Network_.
+    You can now delete the network.
+    Click the three-dot icon (right-hand side of the network row) and select _Delete Network_.
 
     ![Delete Carmacks](assets/del-net/shot-08.png)
 
-    Of course, you will have to confirm this action. Clicking the red _Yes,
-    Delete_ button is enough.
+    Of course, you will have to confirm this action.
+    Clicking the red _Yes, Delete_ button is enough.
 
     ![Confirm network delete](assets/del-net/shot-09.png)
 
-    After deleting the network, it will not be on the list of all available
-    networks.
+    After deleting the network, it will not be on the list of all available networks.
 
     ![List of networks](assets/del-net/shot-10.png)
 
-    There's still that router lying around, and if you have no use for it,
-    go to the _Routers_ page to delete it. In the vertical pane on the
-    left, expand the _Networking_ section and click on _Routers_. In the
-    central pane of the page, you will see all routers in all regions you
-    have access to.
+    There's still that router lying around, and if you have no use for it, go to the _Routers_ page to delete it.
+    In the vertical pane on the left, expand the _Networking_ section and click on _Routers_.
+    In the central pane of the page, you will see all routers in all regions you have access to.
 
     ![All routers](assets/del-net/shot-11.png)
 
-    Click the red three-dot icon of the router you wish to delete and
-    select _Delete Router_. A pop-up will appear asking for confirmation,
-    so click the red _Yes, Delete_ button.
+    Click the red three-dot icon of the router you wish to delete and select _Delete Router_.
+    A pop-up will appear asking for confirmation, so click the red _Yes, Delete_ button.
 
     ![Confirm router delete](assets/del-net/shot-12.png)
 
-    After successfully deleting the router, there will be no trace of it in
-    the list of all routers.
+    After successfully deleting the router, there will be no trace of it in the list of all routers.
 
     ![Router is gone](assets/del-net/shot-13.png)
 === "OpenStack CLI"
@@ -281,8 +244,8 @@ that, you can finish up with deleting the router.
     +-------------------------------+-----------------+--------------------------------+---------------+
     ```
 
-    As you would expect, included on the list is subnet `carmacks-subnet`,
-    which you are about to delete. That's easier said than done, though:
+    As you would expect, included on the list is subnet `carmacks-subnet`, which you are about to delete.
+    That's easier said than done, though:
 
     ```bash
     openstack subnet delete $SUBNET_ID
@@ -295,25 +258,21 @@ that, you can finish up with deleting the router.
     1 of 1 subnets failed to delete.
     ```
 
-    The trick here is to first disconnect the subnet from the corresponding
-    router, which is perfectly doable from the side of the router. As we
-    discovered a bit earlier, the router we are talking about is
-    `carmacks-router`:
+    The trick here is to first disconnect the subnet from the corresponding router, which is perfectly doable from the side of the router.
+    As we discovered a bit earlier, the router we are talking about is `carmacks-router`:
 
     ```bash
     openstack router remove subnet carmacks-router $SUBNET_ID
     ```
 
-    If the command above is successful, you will see no output on your
-    terminal. Now, an attempt to delete `carmacks-subnet` should go through
-    with flying colors:
+    If the command above is successful, you will see no output on your terminal.
+    Now, an attempt to delete `carmacks-subnet` should go through with flying colors:
 
     ```bash
     openstack subnet delete $SUBNET_ID
     ```
 
-    Again, no command output means success, but we suggest you check
-    yourself:
+    Again, no command output means success, but we suggest you check yourself:
 
     ```bash
     openstack subnet list
@@ -329,9 +288,9 @@ that, you can finish up with deleting the router.
     +--------------------------------+---------------+---------------------------------+---------------+
     ```
 
-    The subnet `carmacks-subnet` is not on the list, which is what you
-    wanted exactly. Next is network `carmacks`, which you should be able to
-    delete by now. First, take a look at all available networks:
+    The subnet `carmacks-subnet` is not on the list, which is what you wanted exactly.
+    Next is network `carmacks`, which you should be able to delete by now.
+    First, take a look at all available networks:
 
     ```bash
     openstack network list --internal
@@ -347,9 +306,8 @@ that, you can finish up with deleting the router.
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
-    Network `carmacks` is on the list, and by looking at the `Subnets`
-    column, you see that it has no subnet. That's expected, so go ahead and
-    delete the network:
+    Network `carmacks` is on the list, and by looking at the `Subnets` column, you see that it has no subnet.
+    That's expected, so go ahead and delete the network:
 
     ```bash
     openstack network delete carmacks
@@ -370,8 +328,7 @@ that, you can finish up with deleting the router.
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
-    Network `carmacks` is gone, and if you have no use of
-    `carmacks-router`, go ahead and delete it:
+    Network `carmacks` is gone, and if you have no use of `carmacks-router`, go ahead and delete it:
 
     ```bash
     openstack router delete carmacks-router
@@ -393,29 +350,23 @@ that, you can finish up with deleting the router.
 
 ## Networks with a subnet but no router
 
-These are faster to delete, for there is no router to disconnect the
-subnet from. For our demonstration, we created network `teslin`, with
-subnet `teslin-subnet` and no router in front of it.
+These are faster to delete, for there is no router to disconnect the subnet from.
+For our demonstration, we created network `teslin`, with subnet `teslin-subnet` and no router in front of it.
 
 === "{{gui}}"
-    In the vertical pane on the left-hand side of the dashboard, expand the
-    _Networking_ section and click _Networks_. In the central pane of the
-    page, you will see all networks in all regions you have access to.
-    Select a network with a subnet and no router --- like `teslin` in our
-    example.
+    In the vertical pane on the left-hand side of the dashboard, expand the _Networking_ section and click _Networks_.
+    In the central pane of the page, you will see all networks in all regions you have access to.
+    Select a network with a subnet and no router --- like `teslin` in our example.
 
-    Looking at the network details, it is immediately apparent that there's
-    no router in front of it.
+    Looking at the network details, it is immediately apparent that there's no router in front of it.
 
     ![No router in sight](assets/del-net/shot-14.png)
 
-    Go to the _Subnets_ tab, and click the red circle-with-trashcan icon to
-    delete the subnet.
+    Go to the _Subnets_ tab, and click the red circle-with-trashcan icon to delete the subnet.
 
     ![Delete subnet](assets/del-net/shot-15.png)
 
-    Then, click the red three-dot icon at the right-hand side of the
-    `teslin` row, and select _Delete Network_.
+    Then, click the red three-dot icon at the right-hand side of the `teslin` row, and select _Delete Network_.
 
     ![Delete Teslin](assets/del-net/shot-16.png)
 === "OpenStack CLI"
@@ -450,15 +401,14 @@ subnet `teslin-subnet` and no router in front of it.
     +--------------------------------+---------------+---------------------------------+---------------+
     ```
 
-    Since there is nothing to disconnect the `teslin-subnet` from, you may
-    go ahead and delete the subnet:
+    Since there is nothing to disconnect the `teslin-subnet` from, you may go ahead and delete the subnet:
 
     ```bash
     openstack subnet delete teslin-subnet
     ```
 
-    There is no command output. This is expected, but why not check
-    yourself?
+    There is no command output.
+    This is expected, but why not check yourself?
 
     ```bash
     openstack subnet list
@@ -478,8 +428,8 @@ subnet `teslin-subnet` and no router in front of it.
     openstack network delete teslin
     ```
 
-    The absence of any output means the command was successful. Take a look
-    yourself:
+    The absence of any output means the command was successful.
+    Take a look yourself:
 
     ```bash
     openstack network list --internal
@@ -495,15 +445,12 @@ subnet `teslin-subnet` and no router in front of it.
 
 ## Networks with no subnet and no router
 
-You may directly, without the slightest preparation, delete networks
-like these. For our demonstration, we created a network named `mayo`,
-with no subnet and no router in front of it.
+You may directly, without the slightest preparation, delete networks like these.
+For our demonstration, we created a network named `mayo`, with no subnet and no router in front of it.
 
 === "{{gui}}"
-    While viewing all available networks, click the red three-dot icon at
-    the right-hand side of the `mayo` row and select _Delete Network_. You
-    will have to confirm the action, and the network will be gone as soon
-    as you do.
+    While viewing all available networks, click the red three-dot icon at the right-hand side of the `mayo` row and select _Delete Network_.
+    You will have to confirm the action, and the network will be gone as soon as you do.
 
     ![Delete Mayo](assets/del-net/shot-17.png)
 === "OpenStack CLI"
@@ -542,11 +489,8 @@ with no subnet and no router in front of it.
 
 ## Recap: Of networks and towns
 
-Depending on the features of a Neutron network, deleting it may require
-some preparation work. For the purposes of this guide, we created three
-different networks with different characteristics; `carmacks`, `teslin`,
-and `mayo`. Then, either from the {{gui}} or with the help of OpenStack
-CLI, we showed how we discover any component dependencies and how we
-work towards deletion. Eventually, all three test networks were gone.
-We should point out, though, that all three namesake towns in Yukon are
-still there.
+Depending on the features of a Neutron network, deleting it may require some preparation work.
+For the purposes of this guide, we created three different networks with different characteristics; `carmacks`, `teslin`, and `mayo`.
+Then, either from the {{gui}} or with the help of OpenStack CLI, we showed how we discover any component dependencies and how we work towards deletion.
+Eventually, all three test networks were gone.
+We should point out, though, that all three namesake towns in Yukon are still there.

--- a/docs/howto/openstack/neutron/multiple-public-ips.md
+++ b/docs/howto/openstack/neutron/multiple-public-ips.md
@@ -1,23 +1,17 @@
 # Assigning multiple public (floating) IPs to a server
 
-In {{brand}}, we do not pass external networks to the compute nodes. This means
-that you, as a user, can not directly attach a server to the public network.
+In {{brand}}, we do not pass external networks to the compute nodes.
+This means that you, as a user, can not directly attach a server to the public network.
 
-In order to provide connectivity to the public network (for IPv4), you need to use
-floating IPs. A floating IP is created in the public subnet,
-and is mapped to the specific network port. All traffic comes through a virtual
-router.
+In order to provide connectivity to the public network (for IPv4), you need to use floating IPs.
+A floating IP is created in the public subnet, and is mapped to the specific network port.
+All traffic comes through a virtual router.
 
-For some scenarios, you might need to have more than one public IP assigned to
-a server. But in case of 1-to-1 NAT (which is how the floating IP is implemented
-under the hood) you can not assign more than one external IP to the internal
-one. And adding a new port to the VM is also not an option, since this would
-result in asymmetric routing, as replies will go through the first interface
-for which a default route is set.
+For some scenarios, you might need to have more than one public IP assigned to a server.
+But in case of 1-to-1 NAT (which is how the floating IP is implemented under the hood) you can not assign more than one external IP to the internal one.
+And adding a new port to the VM is also not an option, since this would result in asymmetric routing, as replies will go through the first interface for which a default route is set.
 
-Instead, you must first configure an additional *private* (“fixed”) IP
-address for your port, then associate a public (“floating”) IP address
-to map to it.
+Instead, you must first configure an additional *private* (“fixed”) IP address for your port, then associate a public (“floating”) IP address to map to it.
 
 
 ## Add an extra IP to the port
@@ -65,8 +59,8 @@ $ openstack port show 51dae637-ad79-4ba9-9e41-78e5e0f3332c -c fixed_ips
 
 > Don't forget to configure new IP as an alias to the interface inside your VM!
 
-When you have an IP address on your port that is not yet assigned to any
-floating IP, you can assign it to the new floating IP. Proceed with:
+When you have an IP address on your port that is not yet assigned to any floating IP, you can assign it to the new floating IP.
+Proceed with:
 
 ```bash
 openstack floating ip set c45a5eaf-2f3a-4679-89fe-266a5cbe840a \
@@ -74,8 +68,7 @@ openstack floating ip set c45a5eaf-2f3a-4679-89fe-266a5cbe840a \
   --fixed-ip-address 10.2.0.228
 ```
 
-Then, list the floating (public) IP addresses, together with their
-fixed (private) counterparts:
+Then, list the floating (public) IP addresses, together with their fixed (private) counterparts:
 
 
 ```console

--- a/docs/howto/openstack/neutron/new-network.md
+++ b/docs/howto/openstack/neutron/new-network.md
@@ -1,38 +1,28 @@
 # Creating new networks
 
-Before creating a server in {{brand}}, you need at least
-one network to make the new server a member of. Since you may have
-more than one network per region, let us now walk through creating
-a new network using the {{gui}} or the OpenStack CLI.
+Before creating a server in {{brand}}, you need at least one network to make the new server a member of.
+Since you may have more than one network per region, let us now walk through creating a new network using the {{gui}} or the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](../../getting-started/create-account.md)
-in {{brand}}. Additionally, to use the OpenStack CLI make sure to
-[enable it first](../../getting-started/enable-openstack-cli.md).
+Whether you choose to work from the {{gui}} or with the OpenStack CLI, you need to [have an account](../../getting-started/create-account.md) in {{brand}}.
+Additionally, to use the OpenStack CLI make sure to [enable it first](../../getting-started/enable-openstack-cli.md).
 
 ## Creating a network
 
-To create a network from the {{gui}}, fire up your favorite web
-browser, navigate to the [Cleura Cloud](https://{{gui_domain}}) start
-page, and login into your {{brand}} account. On the other hand, if you
-prefer to work with OpenStack CLI, please do not forget to source the
-RC file first.
+To create a network from the {{gui}}, fire up your favorite web browser, navigate to the [Cleura Cloud](https://{{gui_domain}}) start page, and login into your {{brand}} account.
+On the other hand, if you prefer to work with OpenStack CLI, please do not forget to source the RC file first.
 
 === "{{gui}}"
-    On the top right-hand side of the {{gui}}, click the _Create_
-    button. A new pane will slide into view from the right-hand side of
-    the browser window, titled _Create_.
+    On the top right-hand side of the {{gui}}, click the _Create_ button.
+    A new pane will slide into view from the right-hand side of the browser window, titled _Create_.
 
     ![Create a new object](assets/new-net-panel/shot-01.png)
 
-    You will notice several rounded boxes prominently displayed on that
-    pane, each for defining, configuring, and instantiating a different
-    {{brand}} object. Go ahead and click the _Network_ box. A
-    new pane titled _Create Network_ will slide over. At the top, type
-    in a name and select one of the available regions for the new
-    network.
+    You will notice several rounded boxes prominently displayed on that pane, each for defining, configuring, and instantiating a different {{brand}} object.
+    Go ahead and click the _Network_ box.
+    A new pane titled _Create Network_ will slide over.
+    At the top, type in a name and select one of the available regions for the new network.
 
     ![New network name and region](assets/new-net-panel/shot-02.png)
 === "OpenStack CLI"
@@ -43,8 +33,7 @@ RC file first.
     openstack network create nordostbahnhof
     ```
 
-    After issuing the command above, you immediately get information
-    regarding the new network:
+    After issuing the command above, you immediately get information regarding the new network:
 
     ```plain
     +---------------------------+------------------------------------------------------------+
@@ -87,16 +76,11 @@ RC file first.
 
 ## Adding a subnet and a router
 
-Creating a new network does not necessarily mean it has all the
-features you most likely would expect. Unless you work from the
-{{gui}}, where almost every component is activated for you with
-a few clicks here and there, when you use the OpenStack CLI there is
-some extra work you need to do before you get a network you would
-characterize as useful.
+Creating a new network does not necessarily mean it has all the features you most likely would expect.
+Unless you work from the {{gui}}, where almost every component is activated for you with a few clicks here and there, when you use the OpenStack CLI there is some extra work you need to do before you get a network you would characterize as useful.
 
 === "{{gui}}"
-    Expand the _Advanced Options_ section below, make sure _Port Security_
-    is enabled, and leave the MTU parameter blank.
+    Expand the _Advanced Options_ section below, make sure _Port Security_ is enabled, and leave the MTU parameter blank.
 
     ![MTU and port security](assets/new-net-panel/shot-03.png)
 
@@ -127,10 +111,9 @@ characterize as useful.
 
     ![IPv6-based network parameters](assets/new-net-panel/shot-04-toronto.png)
 
-    Scroll down a bit if you have to. Assuming you want your cloud
-    servers to reach hosts on the Internet, for the _External network_
-    parameter make sure you select _ext-net_. Then, click the green
-    _Create_ button.
+    Scroll down a bit if you have to.
+    Assuming you want your cloud servers to reach hosts on the Internet, for the _External network_ parameter make sure you select _ext-net_.
+    Then, click the green _Create_ button.
     In a few seconds, the new network will be readily available.
 
     ![Finish creating network](assets/new-net-panel/shot-05.png)
@@ -228,10 +211,8 @@ characterize as useful.
     +----------------------+-----------------------------------------------------------------+
     ```
 
-    If you want servers connected to the `nordostbahnhof` network to have
-    Internet access, you need a router in front of the network. Following
-    our unofficial naming convention, go ahead and create a new router
-    called `nordostbahnhof-router`:
+    If you want servers connected to the `nordostbahnhof` network to have Internet access, you need a router in front of the network.
+    Following our unofficial naming convention, go ahead and create a new router called `nordostbahnhof-router`:
 
     ```bash
     openstack router create nordostbahnhof-router 
@@ -266,17 +247,15 @@ characterize as useful.
     +-------------------------+--------------------------------------------------------------+
     ```
 
-    You want the `nordostbahnhof-router` connected to the external
-    network. The name of this network is `ext-net`:
+    You want the `nordostbahnhof-router` connected to the external network.
+    The name of this network is `ext-net`:
 
     ```bash
     openstack router set nordostbahnhof-router --external-gateway ext-net
     ```
 
-    Please note that if the command above is successful, you will get
-    no output on your terminal. There is one last step to take, and
-    that is to connect router `nordostbahnhof-router` to the subnet
-    `nordostbahnhof-subnet-ipv4`...
+    Please note that if the command above is successful, you will get no output on your terminal.
+    There is one last step to take, and that is to connect router `nordostbahnhof-router` to the subnet `nordostbahnhof-subnet-ipv4`...
 
     ```bash
     openstack router add subnet nordostbahnhof-router nordostbahnhof-subnet-ipv4
@@ -292,15 +271,11 @@ characterize as useful.
 
 ## Listing networks and getting information
 
-At any time, you may connect to the {{gui}}, list all networks
-you have already created, and get detailed information for any of
-these networks. Alternatively, you may get all that information using
-the OpenStack CLI.
+At any time, you may connect to the {{gui}}, list all networks you have already created, and get detailed information for any of these networks.
+Alternatively, you may get all that information using the OpenStack CLI.
 
 === "{{gui}}"
-    You may see all defined networks, in all supported regions, by
-    selecting _Networking_ > _Networks_ (see the left-hand side pane
-    on the {{gui}}).
+    You may see all defined networks, in all supported regions, by selecting _Networking_ > _Networks_ (see the left-hand side pane on the {{gui}}).
 
     ![All networks in all regions](assets/new-net-panel/shot-06.png)
 
@@ -316,8 +291,8 @@ the OpenStack CLI.
     openstack network list
     ```
 
-    You can always ask for more specific results. For instance, to see
-    all internal networks only, type the following:
+    You can always ask for more specific results.
+    For instance, to see all internal networks only, type the following:
 
     ```bash
     openstack network list --internal
@@ -329,7 +304,4 @@ the OpenStack CLI.
     openstack network show nordostbahnhof
     ```
 
-    At any time, type `openstack network list --help` or
-    `openstack network show --help` to see how to get information
-    regarding networks, and what specific pieces of information you
-    can have.
+    At any time, type `openstack network list --help` or `openstack network show --help` to see how to get information regarding networks, and what specific pieces of information you can have.

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -1,29 +1,22 @@
 # Creating a VPN connection between regions
 
-Thanks to the Openstack Neutron VPN as a Service (VPNaaS) feature, you
-can bridge two different regions via a site-to-site IPSec VPN
-connection. This is made possible without setting up and configuring a
-virtual machine in any one of the regions. On the contrary, you can
-quickly establish such a connection using the {{gui}} or the OpenStack
-CLI. Let us demonstrate the process following both approaches.
+Thanks to the Openstack Neutron VPN as a Service (VPNaaS) feature, you can bridge two different regions via a site-to-site IPSec VPN connection.
+This is made possible without setting up and configuring a virtual machine in any one of the regions.
+On the contrary, you can quickly establish such a connection using the {{gui}} or the OpenStack CLI.
+Let us demonstrate the process following both approaches.
 
 ## Prerequisites
 
-Whether you choose to work from the {{gui}} or with the OpenStack CLI,
-you need to [have an account](../../getting-started/create-account.md) in
-{{brand}}. If you prefer to work with the [OpenStack
-CLI](../../getting-started/enable-openstack-cli.md), then in addition to
-the Python `openstackclient` module, you need to install the
-Python `neutronclient` module also. Use either the package manager
-of your operating system or `pip`:
+Whether you choose to work from the {{gui}} or with the OpenStack CLI, you need to [have an account](../../getting-started/create-account.md) in {{brand}}.
+If you prefer to work with the [OpenStack CLI](../../getting-started/enable-openstack-cli.md), then in addition to the Python `openstackclient` module, you need to install the Python `neutronclient` module also.
+Use either the package manager of your operating system or `pip`:
 
 === "Debian/Ubuntu"
     ```bash
     apt install python3-neutronclient
     ```
 === "Mac OS X with Homebrew"
-    This Python module is unavailable via `brew`, but you can
-    install it via `pip`.
+    This Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
     pip install python-neutronclient
@@ -31,25 +24,19 @@ of your operating system or `pip`:
 
 ## Creating a VPN connection between two regions
 
-To create and establish such a connection from the {{gui}}, fire up
-your favorite web browser, navigate to the
-[{{gui}}](https://{{gui_domain}}) start page, and log into your
-{{brand}} account. Should you decide to follow the OpenStack CLI route
-instead, please make sure you have the appropriate [RC
-file](../../getting-started/enable-openstack-cli.md) for each region
-involved.
+To create and establish such a connection from the {{gui}}, fire up your favorite web browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log into your {{brand}} account.
+Should you decide to follow the OpenStack CLI route instead, please make sure you have the appropriate [RC file](../../getting-started/enable-openstack-cli.md) for each region involved.
 
 === "{{gui}}"
-    On the top right-hand side of the {{gui}}, click the _Create_
-    button. A vertical pane titled _Create_ will slide into view from the
-    right-hand side of the browser window. You will notice several rounded
-    boxes, each one for defining, configuring, and instantiating a
-    different {{brand}} object. Go ahead and click the _VPN_ box.
+    On the top right-hand side of the {{gui}}, click the _Create_ button.
+    A vertical pane titled _Create_ will slide into view from the right-hand side of the browser window.
+    You will notice several rounded boxes, each one for defining, configuring, and instantiating a different {{brand}} object.
+    Go ahead and click the _VPN_ box.
 
     ![Create new object](assets/vpnaas/shot-01.png)
 
-    A new pane titled _Create a VPN Service_ will slide over. Between
-    the two boxes, click the one titled _Quick (Guided) Connect_.
+    A new pane titled _Create a VPN Service_ will slide over.
+    Between the two boxes, click the one titled _Quick (Guided) Connect_.
 
     ![Quick connect](assets/vpnaas/shot-02.png)
 
@@ -57,37 +44,28 @@ involved.
 
     ![Connection name](assets/vpnaas/shot-03.png)
 
-    Select a region, project, and network for each of the two data
-    centers involved.
+    Select a region, project, and network for each of the two data centers involved.
 
     ![Data center choices](assets/vpnaas/shot-04.png)
 
-    Look at the pre-shared key and, optionally, expand the _Advanced
-    Options_ section to see all presets. You do not have to change anything
-    there. When you are ready, click the green _Create_ button. The VPN
-    connection between the two regions will be established in a few seconds.
+    Look at the pre-shared key and, optionally, expand the _Advanced Options_ section to see all presets.
+    You do not have to change anything there.
+    When you are ready, click the green _Create_ button.
+    The VPN connection between the two regions will be established in a few seconds.
 
     ![Create](assets/vpnaas/shot-05.png)
 === "OpenStack CLI"
-    First, you need to have the RC files of the two regions you will be
-    connecting. In the example that follows, we demonstrate establishing a
-    site-to-site connection between regions `fra1` and `kna1`. This means
-    that, while following through, before working in `fra1` you need to
-    source the RC file for `fra1`, and before working in `kna1` you need
-    to source the RC file for `kna1`.
+    First, you need to have the RC files of the two regions you will be connecting.
+    In the example that follows, we demonstrate establishing a site-to-site connection between regions `fra1` and `kna1`.
+    This means that, while following through, before working in `fra1` you need to source the RC file for `fra1`, and before working in `kna1` you need to source the RC file for `kna1`.
 
-    > It helps to imagine the site-to-site connection schematically,
-    with `fra1` being on the left side and `kna1` being on the right side
-    of the connection. That is why we interchange the terms `fra1`, _left_
-    and `kna1`, _right_.
+    > It helps to imagine the site-to-site connection schematically, with `fra1` being on the left side and `kna1` being on the right side of the connection.
+    That is why we interchange the terms `fra1`, _left_ and `kna1`, _right_.
 
-    You also have to decide which subnets from either side you will
-    connect. Additionally, you need to know the respective CIDR notations
-    and routers. In the examples that follow, on the left side we have
-    subnet `subnet-fra1` with CIDR `10.15.25.0/24` and router
-    `router-fra1`, and on the right side we have subnet `subnet-kna1` with
-    CIDR `10.15.20.0/24` and router `router-kna1`. For convenience, we have
-    set the shell variables `SUBNET_FRA1` and `SUBNET_KNA1`:
+    You also have to decide which subnets from either side you will connect.
+    Additionally, you need to know the respective CIDR notations and routers.
+    In the examples that follow, on the left side we have subnet `subnet-fra1` with CIDR `10.15.25.0/24` and router `router-fra1`, and on the right side we have subnet `subnet-kna1` with CIDR `10.15.20.0/24` and router `router-kna1`.
+    For convenience, we have set the shell variables `SUBNET_FRA1` and `SUBNET_KNA1`:
 
     ```bash
     SUBNET_FRA1="10.15.25.0/24"
@@ -121,8 +99,7 @@ involved.
     +-------------------------------+--------------------------------------+
     ```
 
-    Then, create a new [IPSec](https://en.wikipedia.org/wiki/IPsec)
-    policy:
+    Then, create a new [IPSec](https://en.wikipedia.org/wiki/IPsec) policy:
 
     ```bash
     openstack vpn ipsec policy create ipsec-pol-fra1
@@ -172,21 +149,17 @@ involved.
     ```
 
     Notice in the command output that the `Status` is `PENDING_CREATE`.
-    This is expected. Also, jot down the value of the `external_v4_ip`
-    parameter. Better yet, set this value to a new variable, `EXT_IP_FRA1`,
-    for you will soon need it:
+    This is expected.
+    Also, jot down the value of the `external_v4_ip` parameter.
+    Better yet, set this value to a new variable, `EXT_IP_FRA1`, for you will soon need it:
 
     ```bash
     EXT_IP_FRA1="198.51.100.50"
     ```
 
-    The site-to-site connection you are about to create needs two
-    end-point groups on the left, and two end-point groups on the right.
-    More specifically, on either side of the connection, there should be
-    one end-point group for the local subnet and one end-point group for
-    the peer (remote) subnet. You are now on the left side of the
-    connection (region `fra1`), so begin with the left local end-point
-    group...
+    The site-to-site connection you are about to create needs two end-point groups on the left, and two end-point groups on the right.
+    More specifically, on either side of the connection, there should be one end-point group for the local subnet and one end-point group for the peer (remote) subnet.
+    You are now on the left side of the connection (region `fra1`), so begin with the left local end-point group...
 
     ```bash
     openstack vpn endpoint group create \
@@ -230,11 +203,9 @@ involved.
 
     ### Prepare the right side (region `kna1`)
 
-    Before establishing a site-to-site VPN connection between the two
-    regions, you must make similar preparations on the right side of the
-    connection (region `kna1`). You should adjust all commands you entered
-    above and execute them on the right side. For your convenience, these
-    are all the adjusted commands with the respective outputs:
+    Before establishing a site-to-site VPN connection between the two regions, you must make similar preparations on the right side of the connection (region `kna1`).
+    You should adjust all commands you entered above and execute them on the right side.
+    For your convenience, these are all the adjusted commands with the respective outputs:
 
     Create a new IKE policy:
 
@@ -309,8 +280,7 @@ involved.
     +----------------+--------------------------------------+
     ```
 
-    For convenience, set the value of parameter `external_v4_ip ` to a
-    shell variable:
+    For convenience, set the value of parameter `external_v4_ip ` to a shell variable:
 
     ```bash
     EXT_IP_KNA1="203.0.113.101"
@@ -360,17 +330,16 @@ involved.
 
     ### Instantiate a pre-shared key
 
-    Before establishing a site-to-site IPSec VPN connection, you must
-    have a randomly generated pre-shared key. You may use `openssl` for
-    generating a random string and immediately set it to a shell variable:
+    Before establishing a site-to-site IPSec VPN connection, you must have a randomly generated pre-shared key.
+    You may use `openssl` for generating a random string and immediately set it to a shell variable:
 
     ```bash
     PRE_SHARED_KEY=$(openssl rand -hex 24)
     ```
 
-    The above is just an example. The key should not necessarily be a
-    hexadecimal string, nor do you have to use `openssl`. Another option
-    would be to use the fine `pwgen` tool, for example like this:
+    The above is just an example.
+    The key should not necessarily be a hexadecimal string, nor do you have to use `openssl`.
+    Another option would be to use the fine `pwgen` tool, for example like this:
 
     ```bash
     PRE_SHARED_KEY=$(pwgen 64 1)
@@ -378,8 +347,7 @@ involved.
 
     ### Establish a left-to-right connection (region `fra1`)
 
-    To create a VPN connection from left to right, i.e., from region
-    `fra1` to region `kna1`, issue the following command:
+    To create a VPN connection from left to right, i.e., from region `fra1` to region `kna1`, issue the following command:
 
     ```bash
     openstack vpn ipsec site connection create \
@@ -425,8 +393,7 @@ involved.
 
     ### Establish a right-to-left connection (region `kna1`)
 
-    Similarly, to create a VPN connection from right to left, i.e.,
-    from region `kna1` to region `fra1`, issue the following command:
+    Similarly, to create a VPN connection from right to left, i.e., from region `kna1` to region `fra1`, issue the following command:
 
     ```bash
     openstack vpn ipsec site connection create \
@@ -472,26 +439,22 @@ involved.
 
 ## Viewing VPN connections and getting details
 
-No matter if you use the {{gui}} or the OpenStack CLI, you may at any
-time list all VPN connections and get relevant details.
+No matter if you use the {{gui}} or the OpenStack CLI, you may at any time list all VPN connections and get relevant details.
 
 === "{{gui}}"
-    In the vertical pane on the left-hand side of the {{gui}}, expand
-    the _Networking_ section and then the _VPN Services_ subsection. From
-    the available options, click _VPN Services_ again. You will see two VPN
-    connections in the main pane, each from one region to the other.
+    In the vertical pane on the left-hand side of the {{gui}}, expand the _Networking_ section and then the _VPN Services_ subsection.
+    From the available options, click _VPN Services_ again.
+    You will see two VPN connections in the main pane, each from one region to the other.
 
     ![Create](assets/vpnaas/shot-06.png)
 
-    For more information regarding a specific connection, click the
-    corresponding three-dot icon (right-hand side) and select _View
-    details_. Then, you can glance over all the details regarding, for
-    example, the connection status and public IP address.
+    For more information regarding a specific connection, click the corresponding three-dot icon (right-hand side) and select _View details_.
+    Then, you can glance over all the details regarding, for example, the connection status and public IP address.
 
     ![Create](assets/vpnaas/shot-07.png)
 === "OpenStack CLI"
-    You can list all IPSec VPN connections working from any of the two
-    regions involved. See, for example, the view from `fra1`:
+    You can list all IPSec VPN connections working from any of the two regions involved.
+    See, for example, the view from `fra1`:
 
     ```bash
     openstack vpn ipsec site connection list
@@ -506,8 +469,7 @@ time list all VPN connections and get relevant details.
     +--------------------------+------------------+---------------+--------------------------+--------+
     ```
 
-    If you want more information regarding a specific connection, type
-    something like this:
+    If you want more information regarding a specific connection, type something like this:
 
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1
@@ -544,11 +506,8 @@ time list all VPN connections and get relevant details.
 
 ## Testing the site-to-site VPN connection
 
-One way to test the VPN connection is to have two servers (e.g.,
-`server-fra1` and `server-kna1`), each on a different region (e.g.,
-`fra1` and `kna1` respectively), ping each other using private IP
-addresses. With no VPN connection between the two regions, pinging
-should not be possible:
+One way to test the VPN connection is to have two servers (e.g., `server-fra1` and `server-kna1`), each on a different region (e.g., `fra1` and `kna1` respectively), ping each other using private IP addresses.
+With no VPN connection between the two regions, pinging should not be possible:
 
 ```console
 ubuntu@server-fra1:~$ ping -c 3 10.15.20.148
@@ -566,8 +525,7 @@ PING 10.15.25.58 (10.15.25.58) 56(84) bytes of data.
 3 packets transmitted, 0 received, 100% packet loss, time 2045ms
 ```
 
-On the other hand, with a VPN connection established between the two
-regions, pinging should be all possible:
+On the other hand, with a VPN connection established between the two regions, pinging should be all possible:
 
 ```console
 ubuntu@server-fra1:~$ ping -c 3 10.15.20.148
@@ -598,16 +556,12 @@ rtt min/avg/max/mdev = 32.533/32.832/33.336/0.358 ms
 You may, at any time, disable an active site-to-site VPN connection.
 
 === "{{gui}}"
-    Currently, there is no way to disable an active connection from the
-    {{gui}}. If you want to disable an active connection, please use the
-    OpenStack CLI.
+    Currently, there is no way to disable an active connection from the {{gui}}.
+    If you want to disable an active connection, please use the OpenStack CLI.
 === "OpenStack CLI"
-    All you have to do is get on either side of the connection and
-    disable the VPN connection across the other side. Suppose you are on
-    the left side of the connection (region `fra1`), and for whatever
-    reason, you want to disable the site-to-site connection between left
-    and right (regions `fra1` and `kna1`). First, you might want to
-    remember the name of the VPN connection to the right:
+    All you have to do is get on either side of the connection and disable the VPN connection across the other side.
+    Suppose you are on the left side of the connection (region `fra1`), and for whatever reason, you want to disable the site-to-site connection between left and right (regions `fra1` and `kna1`).
+    First, you might want to remember the name of the VPN connection to the right:
 
     ```bash
     openstack vpn ipsec site connection list
@@ -622,8 +576,8 @@ You may, at any time, disable an active site-to-site VPN connection.
     +--------------------------+------------------+---------------+--------------------------+--------+
     ```
 
-    That would be `vpn-conn-to-kna1`, and according to the command
-    output above, it is active. To disable it, type the following:
+    That would be `vpn-conn-to-kna1`, and according to the command output above, it is active.
+    To disable it, type the following:
 
     ```bash
     openstack vpn ipsec site connection set --disable vpn-conn-to-kna1
@@ -645,16 +599,14 @@ You may, at any time, disable an active site-to-site VPN connection.
 
     It looks like it is disabled --- or `DOWN`.
 
-    > You will probably have to wait several seconds before seeing a
-    status change. If you are impatient, try something like this:
+    > You will probably have to wait several seconds before seeing a status change.
+    > If you are impatient, try something like this:
     ```bash
     watch "openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status"
     ```
     Hit CTRL+C as soon as you see the status change you expect.
 
-    Now, get on the right side of the connection (region `kna1`),
-    optionally look for the name of the VPN connection to the left (in our
-    example, that would be `vpn-conn-to-fra1`), and check its status:
+    Now, get on the right side of the connection (region `kna1`), optionally look for the name of the VPN connection to the left (in our example, that would be `vpn-conn-to-fra1`), and check its status:
 
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-fra1 -c Status
@@ -670,12 +622,9 @@ You may, at any time, disable an active site-to-site VPN connection.
 
     It turns out that this direction of the connection is also disabled.
 
-To test that a previously enabled site-to-site connection is now disabled,
-select a server from one region and try to ping a server in another region.
-Suppose, for example, that a now-disabled connection involved regions
-`fra1` and `kna1`, and that we have servers `server-fra1` (in `fra1`) and
-`server-kna1` (in `kna1`). With the VPN connection between the two regions
-now disabled, pinging should not be possible:
+To test that a previously enabled site-to-site connection is now disabled, select a server from one region and try to ping a server in another region.
+Suppose, for example, that a now-disabled connection involved regions `fra1` and `kna1`, and that we have servers `server-fra1` (in `fra1`) and `server-kna1` (in `kna1`).
+With the VPN connection between the two regions now disabled, pinging should not be possible:
 
 ```console
 ubuntu@server-fra1:~$ ping -c 3 10.15.20.148
@@ -698,15 +647,12 @@ PING 10.15.25.58 (10.15.25.58) 56(84) bytes of data.
 You can easily enable an inactive site-to-site VPN connection.
 
 === "{{gui}}"
-    Currently, there is no way to enable an inactive connection from
-    the {{gui}}. If you want to re-enable an inactive connection,
-    please use the OpenStack CLI.
+    Currently, there is no way to enable an inactive connection from the {{gui}}.
+    If you want to re-enable an inactive connection, please use the OpenStack CLI.
 === "OpenStack CLI"
-    Make sure you hop on the side where you initially disabled the
-    connection. According to the example scenario we described in the
-    previous section, that would be the left side (region `fra1`), and the
-    name of the disabled connection would be `vpn-conn-to-kna1`. Make sure
-    the connection status is `DOWN`:
+    Make sure you hop on the side where you initially disabled the connection.
+    According to the example scenario we described in the previous section, that would be the left side (region `fra1`), and the name of the disabled connection would be `vpn-conn-to-kna1`.
+    Make sure the connection status is `DOWN`:
 
     ```bash
     openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
@@ -720,10 +666,8 @@ You can easily enable an inactive site-to-site VPN connection.
     +--------+-------+
     ```
 
-    Note that if you issued a similar command from the right side of
-    the connection (region `kna1`), you would also get a `DOWN` status.
-    Being on the left side, all you have to do to enable the inactive
-    connection is type the following:
+    Note that if you issued a similar command from the right side of the connection (region `kna1`), you would also get a `DOWN` status.
+    Being on the left side, all you have to do to enable the inactive connection is type the following:
 
     ```bash
     openstack vpn ipsec site connection set --enable vpn-conn-to-kna1
@@ -743,22 +687,17 @@ You can easily enable an inactive site-to-site VPN connection.
     +--------+--------+
     ```
 
-    You get the same status by issuing a similar command from the right
-    side.
+    You get the same status by issuing a similar command from the right side.
 
-    > Again, since you may have to wait several seconds before seeing
-    the status change you expect, try something like this:
+    > Again, since you may have to wait several seconds before seeing the status change you expect, try something like this:
     ```bash
     watch "openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status"
     ```
     Hit CTRL+C to stop watching.
 
-To test that a previously disabled site-to-site connection is now enabled,
-select a server from one region and try to ping a server in another region.
-Suppose, for example, that a re-enabled connection involves regions
-`fra1` and `kna1`, and that we have servers `server-fra1` (in `fra1`) and
-`server-kna1` (in `kna1`). With the VPN connection between the two regions
-now re-established, pinging should be possible:
+To test that a previously disabled site-to-site connection is now enabled, select a server from one region and try to ping a server in another region.
+Suppose, for example, that a re-enabled connection involves regions `fra1` and `kna1`, and that we have servers `server-fra1` (in `fra1`) and `server-kna1` (in `kna1`).
+With the VPN connection between the two regions now re-established, pinging should be possible:
 
 ```console
 ubuntu@server-fra1:~$ ping -c 3 10.15.20.148


### PR DESCRIPTION
We reformat all How-Tos in the neutron subcategory of the openstack category, to follow the one sentence per line policy.