### PR TITLE
chore: Apply the one sentence per line policy in the nova subcategory

### DIFF
--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -3,54 +3,42 @@ description: How to modernize old boot-from-image servers
 ---
 # Converting a boot-from-image server to boot-from-volume
 
-You can freely move any server [between {{brand}}
-regions](move-server-between-regions.md), provided it boots from a volume
-(which we generally recommend, since it affords more flexibility than
-booting from an image). You may still have boot-from-image servers,
-though. To verify that a particular server is of that type, you can go
-to the {{gui}}, locate the server, and expand its detailed view. Go to
-the *Details* tab and pay attention to the *Boot Target* field. If this
-is a boot-from-image server, it says *Ephemeral Disk*.
+You can freely move any server [between {{brand}} regions](move-server-between-regions.md), provided it boots from a volume (which we generally recommend, since it affords more flexibility than booting from an image).
+You may still have boot-from-image servers, though.
+To verify that a particular server is of that type, you can go to the {{gui}}, locate the server, and expand its detailed view.
+Go to the *Details* tab and pay attention to the *Boot Target* field.
+If this is a boot-from-image server, it says *Ephemeral Disk*.
 
 ![Checking the boot target of a server](assets/bfi-to-bfv/ephemeral.png)
 
-Whenever you decide to move a boot-from-image server between regions,
-you will discover that you cannot do so. The solution is first to
-convert it to a boot-from-volume server and then move it. In the
-following, we show how to perform the conversion using the {{gui}} or
-the OpenStack CLI.
+Whenever you decide to move a boot-from-image server between regions, you will discover that you cannot do so.
+The solution is first to convert it to a boot-from-volume server and then move it.
+In the following, we show how to perform the conversion using the {{gui}} or the OpenStack CLI.
 
 ## Preparation
 
 === "{{gui}}"
-    Fire up your favorite web browser and navigate to the
-    [{{gui}}](https://{{gui_domain}}) start page. Log into your {{brand}}
-    account if you have to.
+    Fire up your favorite web browser and navigate to the [{{gui}}](https://{{gui_domain}}) start page.
+    Log into your {{brand}} account if you have to.
 === "OpenStack CLI"
-    To work with the OpenStack CLI, make sure to properly [enable
-    it](../../getting-started/enable-openstack-cli.md) for the region your
-    boot-from-image server resides in.
+    To work with the OpenStack CLI, make sure to properly [enable it](../../getting-started/enable-openstack-cli.md) for the region your boot-from-image server resides in.
 
 ## Shutting down the server
 
 === "{{gui}}"
-    Make sure the left-hand side vertical pane is in full view, then select
-    *Compute* → [*Servers*](https://{{gui_domain}}/compute/servers). You will
-    see all supported {{brand}} regions in the main pane. Expand the one
-    with the boot-from-image server you want to convert to boot-from-volume.
-    Click the orange three-dots-in-a-circle icon at the right of the
-    server row, and from the pop-up menu that appears, select *Stop Server*.
+    Make sure the left-hand side vertical pane is in full view, then select *Compute* → [*Servers*](https://{{gui_domain}}/compute/servers).
+    You will see all supported {{brand}} regions in the main pane.
+    Expand the one with the boot-from-image server you want to convert to boot-from-volume.
+    Click the orange three-dots-in-a-circle icon at the right of the server row, and from the pop-up menu that appears, select *Stop Server*.
 
     ![Stopping server](assets/bfi-to-bfv/shot01.png)
 
-    A pop-up window appears, asking if you want to stop the server. Confirm
-    by clicking on the red button labeled *Yes, Stop*.
+    A pop-up window appears, asking if you want to stop the server.
+    Confirm by clicking on the red button labeled *Yes, Stop*.
     
     ![Confirming server shutdown](assets/bfi-to-bfv/are-you-really-really-sure.png) 
 === "OpenStack CLI"
-    Assuming your boot-from-image server is named
-    [`nanisivik`](https://en.wikipedia.org/wiki/Nanisivik), using your
-    favorite terminal application, shut it down by typing the following:
+    Assuming your boot-from-image server is named [`nanisivik`](https://en.wikipedia.org/wiki/Nanisivik), using your favorite terminal application, shut it down by typing the following:
 
     ```bash
     openstack server stop nanisivik
@@ -71,22 +59,18 @@ the OpenStack CLI.
 ## Taking a snapshot
 
 === "{{gui}}"
-    When the server is shut off, click on its row to get the detailed view
-    and go to the *Snapshots* tab. There, click the green button labeled
-    *Create a Snapshot*.
+    When the server is shut off, click on its row to get the detailed view and go to the *Snapshots* tab.
+    There, click the green button labeled *Create a Snapshot*.
 
     ![Creating a snapshot](assets/bfi-to-bfv/shot02.png)
 
-    A pop-up window appears, where you have to type in a name for the
-    snapshot. You must also be explicit regarding the operation you are
-    about to perform, by activating the switch at the left of the
-    corresponding question. When you are ready, click the green button
-    labeled *Create*.
+    A pop-up window appears, where you have to type in a name for the snapshot.
+    You must also be explicit regarding the operation you are about to perform, by activating the switch at the left of the corresponding question.
+    When you are ready, click the green button labeled *Create*.
 
     ![Confirming snapshot creation](assets/bfi-to-bfv/shot03.png)
 === "OpenStack CLI"
-    To take a snapshot of the server, all you have to do is type something
-    like the following:
+    To take a snapshot of the server, all you have to do is type something like the following:
 
     ```bash
     openstack server image create --name nanisivik_snap nanisivik
@@ -118,8 +102,8 @@ the OpenStack CLI.
     +------------+-------------------------------------------------------------------------------------+
     ```
 
-    At first, the status of the snapshot is `queued`. To make sure the
-    snapshot has been successfully created, type:
+    At first, the status of the snapshot is `queued`.
+    To make sure the snapshot has been successfully created, type:
 
     ```bash
     openstack image show nanisivik_snap -c status -f value
@@ -134,17 +118,15 @@ the OpenStack CLI.
 ## Creating a volume from the snapshot
 
 === "{{gui}}"
-    After a few seconds, the snapshot will be created and listed in the
-    *Snapshots* tab. Before you proceed, take note of its size. At the
-    right-hand side of the snapshot row, click the :fontawesome-solid-database:
-    icon to create a new volume off of the snapshot you just created.
+    After a few seconds, the snapshot will be created and listed in the *Snapshots* tab.
+    Before you proceed, take note of its size.
+    At the right-hand side of the snapshot row, click the :fontawesome-solid-database: icon to create a new volume off of the snapshot you just created.
 
     ![Creating volume from snapshot](assets/bfi-to-bfv/shot04.png)
 
-    A new vertical pane will slide over from the right-hand side of the
-    {{gui}}. Type in a name for the new volume, and choose a volume size
-    **bigger** than the snapshot size. Then, you need to type in a
-    description regarding the new volume.
+    A new vertical pane will slide over from the right-hand side of the {{gui}}.
+    Type in a name for the new volume, and choose a volume size **bigger** than the snapshot size.
+    Then, you need to type in a description regarding the new volume.
 
     ![Typing in name, size, and description](assets/bfi-to-bfv/shot05.png)
 
@@ -152,17 +134,14 @@ the OpenStack CLI.
 
     ![Starting volume creation](assets/bfi-to-bfv/shot06.png)
 === "OpenStack CLI"
-    Before creating a volume off of the snapshot you just created, jot down
-    its size like this:
+    Before creating a volume off of the snapshot you just created, jot down its size like this:
 
     ```bash
     openstack image show nanisivik_snap -c min_disk -f value
     ```
 
-    In our example, the size of the snapshot is `50`
-    [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)).
-    Now, go ahead and create a volume slightly larger than the size of the
-    snapshot:
+    In our example, the size of the snapshot is `50` [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)).
+    Now, go ahead and create a volume slightly larger than the size of the snapshot:
 
     ```bash
     openstack volume create --size 56 --image nanisivik_snap nanisivik_vol
@@ -194,9 +173,8 @@ the OpenStack CLI.
     +---------------------+--------------------------------------+
     ```
 
-    As you can see in the example above, we named our volume
-    `nanisivik_vol`, and its `status` was at first `creating`. You may check
-    the progress of this operation by typing this:
+    As you can see in the example above, we named our volume `nanisivik_vol`, and its `status` was at first `creating`.
+    You may check the progress of this operation by typing this:
 
     ```bash
     openstack volume show nanisivik_vol -c status -f value
@@ -207,17 +185,15 @@ the OpenStack CLI.
 ## Viewing the new volume
 
 === "{{gui}}"
-    In the left-hand side vertical pane, select *Storage* →
-    [*Volumes*](https://{{gui_domain}}/storage/volumes). In the main pane,
-    select the region your boot-from-image server resides in. You will see
-    the volume you created in the previous step. In the intersection of the
-    volume row and the column labeled *Attached To*, it will say *-No
-    attachments-*. That is expected.
+    In the left-hand side vertical pane, select *Storage* → [*Volumes*](https://{{gui_domain}}/storage/volumes).
+    In the main pane, select the region your boot-from-image server resides in.
+    You will see the volume you created in the previous step.
+    In the intersection of the volume row and the column labeled *Attached To*, it will say *-No attachments-*.
+    That is expected.
 
     ![Viewing new volume](assets/bfi-to-bfv/shot07.png)
 === "OpenStack CLI"
-    To view all details regarding the volume you just created off of the
-    boot-from-image server snapshot, type the following:
+    To view all details regarding the volume you just created off of the boot-from-image server snapshot, type the following:
 
     ```bash
     openstack volume show nanisivik_vol
@@ -266,22 +242,17 @@ the OpenStack CLI.
 ## Deleting the boot-from-image server
 
 === "{{gui}}"
-    Go to the servers view by selecting *Compute* →
-    [*Servers*](https://{{gui_domain}}/compute/servers), and locate the
-    boot-from-image server. It is time to delete it, so click the orange
-    three-dots-in-a-circle icon at the right of the server row, and
-    from the pop-up menu that appears, select *Delete Server*.
+    Go to the servers view by selecting *Compute* → [*Servers*](https://{{gui_domain}}/compute/servers), and locate the boot-from-image server.
+    It is time to delete it, so click the orange three-dots-in-a-circle icon at the right of the server row, and from the pop-up menu that appears, select *Delete Server*.
 
     ![Deleting server](assets/bfi-to-bfv/shot08.png)
 
-    A window titled *About to delete a server* will appear, asking you if
-    you want to proceed with the deletion. Click the red button labeled
-    *Yes, Delete*.
+    A window titled *About to delete a server* will appear, asking you if you want to proceed with the deletion.
+    Click the red button labeled *Yes, Delete*.
 
     ![Confirming server deletion](assets/bfi-to-bfv/shot09.png)
 === "OpenStack CLI"
-    Since you have a snapshot and a volume of your server, you can now
-    delete it:
+    Since you have a snapshot and a volume of your server, you can now delete it:
 
     ```bash
     openstack server delete nanisivik
@@ -292,37 +263,30 @@ the OpenStack CLI.
 ## Creating a new boot-from-volume server
 
 === "{{gui}}"
-    Now, go back to your volumes by selecting *Storage* →
-    [*Volumes*](https://{{gui_domain}}/storage/volumes). Tick the volume you
-    created a bit earlier, click the orange three-dots-in-a-circle
-    icon at the right of the volume row, and from the pop-up menu that
-    appears, select *Create Server*. A vertical pane will slide over from
-    the right-hand side of the {{gui}}, titled *Create a Server*.
+    Now, go back to your volumes by selecting *Storage* → [*Volumes*](https://{{gui_domain}}/storage/volumes).
+    Tick the volume you created a bit earlier, click the orange three-dots-in-a-circle icon at the right of the volume row, and from the pop-up menu that appears, select *Create Server*.
+    A vertical pane will slide over from the right-hand side of the {{gui}}, titled *Create a Server*.
 
     ![Creating new server](assets/bfi-to-bfv/shot10.png)
 
-    Type in a name for the new server. That could as well be the name your
-    boot-from-image server had. Notice that the server region is
-    pre-selected and the same as the one in which the volume resides. The
-    boot source of the server is also pre-selected and is the volume itself.
+    Type in a name for the new server.
+    That could as well be the name your boot-from-image server had.
+    Notice that the server region is pre-selected and the same as the one in which the volume resides.
+    The boot source of the server is also pre-selected and is the volume itself.
 
     ![Naming the server](assets/bfi-to-bfv/shot11.png)
 
-    Scroll down a bit if you have to. Take notice of the *Boot Target*,
-    which should be *Volume (Recommended)*. Select a flavor for the new
-    boot-from-volume server, similar to or even the same as the flavor the
-    boot-from-image server had.
+    Scroll down a bit if you have to.
+    Take notice of the *Boot Target*, which should be *Volume (Recommended)*.
+    Select a flavor for the new boot-from-volume server, similar to or even the same as the flavor the boot-from-image server had.
 
     ![Choosing a flavor](assets/bfi-to-bfv/shot12.png)
 
-    Consider leaving the [*Disaster
-    recovery*](../../../background/disaster-recovery.md) option enabled, and see if you
-    want an external IP address for the server.
+    Consider leaving the [*Disaster recovery*](../../../background/disaster-recovery.md) option enabled, and see if you want an external IP address for the server.
 
     ![Enabling disaster recovery and asking for external IP](assets/bfi-to-bfv/shot13.png)
 
-    Select the *default* security group and choose a *keypair* for the
-    server.
+    Select the *default* security group and choose a *keypair* for the server.
 
     ![Selecting security group and login keypair](assets/bfi-to-bfv/shot14.png)
 
@@ -330,9 +294,7 @@ the OpenStack CLI.
 
     ![Starting server creation](assets/bfi-to-bfv/shot15.png)
 === "OpenStack CLI"
-    To create your new boot-from-volume server, which will be using the
-    volume you got starting from the snapshot of the old boot-from-image
-    server, type something like the following:
+    To create your new boot-from-volume server, which will be using the volume you got starting from the snapshot of the old boot-from-image server, type something like the following:
 
     ```bash
     openstack server create \
@@ -345,26 +307,20 @@ the OpenStack CLI.
         nanisivik
     ```
 
-    The most important parameter in the command above is `--volume`, which
-    is used to specify the boot volume of the server. Regarding server
-    creation in general, you might want to [check the corresponding
-    guide](new-server.md).
+    The most important parameter in the command above is `--volume`, which is used to specify the boot volume of the server.
+    Regarding server creation in general, you might want to [check the corresponding guide](new-server.md).
 
 ## Viewing the new server
 
 === "{{gui}}"
-    In the left-hand side vertical pane, select *Compute* →
-    [*Servers*](https://{{gui_domain}}/compute/servers). In the main pane of
-    the {{gui}}, go to the region the new server resides, select it and
-    click on its row to see all its characteristics. In the *Details* tab,
-    you will notice, among other things, that it has one attached volume;
-    that would be the one you created from the snapshot you created from the
-    old boot-from-image server.
+    In the left-hand side vertical pane, select *Compute* → [*Servers*](https://{{gui_domain}}/compute/servers).
+    In the main pane of the {{gui}}, go to the region the new server resides, select it and click on its row to see all its characteristics.
+    In the *Details* tab, you will notice, among other things, that it has one attached volume;
+    that would be the one you created from the snapshot you created from the old boot-from-image server.
 
     ![Viewing the new boot-from-volume server](assets/bfi-to-bfv/shot16.png)
 === "OpenStack CLI"
-    You may see all details regarding the new boot-from-volume server, by
-    typing something like the following:
+    You may see all details regarding the new boot-from-volume server, by typing something like the following:
 
     ```bash
     openstack server show nanisivik
@@ -403,5 +359,4 @@ the OpenStack CLI.
     +-----------------------------+----------------------------------------------------------+
     ```
 
-    Pay attention to the value of the `image` field, which confirms that
-    this is indeed a boot-from-volume server.
+    Pay attention to the value of the `image` field, which confirms that this is indeed a boot-from-volume server.

--- a/docs/howto/openstack/nova/config-drive.md
+++ b/docs/howto/openstack/nova/config-drive.md
@@ -6,66 +6,50 @@ description: How to launch a virtual server with config drive support
 
 ## Background: OpenStack metadata discovery
 
-OpenStack Compute uses metadata to inject custom configurations to
-servers on boot. You can add custom scripts, install packages, and
-add SSH keys to the servers using metadata.
+OpenStack Compute uses metadata to inject custom configurations to servers on boot.
+You can add custom scripts, install packages, and add SSH keys to the servers using metadata.
 
-By default, metadata discovery in {{brand}} uses an HTTP
-data source that booting servers connect to. Sometimes, this is
-undesirable or — for specific server/networking configurations —
-unreliable. Under those circumstances, you can use an alternate
-configuration source.
+By default, metadata discovery in {{brand}} uses an HTTP data source that booting servers connect to.
+Sometimes, this is undesirable or — for specific server/networking configurations — unreliable.
+Under those circumstances, you can use an alternate configuration source.
 
 
 ## Store metadata on a configuration drive
 
-A **configuration drive** (config drive) is a read-only virtual drive
-that gets attached to a server during boot. The server can then
-mount the drive and read files from it. Configuration drives are used
-as a data source for
-[cloud-init](https://cloudinit.readthedocs.io/en/latest/).
+A **configuration drive** (config drive) is a read-only virtual drive that gets attached to a server during boot.
+The server can then mount the drive and read files from it.
+Configuration drives are used as a data source for [cloud-init](https://cloudinit.readthedocs.io/en/latest/).
 
 
 ## Enable the configuration drive on server creation
 
-Follow our [How-To guide](new-server.md) to create your new cloud server
-using either the {{gui}} or the OpenStack CLI.
+Follow our [How-To guide](new-server.md) to create your new cloud server using either the {{gui}} or the OpenStack CLI.
 
 === "{{gui}}"
-    When you are done configuring the server, right before creating it
-    notice the icon on the left-hand side of _Advanced Options_. Click on it
-    to expand all related options.
+    When you are done configuring the server, right before creating it notice the icon on the left-hand side of _Advanced Options_.
+    Click on it to expand all related options.
 
     ![Expand advanced configuration options](assets/config-drive/shot-01.png)
 
-    In the _User-Data_ area, you see everything that will be executed upon
-    server boot.
+    In the _User-Data_ area, you see everything that will be executed upon server boot.
 
-    Right below, in the _User-data propagation method_ area, the _Use
-    metadata service (Default)_ option is preselected for you. To opt for
-    the alternative metadata discovery method, select _Use configuration
-    drive_.
+    Right below, in the _User-data propagation method_ area, the _Use metadata service (Default)_ option is preselected for you.
+    To opt for the alternative metadata discovery method, select _Use configuration drive_.
 
     ![Select the configuration drive method](assets/config-drive/shot-02.png)
 
     Then, instantiate the server by clicking the green _Create_ button.
 
-    Once the server is ready, you may see what happened during configuration
-    by examining the console log. In the {{gui}}, click on the server line
-    to get an extended view of its characteristics, and then click once more
-    on the _Console Output_ tab.
+    Once the server is ready, you may see what happened during configuration by examining the console log.
+    In the {{gui}}, click on the server line to get an extended view of its characteristics, and then click once more on the _Console Output_ tab.
 
     ![Watch the server console](assets/config-drive/shot-03.png)
 
-    There might be quite a lot of text to sift through, but you can easily
-    do so by pressing the `Up` or `Down` arrow keys.
+    There might be quite a lot of text to sift through, but you can easily do so by pressing the `Up` or `Down` arrow keys.
 === "OpenStack CLI"
-    To enable the configuration drive, you need to pass the parameter
-    `--use-config-drive` to the `openstack server create` command.
+    To enable the configuration drive, you need to pass the parameter `--use-config-drive` to the `openstack server create` command.
 
-    In the following example, replace the image, flavor, keypair, and
-    network reference, as well as the server name, to match your desired
-    configuration.
+    In the following example, replace the image, flavor, keypair, and network reference, as well as the server name, to match your desired configuration.
 
     ```bash
     openstack server create \
@@ -77,8 +61,7 @@ using either the {{gui}} or the OpenStack CLI.
       myserver
     ```
 
-    Once the server launches, you can monitor its configuration process
-    by watching the server console log:
+    Once the server launches, you can monitor its configuration process by watching the server console log:
 
     ```bash
     openstack console log show myserver

--- a/docs/howto/openstack/nova/move-server-between-regions.md
+++ b/docs/howto/openstack/nova/move-server-between-regions.md
@@ -3,33 +3,25 @@ description: How to transfer a virtual server between Cleura Cloud regions
 ---
 # Moving a server from one region to another
 
-This guide will show you how to move a server to a different region in
-{{brand}}.
+This guide will show you how to move a server to a different region in {{brand}}.
 
 ## Prerequisites
 
 In order to move a server from one region to another, you will need
 
-- a correctly installed and configured [OpenStack CLI
-  client](../../getting-started/enable-openstack-cli.md),
-- access to the RC files with credentials for both the source and
-  target region,
-- enough space on the local machine to be able to download an image of
-  your server,
-- a sufficiently configured target region including a [virtual
-  network](../neutron/new-network.md) and necessary [security
-  groups](../neutron/create-security-groups.md).
+- a correctly installed and configured [OpenStack CLI client](../../getting-started/enable-openstack-cli.md),
+- access to the RC files with credentials for both the source and target region,
+- enough space on the local machine to be able to download an image of your server,
+- a sufficiently configured target region including a [virtual network](../neutron/new-network.md) and necessary [security groups](../neutron/create-security-groups.md).
 
 ## Finding a volume's ID
 
-To work with the OpenStack CLI, please do not forget to [source the RC
-file first](../../getting-started/enable-openstack-cli.md).
+To work with the OpenStack CLI, please do not forget to [source the RC file first](../../getting-started/enable-openstack-cli.md).
 
-Use the ID of the server instead of using the server name. This will
-make sure that you are using the correct server.
+Use the ID of the server instead of using the server name.
+This will make sure that you are using the correct server.
 
-Find the ID of your server by matching the name, using the following
-command:
+Find the ID of your server by matching the name, using the following command:
 
 ```console
 $ openstack server list --name 'name'
@@ -45,9 +37,8 @@ $ openstack server list --name 'name'
 +-----------------+-----------------+---------+-----------------+--------------------+-------------+
 ```
 
-This guide is only applicable to servers that are using boot from
-volume. To verify this, make sure your server's `Image` value is `N/A
-(booted from volume)`.
+This guide is only applicable to servers that are using boot from volume.
+To verify this, make sure your server's `Image` value is `N/A (booted from volume)`.
 
 To get the ID of your server's boot volume, use the following command:
 
@@ -62,22 +53,17 @@ $ openstack server show -c volumes_attached <server_id>
 +------------------+-------------------------------------------+
 ```
 
-If there are multiple volumes attached, the first volume in the list
-is the server system volume. Copy this ID.
+If there are multiple volumes attached, the first volume in the list is the server system volume.
+Copy this ID.
 
-If you want to move any other attached volumes along with your
-server's system volume, you also need to follow the same steps for
-each one of these volumes.
+If you want to move any other attached volumes along with your server's system volume, you also need to follow the same steps for each one of these volumes.
 
 ## Stopping a running server
 
-In the next step you are instructed to make a copy of the server's
-system volume. Some operating systems or applications might experience
-issues being copied at the same time it might be performing
-operations.
+In the next step you are instructed to make a copy of the server's system volume.
+Some operating systems or applications might experience issues being copied at the same time it might be performing operations.
 
-While this step is not strictly required, it is recommended to first
-power off your server.
+While this step is not strictly required, it is recommended to first power off your server.
 
 Stop the running server with the following command:
 
@@ -93,10 +79,7 @@ Begin by making a copy of the volume, using the following command:
 openstack volume create --source <source_volume_id> <copy_volume_name>
 ```
 
-You will get a printout showing you information about the created
-volume, such as `source_volid` which is the ID of volume you just
-copied, and `id` of this **new** volume, that you will use in the next
-step to create an image.
+You will get a printout showing you information about the created volume, such as `source_volid` which is the ID of volume you just copied, and `id` of this **new** volume, that you will use in the next step to create an image.
 
 ```plain
 +---------------------+--------------------------------------+
@@ -126,8 +109,7 @@ step to create an image.
 
 ## Creating an image of a volume
 
-Then create an image of the copied volume, by using the following
-command:
+Then create an image of the copied volume, by using the following command:
 
 ```bash
 openstack image create --volume <copy_volume_id> <new_image_name>
@@ -135,9 +117,7 @@ openstack image create --volume <copy_volume_id> <new_image_name>
 
 > Substitute `<copy_volume_id>` with the ID from the newly created volume in the previous step.
 
-After a while you will get a printout showing you information of the
-new image, such as the image disk format `disk_format` and the image
-ID `image_id`, you need these two values in an upcoming step.
+After a while you will get a printout showing you information of the new image, such as the image disk format `disk_format` and the image ID `image_id`, you need these two values in an upcoming step.
 
 ```plain
 +---------------------+--------------------------------------+
@@ -158,10 +138,8 @@ ID `image_id`, you need these two values in an upcoming step.
 +---------------------+--------------------------------------+
 ```
 
-Depending on the size of the volume it might take some time to upload
-and while it is, the image `status` will be `uploading`. Before you
-continue to the next step, make sure the image `status` is `active`,
-otherwise wait a bit and then check again with:
+Depending on the size of the volume it might take some time to upload and while it is, the image `status` will be `uploading`.
+Before you continue to the next step, make sure the image `status` is `active`, otherwise wait a bit and then check again with:
 
 ```bash
 openstack image show -c status <image_id>
@@ -177,26 +155,21 @@ The printout should look like this before you continue.
 +--------+--------+
 ```
 
-> It is now safe to remove the volume you created earlier, using the
-> command: `openstack volume delete <copy_volume_id>`
+> It is now safe to remove the volume you created earlier, using the command: `openstack volume delete <copy_volume_id>`
 
 ## Downloading an image
 
-Download the image to your local computer, using the following
-command:
+Download the image to your local computer, using the following command:
 
 ```bash
 openstack image save --file <local_image_name>.<disk_format> <image_id>
 ```
 
-> Substitute `<disk_format>` with the value from the printout in the
-> previous step.
+> Substitute `<disk_format>` with the value from the printout in the previous step.
 >
-> Substitute `<image_id>` with the ID from the printout in the
-> previous step.
+> Substitute `<image_id>` with the ID from the printout in the previous step.
 
-When you have downloaded the file, verify that the checksum of the
-file is the same as the `checksum` value of the image.
+When you have downloaded the file, verify that the checksum of the file is the same as the `checksum` value of the image.
 
 ```bash
 md5 <local_image_name>.<disk_format>
@@ -208,8 +181,7 @@ This will output the checksum of your local file.
 MD5 (<local_image_name>.<disk_format>) = 4b086035a943cc1676583c0cc78f0896
 ```
 
-Show the checksum of the image in the cloud, using the following
-command:
+Show the checksum of the image in the cloud, using the following command:
 
 ```bash
 openstack image show -c checksum <image_id>
@@ -225,11 +197,10 @@ These two checksums should be the same.
 +----------+----------------------------------+
 ```
 
-You are now done with the steps for the source region. The following
-steps will be done on the target region.
+You are now done with the steps for the source region.
+The following steps will be done on the target region.
 
-> It is now safe to remove the image you created earlier, using the
-> command:
+> It is now safe to remove the image you created earlier, using the command:
 > ```bash
 > openstack image delete <image_id>
 > ```
@@ -242,16 +213,15 @@ Source the RC-file for the region you want to upload to.
 source <target_region_openrc>
 ```
 
-Upload the image to the new region. Set the correct disk format, input
-the path to the image file and select a name for the new image.
+Upload the image to the new region.
+Set the correct disk format, input the path to the image file and select a name for the new image.
 
 ```bash
 openstack image create --disk-format <disk_format> --file <local_image_name>.<disk_format> <new_image_name>
 ```
 
-The upload will take some time, depending on your internet upload
-speed and the size of the image. When the upload is finished you get a
-printout displaying information about your image.
+The upload will take some time, depending on your internet upload speed and the size of the image.
+When the upload is finished you get a printout displaying information about your image.
 
 ```plain
 +------------------+-------------------------------------------------------------------------------+
@@ -278,9 +248,8 @@ printout displaying information about your image.
 +------------------+-------------------------------------------------------------------------------+
 ```
 
-But your image is not yet ready to use, {{brand}} still needs to
-process the file, which shouldn't take long. To check the status of
-the image, use the ID of the new image with the following command:
+But your image is not yet ready to use, {{brand}} still needs to process the file, which shouldn't take long.
+To check the status of the image, use the ID of the new image with the following command:
 
 ```console
 $ openstack image show <new_image_id>
@@ -309,11 +278,9 @@ $ openstack image show <new_image_id>
 +------------------+-------------------------------------------------------------------------------+
 ```
 
-When the image's `status` value is `active`, the whole upload process
-is done.
+When the image's `status` value is `active`, the whole upload process is done.
 
-Verify that the checksum of the new image is the same as your local
-file:
+Verify that the checksum of the new image is the same as your local file:
 
 ```bash
 openstack image show -c checksum <new_image_id>
@@ -342,21 +309,16 @@ Then create the volume using the ID of the image in this command:
 openstack volume create --size <GB> --image <new_image_id> <new_volume_name>
 ```
 
-> Substitute `<GB>` with the size in gigabytes you wish the volume to
-> be.
+> Substitute `<GB>` with the size in gigabytes you wish the volume to be.
 
 ## Creating a server from a volume
 
-Now you need to create the new server using the system volume. To
-create a new server, follow [this guide](new-server.md).
+Now you need to create the new server using the system volume.
+To create a new server, follow [this guide](new-server.md).
 
 === "{{gui}}"
-    If you use the {{gui}}, when choosing a _boot source,_ select
-    _Boot from volume_ and then your server's system volume.
+    If you use the {{gui}}, when choosing a _boot source,_ select _Boot from volume_ and then your server's system volume.
 === "OpenStack CLI"
-    If you use the OpenStack CLI, forgo the `--image` and
-    `--boot-from-volume` options and instead use `--volume
-    <new_volume_name>`
+    If you use the OpenStack CLI, forgo the `--image` and `--boot-from-volume` options and instead use `--volume <new_volume_name>`
 
-If you also moved other volumes, after you have created the server is
-the time to attach those volumes to the server.
+If you also moved other volumes, after you have created the server is the time to attach those volumes to the server.

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -4,26 +4,18 @@ description: How to create a new virtual server in Cleura Cloud
 # Creating new servers
 
 Once you have an [account in
-{{brand}}](../../getting-started/create-account.md), you can create
-virtual machines --- henceforth simply _servers_ --- using either the
-{{gui}} or the OpenStack CLI. Let us demonstrate the creation of a new
-server, following both approaches.
+{{brand}}](../../getting-started/create-account.md), you can create virtual machines --- henceforth simply _servers_ --- using either the {{gui}} or the OpenStack CLI.
+Let us demonstrate the creation of a new server, following both approaches.
 
 ## Prerequisites
 
-You need to [have at least one
-network](../neutron/new-network.md) in the region you are
-interested in. Additionally, if you prefer to work with the OpenStack
-CLI, then make sure to properly [enable it
-first](../../getting-started/enable-openstack-cli.md).
+You need to [have at least one network](../neutron/new-network.md) in the region you are interested in.
+Additionally, if you prefer to work with the OpenStack CLI, then make sure to properly [enable it first](../../getting-started/enable-openstack-cli.md).
 
 ## Creating a server
 
-To create a server from the {{gui}}, fire up your favorite web
-browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page,
-and log into your {{brand}} account. On the other hand, if you prefer
-to work with the OpenStack CLI, please do not forget to [source the RC
-file first](../../getting-started/enable-openstack-cli.md).
+To create a server from the {{gui}}, fire up your favorite web browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log into your {{brand}} account.
+On the other hand, if you prefer to work with the OpenStack CLI, please do not forget to [source the RC file first](../../getting-started/enable-openstack-cli.md).
 
 === "{{gui}}"
     On the top right-hand side of the {{gui}}, click the _Create_ button.
@@ -141,8 +133,7 @@ file first](../../getting-started/enable-openstack-cli.md).
 
     ![Initiate server creation process](assets/new-server/shot-13.png)
 === "OpenStack CLI"
-    An `openstack` command for creating a server may look like
-    this:
+    An `openstack` command for creating a server may look like this:
 
     ```bash
     openstack server create \
@@ -156,23 +147,19 @@ file first](../../getting-started/enable-openstack-cli.md).
         $SERVER_NAME
     ```
 
-    Each variable represents a piece of information we have to look
-    for or, in the cases of `KEY_NAME` and `SERVER_NAME`, arbitrarily
-    define.
+    Each variable represents a piece of information we have to look for or, in the cases of `KEY_NAME` and `SERVER_NAME`, arbitrarily define.
 
-    Let us begin with the [_flavors_](../../../reference/flavors/index.md) (`FLAVOR_NAME`), which
-    describe combinations of CPU core count and memory size. Each server has a
-    distinct flavor, and to see all available flavors type:
+    Let us begin with the [_flavors_](../../../reference/flavors/index.md) (`FLAVOR_NAME`), which describe combinations of CPU core count and memory size.
+    Each server has a distinct flavor, and to see all available flavors type:
 
     ```bash
     openstack flavor list
     ```
 
-    You will get a pretty long list of flavors. For our demonstration,
-    we suggest you go with `b.1c1gb`. A server with this particular flavor will
-    have one CPU core and one
-    [gibibyte](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)) of
-    RAM. Go ahead and set `FLAVOR_NAME` accordingly:
+    You will get a pretty long list of flavors.
+    For our demonstration, we suggest you go with `b.1c1gb`.
+    A server with this particular flavor will have one CPU core and one [gibibyte](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)) of RAM.
+    Go ahead and set `FLAVOR_NAME` accordingly:
 
     ```bash
     FLAVOR_NAME="b.1c1gb"
@@ -185,8 +172,8 @@ file first](../../getting-started/enable-openstack-cli.md).
     openstack image list
     ```
 
-    This time, you get a shorter list, but you can still filter for
-    images with the OS you prefer. For example, filter for Ubuntu:
+    This time, you get a shorter list, but you can still filter for images with the OS you prefer.
+    For example, filter for Ubuntu:
 
     ```bash
     openstack image list --tag "os:ubuntu"
@@ -198,16 +185,15 @@ file first](../../getting-started/enable-openstack-cli.md).
     IMAGE_NAME="Ubuntu 24.04 Noble Numbat x86_64"
     ```
 
-    Before you go on, decide on the capacity (in gibibytes) of the server's
-    boot volume (`VOL_SIZE`). We suggest you start with 10 gibibytes:
+    Before you go on, decide on the capacity (in gibibytes) of the server's boot volume (`VOL_SIZE`).
+    We suggest you start with 10 gibibytes:
 
     ```bash
     VOL_SIZE="10"
     ```
 
-    You need at least one network in the region you're about to
-    create your new server (`NETWORK_NAME`). To get the names of all
-    available (internal) networks, type:
+    You need at least one network in the region you're about to create your new server (`NETWORK_NAME`).
+    To get the names of all available (internal) networks, type:
 
     ```bash
     openstack network list --internal -c Name
@@ -227,8 +213,7 @@ file first](../../getting-started/enable-openstack-cli.md).
     NETWORK_NAME="nordostbahnhof"
     ```
 
-    Regarding the security group (`SEC_GROUP_NAME`), unless you
-    have already created one yourself, you will find only one per region:
+    Regarding the security group (`SEC_GROUP_NAME`), unless you have already created one yourself, you will find only one per region:
 
     ```bash
     openstack security group list -c Name -c Description
@@ -248,18 +233,15 @@ file first](../../getting-started/enable-openstack-cli.md).
     SEC_GROUP_NAME="default"
     ```
 
-    You most likely want a server you can remotely connect to via
-    SSH without typing a password. Upload one of our public keys to your
-    {{brand}} account:
+    You most likely want a server you can remotely connect to via SSH without typing a password.
+    Upload one of our public keys to your {{brand}} account:
 
     ```bash
     openstack keypair create --public-key ~/.ssh/id_ed25519.pub bahnhof
     ```
 
-    In the example above, we uploaded the public key
-    `~/.ssh/id_ed25519.pub` to our {{brand}} account and named
-    it `bahnhof`. Follow our example, and do not forget to set the
-    `KEY_NAME`:
+    In the example above, we uploaded the public key `~/.ssh/id_ed25519.pub` to our {{brand}} account and named it `bahnhof`.
+    Follow our example, and do not forget to set the `KEY_NAME`:
 
     ```bash
     KEY_NAME="bahnhof"
@@ -277,8 +259,7 @@ file first](../../getting-started/enable-openstack-cli.md).
     openstack keypair show $KEY_NAME
     ```
 
-    You are almost ready to create your new server. Decide on a
-    name...
+    You are almost ready to create your new server. Decide on a name...
 
     ```bash
     SERVER_NAME="zug" # just an example
@@ -298,11 +279,9 @@ file first](../../getting-started/enable-openstack-cli.md).
         zug
     ```
 
-    (For clarity's sake, and with the exception of `$IMAGE_NAME`, we
-    used the actual values and not the variables we so meticulously set.)
-    The `--wait` parameter is optional. Whenever you choose to
-    use it, you get back control of your terminal only after the server is
-    readily available in {{brand}}.
+    (For clarity's sake, and with the exception of `$IMAGE_NAME`, we used the actual values and not the variables we so meticulously set.)
+    The `--wait` parameter is optional.
+    Whenever you choose to use it, you get back control of your terminal only after the server is readily available in {{brand}}.
 
     The network your server is attached to might be dual-stack, or it might have an IPv4-based subnet.
     If this is the case and, additionally, you want the server to be reachable via a public IPv4 address, then you need to create a floating IP and assign it to your server.
@@ -324,9 +303,7 @@ file first](../../getting-started/enable-openstack-cli.md).
     openstack server add floating ip zug 198.51.100.12
     ```
 
-    The username of the default user account in the Ubuntu image is
-    `ubuntu`, so now you can connect to your remote server via SSH without
-    typing a password:
+    The username of the default user account in the Ubuntu image is `ubuntu`, so now you can connect to your remote server via SSH without typing a password:
 
     ```bash
     ssh ubuntu@198.51.100.12
@@ -369,12 +346,11 @@ file first](../../getting-started/enable-openstack-cli.md).
 
     ![View and use server console](assets/new-server/shot-16.png)
 === "OpenStack CLI"
-    You may have access to the web console of your server, and you need the
-    corresponding URL for it:
+    You may have access to the web console of your server, and you need the corresponding URL for it:
 
     ```bash
     openstack console url show zug
     ```
 
-    Usage of the web console is discouraged, though. Instead,
-    securely connect to your server via SSH.
+    Usage of the web console is discouraged, though.
+    Instead, securely connect to your server via SSH.

--- a/docs/howto/openstack/nova/rescue-server.md
+++ b/docs/howto/openstack/nova/rescue-server.md
@@ -3,22 +3,15 @@ description: How to access a virtual server in rescue mode
 ---
 # Rescuing a server
 
-This guide will walk you through the required steps to access a server
-in
-[rescue mode](https://docs.openstack.org/nova/latest/user/rescue.html)
-when you need to.
+This guide will walk you through the required steps to access a server in [rescue mode](https://docs.openstack.org/nova/latest/user/rescue.html) when you need to.
 
-You can use rescue mode to access the server’s operating system disk
-to fix a corrupted file system, reset access credentials on the
-server, and do other emergency recovery tasks.
+You can use rescue mode to access the server’s operating system disk to fix a corrupted file system, reset access credentials on the server, and do other emergency recovery tasks.
 
 
 ## Prerequisites
 
-You need to have previously [created a server](new-server.md) that you
-now wish to rescue. Additionally, if you prefer to work with the
-OpenStack CLI, then make sure to properly [enable it
-first](../../getting-started/enable-openstack-cli.md).
+You need to have previously [created a server](new-server.md) that you now wish to rescue.
+Additionally, if you prefer to work with the OpenStack CLI, then make sure to properly [enable it first](../../getting-started/enable-openstack-cli.md).
 
 
 ## Initiating the rescue
@@ -26,37 +19,29 @@ first](../../getting-started/enable-openstack-cli.md).
 === "{{gui}}"
     Navigate to the server list.
 
-    ![The left hand side navigation panel, with the word "Servers"
-    highlighted.](assets/rescue-server/01-left-side-panel.png)
+    ![The left hand side navigation panel, with the word "Servers" highlighted.](assets/rescue-server/01-left-side-panel.png)
 
-    Find the server you want to rescue in the list, and on the
-    right-hand side, click on its menu button.
+    Find the server you want to rescue in the list, and on the right-hand side, click on its menu button.
 
-    ![An orange circle with three white
-    dots.](assets/rescue-server/02-menu-button.png)
+    ![An orange circle with three white dots.](assets/rescue-server/02-menu-button.png)
 
     Click on _Rescue Server_.
 
-    ![A list of server actions, with the line "Rescue Server"
-    highlighted.](assets/rescue-server/03-menu-list.png)
+    ![A list of server actions, with the line "Rescue Server" highlighted.](assets/rescue-server/03-menu-list.png)
 
     Once selected, the rescue dialog appears.
     Leave the default option, _Use System Rescue Image_.
 
     Click _No_ to cancel or _Rescue_ to proceed.
 
-    ![About to rescue a server, showing details with the default option
-    "Use System Rescue Image".](assets/rescue-server/04-rescue-button.png)
+    ![About to rescue a server, showing details with the default option "Use System Rescue Image".](assets/rescue-server/04-rescue-button.png)
 
-    When a server has been switched to rescue mode, its status icon
-    appears with an exclamation mark:
+    When a server has been switched to rescue mode, its status icon appears with an exclamation mark:
 
-    ![Exclamation mark on server icon showing the server on "rescue
-    mode".](assets/rescue-server/05-rescue-mode.png)
+    ![Exclamation mark on server icon showing the server on "rescue mode".](assets/rescue-server/05-rescue-mode.png)
 
 === "OpenStack CLI"
-    You must first select a system rescue image from the available
-    images:
+    You must first select a system rescue image from the available images:
 
     ```console
     $ openstack image list --tag system-rescue
@@ -67,9 +52,7 @@ first](../../getting-started/enable-openstack-cli.md).
     +--------------------------------------+---------------+--------+
     ```
 
-    To start the server using the system rescue image, use the
-    following command, substituting the correct ID for the
-    `system-rescue` image in your {{brand}} region:
+    To start the server using the system rescue image, use the following command, substituting the correct ID for the `system-rescue` image in your {{brand}} region:
 
     ```bash
     openstack --os-compute-api-version 2.87 \
@@ -77,9 +60,7 @@ first](../../getting-started/enable-openstack-cli.md).
       --image cb2217f3-1ca7-4440-b10e-df7ff2d92cae <server_id>
     ```
 
-    While the rescue is ongoing, the server should have the
-    `OS-EXT-STS:vm_state` of `rescued` and the `status` of
-    `RESCUE`.
+    While the rescue is ongoing, the server should have the `OS-EXT-STS:vm_state` of `rescued` and the `status` of `RESCUE`.
 
     ```console
     $ openstack server show -v OS-EXT-STS:vm_state -c status <server_id>
@@ -93,11 +74,6 @@ first](../../getting-started/enable-openstack-cli.md).
 
 ## Accessing the server in rescue mode
 
-You can now proceed to accessing the remote console of your server,
-[as you would with any other newly launched
-server](new-server.md#connecting-to-the-server-console).
+You can now proceed to accessing the remote console of your server, [as you would with any other newly launched server](new-server.md#connecting-to-the-server-console).
 
-Please refer to the [System Rescue
-documentation](https://www.system-rescue.org/manual/) documentation
-for details on the available tools and features bundled with System
-Rescue.
+Please refer to the [System Rescue documentation](https://www.system-rescue.org/manual/) documentation for details on the available tools and features bundled with System Rescue.

--- a/docs/howto/openstack/nova/resize-server.md
+++ b/docs/howto/openstack/nova/resize-server.md
@@ -3,63 +3,47 @@ description: How to adjust the number of CPU cores and amount of memory for a vi
 ---
 # Resizing a server
 
-This guide will walk you through the required steps to change the
-number of CPU cores and the amount of memory your server has access
-to, this is done by changing the server's
-[flavor](../../../reference/flavors/index.md).
+This guide will walk you through the required steps to change the number of CPU cores and the amount of memory your server has access to, this is done by changing the server's [flavor](../../../reference/flavors/index.md).
 
-[Resize](https://docs.openstack.org/nova/latest/admin/configuration/resize.html)
-(or Server resize) is the ability to change the flavor of a server,
-thus allowing it to upscale or downscale according to user needs. A
-resize operation is a two-step process for the user:
+[Resize](https://docs.openstack.org/nova/latest/admin/configuration/resize.html) (or Server resize) is the ability to change the flavor of a server, thus allowing it to upscale or downscale according to user needs.
+A resize operation is a two-step process for the user:
 
 1. Initiate the resize.
-2. Either confirm (verify) success and release the old server, or
-   declare a revert to release the new server and restart the old one.
+2. Either confirm (verify) success and release the old server, or declare a revert to release the new server and restart the old one.
 
 ## Prerequisites
 
-You need to have a server you wish to resize. Additionally, if you
-prefer to work with the OpenStack CLI, then make sure to properly
-[enable it first](../../getting-started/enable-openstack-cli.md).
+You need to have a server you wish to resize.
+Additionally, if you prefer to work with the OpenStack CLI, then make sure to properly [enable it first](../../getting-started/enable-openstack-cli.md).
 
 ## Listing available flavors
 
 === "{{gui}}"
     Navigate to the server list.
 
-    ![The left hand side navigation panel, with the word "Servers"
-    highlighted.](assets/resize-server/01-left-side-panel.png)
+    ![The left hand side navigation panel, with the word "Servers" highlighted.](assets/resize-server/01-left-side-panel.png)
 
-    Find the server you want to resize in the list, and on the
-    right-hand side click on its menu button.
+    Find the server you want to resize in the list, and on the right-hand side click on its menu button.
 
-    ![An orange circle with three white
-    dots.](assets/resize-server/02-menu-button.png)
+    ![An orange circle with three white dots.](assets/resize-server/02-menu-button.png)
 
     Click on _Modify Server_.
 
-    ![A list of server actions, with the line "Modify Server"
-    highlighted.](assets/resize-server/03-menu-list.png)
+    ![A list of server actions, with the line "Modify Server" highlighted.](assets/resize-server/03-menu-list.png)
 
-    On this panel near the top, find the section called _Flavor_. This
-    is the current flavor used by the server. Press on the dropdown
-    menu to see all available flavors.
+    On this panel near the top, find the section called _Flavor_.
+    This is the current flavor used by the server.
+    Press on the dropdown menu to see all available flavors.
 
-    ![A panel displaying the servers current flavor, 8 Cores and 24 GB
-    RAM with the name of the flavor "b.8c24gb" within
-    parenthesis.](assets/resize-server/04-modify-server.png)
+    ![A panel displaying the servers current flavor, 8 Cores and 24 GB RAM with the name of the flavor "b.8c24gb" within parenthesis.](assets/resize-server/04-modify-server.png)
 === "OpenStack CLI"
-    To list all available flavors you can simply run `openstack flavor
-    list`, but that will return a very long unsorted list, instead we
-    recommend the following command:
+    To list all available flavors you can simply run `openstack flavor list`, but that will return a very long unsorted list, instead we recommend the following command:
 
     ```bash
     openstack flavor list -c Name -f value | grep '[0-9]c[0-9]' | sort -V
     ```
 
-    The printout is a simple and clean list, sorted by the compute
-    type, the number of cores and then by the amount of memory.
+    The printout is a simple and clean list, sorted by the compute type, the number of cores and then by the amount of memory.
 
     ```plain
     b.1c1gb
@@ -77,25 +61,18 @@ prefer to work with the OpenStack CLI, then make sure to properly
 
 Choose a new flavor that you want your server to use instead.
 
-> A resize is only possible with [flavors](../../../reference/flavors/index.md) using
-> the same prefix letter. Most commonly you will have a `b.` flavor,
-> thus you must select another `b.` flavor.
+> A resize is only possible with [flavors](../../../reference/flavors/index.md) using the same prefix letter. Most commonly you will have a `b.` flavor, thus you must select another `b.` flavor.
 
 === "{{gui}}"
     Once selected, the _Resize_ button will appear.
 
-    ![A panel displaying the servers new flavor, 4 Cores and 24 GB RAM
-    with the name of the flavor "b.4c24gb" within parenthesis, also a
-    green button below it with the text
-    "Resize".](assets/resize-server/05-resize-button.png)
+    ![A panel displaying the servers new flavor, 4 Cores and 24 GB RAM with the name of the flavor "b.4c24gb" within parenthesis, also a green button below it with the text "Resize".](assets/resize-server/05-resize-button.png)
 
     Click on it to start the resize.
 
-    While the resize is ongoing you will see a spinning circle saying
-    _Resize is in progress_.
+    While the resize is ongoing you will see a spinning circle saying _Resize is in progress_.
 
-    ![A spinning circle with the text "Resize in
-    progress...".](assets/resize-server/06-resize-in-progress.png)
+    ![A spinning circle with the text "Resize in progress...".](assets/resize-server/06-resize-in-progress.png)
 === "OpenStack CLI"
     To start the resize use the following command:
 
@@ -103,9 +80,7 @@ Choose a new flavor that you want your server to use instead.
     openstack server resize --flavor <new_flavor> <server_id>
     ```
 
-    While the resize is ongoing the server should have the
-    `OS-EXT-STS:task_state` of `resize_migrating` and the `status` of
-    `RESIZE`.
+    While the resize is ongoing the server should have the `OS-EXT-STS:task_state` of `resize_migrating` and the `status` of `RESIZE`.
 
     ```bash
     openstack server show -c OS-EXT-STS:task_state -c OS-EXT-STS:vm_state -c status <server_id>
@@ -121,8 +96,7 @@ Choose a new flavor that you want your server to use instead.
     +-----------------------+------------------+
     ```
 
-    You may proceed with the next step once your server status is
-    `VERIFY_RESIZE`.
+    You may proceed with the next step once your server status is `VERIFY_RESIZE`.
 
     ```plain
     +-----------------------+---------------+
@@ -134,30 +108,23 @@ Choose a new flavor that you want your server to use instead.
     +-----------------------+---------------+
     ```
 
-The resize process might take a minute or more. {{brand}} will
-now make a restore point in case the resize process fails. It would
-then restore your server to the state it was before the resize.
+The resize process might take a minute or more.
+{{brand}} will now make a restore point in case the resize process fails.
+It would then restore your server to the state it was before the resize.
 
 ## Confirming the resize
 
-Your server is now using the new flavor you selected earlier, and you
-need to make sure the server is working as intended after the resize.
+Your server is now using the new flavor you selected earlier, and you need to make sure the server is working as intended after the resize.
 
-Once you are certain your server is working as intended, you should
-confirm the resize. If you do not confirm the resize, your server will
-automatically have the resize confirmed after 24 hours.
+Once you are certain your server is working as intended, you should confirm the resize.
+If you do not confirm the resize, your server will automatically have the resize confirmed after 24 hours.
 
 === "{{gui}}"
     This is done by clicking the _Confirm_ button.
 
-    ![A panel displaying the servers flavor, 4 Cores and 24 GB RAM
-    with the name of the flavor "b.4c24gb" within parenthesis, a red
-    button with the text "Cancel" below it and a green button with the
-    text "Confirm" beside
-    that.](assets/resize-server/07-resize-confirm.png)
+    ![A panel displaying the servers flavor, 4 Cores and 24 GB RAM with the name of the flavor "b.4c24gb" within parenthesis, a red button with the text "Cancel" below it and a green button with the text "Confirm" beside that.](assets/resize-server/07-resize-confirm.png)
 
-    > If your server is not working as intended, or you simply regret
-    > the resize, instead click _Cancel_.
+    > If your server is not working as intended, or you simply regret the resize, instead click _Cancel_.
 === "OpenStack CLI"
     This is done by using the following command:
 
@@ -165,8 +132,7 @@ automatically have the resize confirmed after 24 hours.
     openstack server resize confirm <server_id>
     ```
 
-    Alternatively, if your server is not working as intended, revert
-    the resize with the following command:
+    Alternatively, if your server is not working as intended, revert the resize with the following command:
 
     ```bash
     openstack server resize revert <server_id>

--- a/docs/howto/openstack/nova/restore-srv-to-snap.md
+++ b/docs/howto/openstack/nova/restore-srv-to-snap.md
@@ -3,40 +3,30 @@ description: How to restore a server to a particular snapshot
 ---
 # Restoring a server to a snapshot
 
-Servers in {{brand}} that have the [disaster
-recovery](../../../background/disaster-recovery.md) feature enabled can go back in
-time, meaning you may restore such a server to one of the available
-point-in-time snapshots. Here is how you can do that.
+Servers in {{brand}} that have the [disaster recovery](../../../background/disaster-recovery.md) feature enabled can go back in time, meaning you may restore such a server to one of the available point-in-time snapshots.
+Here is how you can do that.
 
 ## How to restore, step by step
 
-To select a particular snapshot and restore your server to it, first
-off, navigate to the {{gui}}. From the left-hand side vertical pane,
-choose Compute → [Servers](https://{{gui_domain}}/compute/servers), then
-expand the detailed view of the server of interest. Select the *Disaster
-Recovery* tab and see all available snapshots listed below. For each one
-of those, the date and creation time are visible.
+To select a particular snapshot and restore your server to it, first off, navigate to the {{gui}}.
+From the left-hand side vertical pane, choose Compute → [Servers](https://{{gui_domain}}/compute/servers), then expand the detailed view of the server of interest.
+Select the *Disaster Recovery* tab and see all available snapshots listed below.
+For each one of those, the date and creation time are visible.
 
-![All available snapshots for selected
-server](assets/rest-srv-to-snap/disaster-recovery-available-snaps.png)
+![All available snapshots for selected server](assets/rest-srv-to-snap/disaster-recovery-available-snaps.png)
 
-Click on the snapshot you want. A pop-up window will appear, asking for
-your permission to proceed. Make sure this is indeed the snapshot you
-want, then click the red button labeled *Yes, Restore snapshot*.
+Click on the snapshot you want.
+A pop-up window will appear, asking for your permission to proceed.
+Make sure this is indeed the snapshot you want, then click the red button labeled *Yes, Restore snapshot*.
 
-![Asking for permission to restore
-snapshot](assets/rest-srv-to-snap/disaster-recovery-permission-to-proceed.png)
+![Asking for permission to restore snapshot](assets/rest-srv-to-snap/disaster-recovery-permission-to-proceed.png)
 
-The restore process will begin immediately. You can tell it is
-progressing by checking the status.
+The restore process will begin immediately.
+You can tell it is progressing by checking the status.
 
-![Snapshot recovery in
-progress](assets/rest-srv-to-snap/disaster-recovery-recover-in-progress.png)
+![Snapshot recovery in progress](assets/rest-srv-to-snap/disaster-recovery-recover-in-progress.png)
 
-As soon as the snapshot is ready to be used, you will see a message
-indicating that it has started. Do not forget to activate the server;
-click on its row to select it, then click the :fontawesome-solid-play:
-button above.
+As soon as the snapshot is ready to be used, you will see a message indicating that it has started.
+Do not forget to activate the server; click on its row to select it, then click the :fontawesome-solid-play: button above.
 
-![Start server to the
-snapshot](assets/rest-srv-to-snap/disaster-recovery-boot-from-snapshot.png)
+![Start server to the snapshot](assets/rest-srv-to-snap/disaster-recovery-boot-from-snapshot.png)

--- a/docs/howto/openstack/nova/server-group.md
+++ b/docs/howto/openstack/nova/server-group.md
@@ -7,7 +7,8 @@ In {{brand}}, you can use server groups to control the scheduling of a group of 
 
 ## Prerequisites
 
-In order to use server groups you must use the OpenStack CLI. Make sure you have [enabled it](../../getting-started/enable-openstack-cli.md).
+In order to use server groups you must use the OpenStack CLI.
+Make sure you have [enabled it](../../getting-started/enable-openstack-cli.md).
 
 ## Policies
 
@@ -58,7 +59,8 @@ If you subsequently launch more servers referencing the same server group, {{bra
 
 If you keep creating servers within a server group with a policy of `anti-affinity`, you will eventually exceed the total amount of physical compute nodes in the region.
 The command will still succeed, but the server will subsequently fail to be scheduled to a compute node.
-Instead, it will assume the `ERROR` status with the following `fault` message: _No valid host was found. There are not enough hosts available._
+Instead, it will assume the `ERROR` status with the following `fault` message: _No valid host was found.
+There are not enough hosts available._
 
 ```console
 $ openstack server show -c fault -c status <server_id>
@@ -85,6 +87,7 @@ $ openstack server show -c hostId <server_id>
 +--------+----------------------------------------------------------+
 ```
 
-`hostId` is a unique identifier for each physical compute node. By comparing this value on your different servers you can be sure if your server group policy is being upheld or not.
+`hostId` is a unique identifier for each physical compute node.
+By comparing this value on your different servers you can be sure if your server group policy is being upheld or not.
 
 > It's not possible to compare `hostId` between different projects because the values are unique for each project.


### PR DESCRIPTION
We reformat all How-Tos in the nova subcategory of the openstack category, to follow the one sentence per line policy.