### PR TITLE
chore: Apply the one sentence per line policy in the octavia subcategory

### DIFF
--- a/docs/howto/openstack/octavia/lbaas-l7pol.md
+++ b/docs/howto/openstack/octavia/lbaas-l7pol.md
@@ -3,41 +3,25 @@ description: How to add automatic HTTP to HTTPS redirection to an HTTPS-terminat
 ---
 # Using layer 7 redirection
 
-Unlike [TCP-based load balancers](lbaas-tcp.md),
-which may be considered low-level, Layer 7 load balancers follow
-high-level application logic to redirect client requests to back-end
-server pools. They take their name from the [OSI
-model](https://en.wikipedia.org/wiki/OSI_model), where Layer 7 is also
-known as the _Application Layer_. A Layer 7, or simply L7, load
-balancer decides where to redirect incoming packets based on URI, host,
-HTTP headers, etc.
+Unlike [TCP-based load balancers](lbaas-tcp.md), which may be considered low-level, Layer 7 load balancers follow high-level application logic to redirect client requests to back-end server pools.
+They take their name from the [OSI model](https://en.wikipedia.org/wiki/OSI_model), where Layer 7 is also known as the _Application Layer_.
+A Layer 7, or simply L7, load balancer decides where to redirect incoming packets based on URI, host, HTTP headers, etc.
 
-One common application of L7 load balancing is HTTP to HTTPS
-redirection. More specifically, you may have an [HTTPS-terminated load
-balancer](tls-lb.md) that distributes incoming
-client traffic to one or more back-end services, and you are looking
-for a way to automatically turn each HΤTP request into an HTTPS one. To
-have this kind of automatic redirection, you equip your load balancer
-with a new listener that acknowledges incoming HTTP requests and
-silently forwards them to the existing HTTPS-based listener.
+One common application of L7 load balancing is HTTP to HTTPS redirection.
+More specifically, you may have an [HTTPS-terminated load balancer](tls-lb.md) that distributes incoming client traffic to one or more back-end services, and you are looking for a way to automatically turn each HΤTP request into an HTTPS one.
+To have this kind of automatic redirection, you equip your load balancer with a new listener that acknowledges incoming HTTP requests and silently forwards them to the existing HTTPS-based listener.
 
-The HTTP listener will apply a specific _L7 policy_ to accomplish this. In
-general, an L7 policy is nothing but a set of one or more _L7 rules_,
-along with a predefined action. That action is fallowed when all L7
-rules evaluate to `true`, and we should point out that an L7 rule is
-a logical test that evaluates to either `true` or `false`.
+The HTTP listener will apply a specific _L7 policy_ to accomplish this.
+In general, an L7 policy is nothing but a set of one or more _L7 rules_, along with a predefined action.
+That action is fallowed when all L7 rules evaluate to `true`, and we should point out that an L7 rule is a logical test that evaluates to either `true` or `false`.
 
-In what follows, we show, step by step, how we add such a listener,
-policy, and set of rules to an existing HTTPS-terminated load balancer.
+In what follows, we show, step by step, how we add such a listener, policy, and set of rules to an existing HTTPS-terminated load balancer.
 
 ## Prerequisites
 
-The {{gui}} does not support defining L7 policies and rules, so you
-will have to work with the OpenStack CLI. [Enable
-it](../../getting-started/enable-openstack-cli.md) for the region you
-will be working in, and make sure you have the Python `octaviaclient`
-module installed. For that, use either the package manager of your
-operating system or `pip`:
+The {{gui}} does not support defining L7 policies and rules, so you will have to work with the OpenStack CLI.
+[Enable it](../../getting-started/enable-openstack-cli.md) for the region you will be working in, and make sure you have the Python `octaviaclient` module installed.
+For that, use either the package manager of your operating system or `pip`:
 
 === "Debian/Ubuntu"
     ```bash
@@ -53,13 +37,8 @@ operating system or `pip`:
 
 ## Assumptions and scenario
 
-We assume you already have an [HTTPS-terminated load
-balancer](tls-lb.md) that forwards client
-requests to a back-end server pool. In our test scenario, the load
-balancer was accepting HTTPS requests for `whoogle.example.com` and
-forwarding them to a two-member pool, with servers each running a
-Docker container for [Whoogle
-Search](https://github.com/benbusby/whoogle-search).
+We assume you already have an [HTTPS-terminated load balancer](tls-lb.md) that forwards client requests to a back-end server pool.
+In our test scenario, the load balancer was accepting HTTPS requests for `whoogle.example.com` and forwarding them to a two-member pool, with servers each running a Docker container for [Whoogle Search](https://github.com/benbusby/whoogle-search).
 
 ## Creating an HTTP listener
 
@@ -78,8 +57,7 @@ $ openstack loadbalancer list
 +---------------+------+---------------+--------------+---------------------+------------------+----------+
 ```
 
-...and here is `mylb-listener-https`, the HTTPS-terminated listener of
-`mylb`:
+...and here is `mylb-listener-https`, the HTTPS-terminated listener of `mylb`:
 
 ```console
 $ openstack loadbalancer listener list
@@ -95,8 +73,7 @@ $ openstack loadbalancer listener list
 +-------------+-----------------+-------------+-------------+-------------+---------------+----------------+
 ```
 
-You may now add `mylb-listener-http`, a new HTTP-based listener for
-`mylb`:
+You may now add `mylb-listener-http`, a new HTTP-based listener for `mylb`:
 
 ```bash
 openstack loadbalancer listener create \
@@ -275,10 +252,8 @@ openstack loadbalancer l7policy list -c name -c provisioning_status
 +---------------------------+---------------------+
 ```
 
-From now on, all client attempts to reach `http://whoogle.example.com`
-will end up at `https://whoogle.example.com`. You may confirm this is
-the case with any web browser or from your terminal, e.g., using `curl`
-like this:
+From now on, all client attempts to reach `http://whoogle.example.com` will end up at `https://whoogle.example.com`.
+You may confirm this is the case with any web browser or from your terminal, e.g., using `curl` like this:
 
 ```bash
 curl -IL http://whoogle.example.com
@@ -298,7 +273,4 @@ server: waitress
 set-cookie: ...
 ```
 
-As you can see in the output, the first thing that happens
-when visiting `http://whoogle.example.com` is a redirection
-(`HTTP/1.1 302 Found`) to `https://whoogle.example.com`.
-
+As you can see in the output, the first thing that happens when visiting `http://whoogle.example.com` is a redirection (`HTTP/1.1 302 Found`) to `https://whoogle.example.com`.

--- a/docs/howto/openstack/octavia/lbaas-tcp.md
+++ b/docs/howto/openstack/octavia/lbaas-tcp.md
@@ -3,29 +3,23 @@ description: A walk-through of creating a TCP load balancer
 ---
 # Setting up a TCP load balancer
 
-Octavia is a Load Balancer as a Service (LBaaS) solution designed to
-work with OpenStack. In this guide, we show how to instantiate and
-configure a simple TCP load balancer in {{brand}}. All intermediate
-steps are presented and explained through a specific scenario, and we
-work using either the {{gui}} or the OpenStack CLI.
+Octavia is a Load Balancer as a Service (LBaaS) solution designed to work with OpenStack.
+In this guide, we show how to instantiate and configure a simple TCP load balancer in {{brand}}.
+All intermediate steps are presented and explained through a specific scenario, and we work using either the {{gui}} or the OpenStack CLI.
 
 ## Prerequisites
 
-Whether you choose the {{gui}} or the OpenStack CLI, you need to [have
-an account](../../getting-started/create-account.md) in {{brand}}.
-Additionally, to use the OpenStack CLI, make sure to [enable
-it](../../getting-started/enable-openstack-cli.md) for the region you
-will be working in. Besides the Python `openstackclient` module, you
-will also have to install the Python `octaviaclient` module. For that,
-use either the package manager of your operating system or `pip`:
+Whether you choose the {{gui}} or the OpenStack CLI, you need to [have an account](../../getting-started/create-account.md) in {{brand}}.
+Additionally, to use the OpenStack CLI, make sure to [enable it](../../getting-started/enable-openstack-cli.md) for the region you will be working in.
+Besides the Python `openstackclient` module, you will also have to install the Python `octaviaclient` module.
+For that, use either the package manager of your operating system or `pip`:
 
 === "Debian/Ubuntu"
     ```bash
     apt install python3-octaviaclient
     ```
 === "Mac OS X with Homebrew"
-    This particular Python module is unavailable via `brew`, but you
-    can install it via `pip`.
+    This particular Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
     pip install python-octaviaclient
@@ -33,61 +27,43 @@ use either the package manager of your operating system or `pip`:
 
 ## Scenario and terminology
 
-To configure and test our basic TCP load balancer, we have two servers
-in the same {{brand}} region, both having `ncat` listening on port
-61234/TCP and returning a greeting to clients asking to connect to that
-port. Both servers are in the same internal network, and our load
-balancer will be responsible for redirecting client connections to them
-in a round-robin fashion. The load balancer will have a single floating
-IP address, so prospective clients will have to know only that address
-and not any of the backend server addresses.
+To configure and test our basic TCP load balancer, we have two servers in the same {{brand}} region, both having `ncat` listening on port 61234/TCP and returning a greeting to clients asking to connect to that port.
+Both servers are in the same internal network, and our load balancer will be responsible for redirecting client connections to them in a round-robin fashion.
+The load balancer will have a single floating IP address, so prospective clients will have to know only that address and not any of the backend server addresses.
 
-> Please note that while working with your load balancer, you will
-encounter some technical terms which go a long way toward
-conceptualizing the inner logic of the whole LBaaS system. This guide
-introduces those terms not beforehand but exactly when needed.
+> Please note that while working with your load balancer, you will encounter some technical terms which go a long way toward conceptualizing the inner logic of the whole LBaaS system.
+This guide introduces those terms not beforehand but exactly when needed.
 
 ## Creating a load balancer
 
-That is only the first step towards our goal, which is to have a fully
-functional TCP load balancer. We will also need a listener and a pool,
-but first things first.
+That is only the first step towards our goal, which is to have a fully functional TCP load balancer.
+We will also need a listener and a pool, but first things first.
 
 === "{{gui}}"
-    Fire up your favorite web browser, navigate to the
-    [{{gui}}](https://{{gui_domain}}) start page, and log into your
-    {{brand}} account. On the top right-hand side of the {{gui}}, click the
-    _Create_ button. A new pane titled _Create_ will slide into view from
-    the right-hand side of the browser window. You will notice several
-    rounded boxes on that pane, each for defining, configuring, and
-    instantiating a different {{brand}} object. Go ahead and click the
-    _Load Balancer_ box.
+    Fire up your favorite web browser, navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log into your {{brand}} account.
+    On the top right-hand side of the {{gui}}, click the _Create_ button.
+    A new pane titled _Create_ will slide into view from the right-hand side of the browser window.
+    You will notice several rounded boxes on that pane, each for defining, configuring, and instantiating a different {{brand}} object.
+    Go ahead and click the _Load Balancer_ box.
 
     ![Create new object](assets/shot-01.png)
 
-    A new pane titled _Create a Load Balancer_ will slide over. At the top,
-    type in a name for the new load balancer and select one of the
-    available regions. Optionally, type in a description.
+    A new pane titled _Create a Load Balancer_ will slide over.
+    At the top, type in a name for the new load balancer and select one of the available regions.
+    Optionally, type in a description.
 
     ![Set name, region, and description for the new LB](assets/shot-02.png)
 
-    In the same pane, scroll down a bit if you have to and activate the
-    _Subnet_ radio button. Then, from the _Subnet_ dropdown menu below,
-    select an appropriate subnet for the new load balancer to move in front
-    of. In our example, the two test servers we have are members of the
-    `network-fra1` internal network, and `subnet-fra1` is the name of the
-    corresponding subnet. Click the green _Create_ button below to
-    instantiate the new load balancer.
+    In the same pane, scroll down a bit if you have to and activate the _Subnet_ radio button.
+    Then, from the _Subnet_ dropdown menu below, select an appropriate subnet for the new load balancer to move in front of.
+    In our example, the two test servers we have are members of the `network-fra1` internal network, and `subnet-fra1` is the name of the corresponding subnet.
+    Click the green _Create_ button below to instantiate the new load balancer.
 
     ![Select a subnet for the new LB](assets/shot-03.png)
 
-    The creation of the new load balancer starts and, unless something goes
-    wrong, finishes successfully in a minute or so. For a view of the load
-    balancer, make sure the left-hand side vertical pane of the {{gui}} is
-    fully visible, click on the _Networking_ category to expand it, and then
-    click once more on the _Load Balancers_ option. In the main area of the
-    {{gui}}, select the new load balancer, click the three-dot icon on the
-    right, and select _View details_ from the pop-up menu that appears.
+    The creation of the new load balancer starts and, unless something goes wrong, finishes successfully in a minute or so.
+    For a view of the load balancer, make sure the left-hand side vertical pane of the {{gui}} is fully visible, click on the _Networking_ category to expand it, and then click once more on the _Load Balancers_ option.
+    In the main area of the {{gui}}, select the new load balancer, click the three-dot icon on the right, and select _View details_ from the pop-up menu that appears.
 
     ![View the newly created LB](assets/shot-04.png)
 === "OpenStack CLI"
@@ -126,12 +102,9 @@ but first things first.
     +---------------------+--------------------------------------+
     ```
 
-    In the example above, the name of the load balancer is `mylb`, and the
-    subnet it will be in front of is named `subnet-fra1` (this is the
-    subnet our two test servers are members of). You will notice in the
-    command output that, at first, the `provisioning_status` is
-    `PENDING_CREATE`. To make sure the load balancer has been successfully
-    created, try this command a couple of times:
+    In the example above, the name of the load balancer is `mylb`, and the subnet it will be in front of is named `subnet-fra1` (this is the subnet our two test servers are members of).
+    You will notice in the command output that, at first, the `provisioning_status` is `PENDING_CREATE`.
+    To make sure the load balancer has been successfully created, try this command a couple of times:
 
     ```bash
     openstack loadbalancer show mylb -c provisioning_status
@@ -147,41 +120,32 @@ but first things first.
 
 ## Creating a listener
 
-A load balancer needs a way to listen for incoming client connection
-requests. The _listener_ allows a load balancer to do just that. The
-load balancer you instantiated has no listener, so let us see how you
-can equip it with one.
+A load balancer needs a way to listen for incoming client connection requests.
+The _listener_ allows a load balancer to do just that.
+The load balancer you instantiated has no listener, so let us see how you can equip it with one.
 
 === "{{gui}}"
-    Looking at the detailed view of the new load balancer, you see three
-    tabs: _Details_, _Listeners_, and _Pools_. Click the _Listeners_ tab
-    and notice the message: "No Listeners for this LoadBalancer". Time to
-    create one, so click the green button labeled _Create a Listener_.
+    Looking at the detailed view of the new load balancer, you see three tabs: _Details_, _Listeners_, and _Pools_.
+    Click the _Listeners_ tab and notice the message: "No Listeners for this LoadBalancer".
+    Time to create one, so click the green button labeled _Create a Listener_.
 
     ![Create a listener](assets/shot-05.png)
 
-    From the right-hand side of the {{gui}}, a pane named _Create a
-    Listener_ slides over. Type in a name for the new listener --- and
-    optionally a description.
+    From the right-hand side of the {{gui}}, a pane named _Create a Listener_ slides over.
+    Type in a name for the new listener --- and optionally a description.
 
     ![Set name and description for the new listener](assets/shot-06.png)
 
-    Further down, from the _Protocol_ dropdown menu, select the protocol
-    the listener will be paying attention to. Since you are setting up a
-    TCP load balancer, the protocol for the listener will also have to be
-    TCP. Additionally, type in the listening port. The load balancer will
-    be redirecting connections to a couple of servers, which listen for
-    connections on port 61234/TCP, so it makes sense ---though it is not
-    necessary--- for the load balancer to use that same listening port.
-    Since you have not yet defined a pool, ignore the _Default pool_
-    dropdown menu for now. Instead, go ahead and click the green _Create_
-    button.
+    Further down, from the _Protocol_ dropdown menu, select the protocol the listener will be paying attention to.
+    Since you are setting up a TCP load balancer, the protocol for the listener will also have to be TCP.
+    Additionally, type in the listening port.
+    The load balancer will be redirecting connections to a couple of servers, which listen for connections on port 61234/TCP, so it makes sense ---though it is not necessary--- for the load balancer to use that same listening port.
+    Since you have not yet defined a pool, ignore the _Default pool_ dropdown menu for now.
+    Instead, go ahead and click the green _Create_ button.
 
     ![Select protocol and set port](assets/shot-07.png)
 
-    The listener will be created in no time, and you will be able to see
-    its characteristics in the _Listeners_ tab of your load balancer
-    detailed view.
+    The listener will be created in no time, and you will be able to see its characteristics in the _Listeners_ tab of your load balancer detailed view.
 
     ![Listener successfully created](assets/shot-08.png)
 === "OpenStack CLI"
@@ -243,52 +207,41 @@ can equip it with one.
     +---------------------+--------+
     ```
 
-    Since you wanted to create a TCP load balancer, in the command above,
-    you specified the connection protocol via the `--protocol` parameter.
-    Also, the new load balancer will be redirecting connections to a couple
-    of servers listening on port 61234, so it makes sense to set the
-    listening port to 61234 (see the `--protocol-port` parameter).
+    Since you wanted to create a TCP load balancer, in the command above, you specified the connection protocol via the `--protocol` parameter.
+    Also, the new load balancer will be redirecting connections to a couple of servers listening on port 61234, so it makes sense to set the listening port to 61234 (see the `--protocol-port` parameter).
 
 ## Creating a pool
 
-Any server accepting connections from the listener is said to be a
-_member_ of a _pool_. For our load balancer to work, we must create a
-pool and explicitly list its members.
+Any server accepting connections from the listener is said to be a _member_ of a _pool_.
+For our load balancer to work, we must create a pool and explicitly list its members.
 
 === "{{gui}}"
-    With the detailed view of the load balancer expanded, click the _Pools_
-    tab. You will notice the message "No pools for this LoadBalancer", so
-    click the green _Create a Pool_ button.
+    With the detailed view of the load balancer expanded, click the _Pools_ tab.
+    You will notice the message "No pools for this LoadBalancer", so click the green _Create a Pool_ button.
 
     ![Create a pool](assets/shot-09.png)
 
-    A new pane named _Create a Pool_ slides over. First, type in a name for
-    the new pool. For the _Algorithm_, make sure to select *ROUND_ROBIN*.
-    Since you are configuring a TCP load balancer, set the _Protocol_ to
-    _TCP_.
+    A new pane named _Create a Pool_ slides over.
+    First, type in a name for the new pool.
+    For the _Algorithm_, make sure to select *ROUND_ROBIN*.
+    Since you are configuring a TCP load balancer, set the _Protocol_ to _TCP_.
 
     ![Type in name, set algorithm and protocol](assets/shot-10.png)
 
-    A little bit further down the pane, there is the _Listener_ dropdown
-    menu; select the one you created in the previous step. Leave the
-    _Session persistence_ parameter as it is, and create your pool with a
-    click on the green _Create_ button.
+    A little bit further down the pane, there is the _Listener_ dropdown menu; select the one you created in the previous step.
+    Leave the _Session persistence_ parameter as it is, and create your pool with a click on the green _Create_ button.
 
     ![Select listener, create pool](assets/shot-11.png)
 
-    The pool is instantaneously available; as you can see, it has zero
-    members and one listener (the one you created in the previous step).
+    The pool is instantaneously available; as you can see, it has zero members and one listener (the one you created in the previous step).
 
     ![Zero members, one listener](assets/shot-12.png)
 
-    Notice that the listener already knows about the new pool, even though
-    you did not explicitly mention it.
+    Notice that the listener already knows about the new pool, even though you did not explicitly mention it.
 
     ![The listener knows](assets/shot-13.png)
 === "OpenStack CLI"
-    To create a pool named `mylb-pool` that distributes incoming TCP
-    connections to its members in a round-robin fashion from the listener
-    named `mylb-listener`, type this command:
+    To create a pool named `mylb-pool` that distributes incoming TCP connections to its members in a round-robin fashion from the listener named `mylb-listener`, type this command:
 
     ```bash
     openstack loadbalancer pool create \
@@ -327,8 +280,7 @@ pool and explicitly list its members.
     +----------------------+--------------------------------------+
     ```
 
-    Once more, you may check the `provisioning_status` by typing the
-    following:
+    Once more, you may check the `provisioning_status` by typing the following:
 
     ```bash
     openstack loadbalancer pool show mylb-pool -c provisioning_status
@@ -347,22 +299,18 @@ pool and explicitly list its members.
 The pool you created has no members, so it is time to populate it.
 
 === "{{gui}}"
-    In the detailed view of your load balancer, go to the _Pools_ tab and
-    click the bulleted-list icon.
+    In the detailed view of your load balancer, go to the _Pools_ tab and click the bulleted-list icon.
 
     ![Populate the pool](assets/shot-14.png)
 
-    A new pane titled _Modify Pool Members_ appears, listing all the
-    servers that share the same region with the load balancer. In our
-    example, there are three servers. We created `srv-lbaas-1` and
-    `srv-lbaas-2` to test the load balancer, so now we click on the
-    corresponding plus-sign icons to add those to the pool.
+    A new pane titled _Modify Pool Members_ appears, listing all the servers that share the same region with the load balancer.
+    In our example, there are three servers.
+    We created `srv-lbaas-1` and `srv-lbaas-2` to test the load balancer, so now we click on the corresponding plus-sign icons to add those to the pool.
 
     ![Add members](assets/shot-15.png)
 
-    You may have noticed that the listening port of each server we added is
-    by default 80, but we want port 61234. To change the listening port of
-    a server, just click the corresponding notepad-and-pen icon.
+    You may have noticed that the listening port of each server we added is by default 80, but we want port 61234.
+    To change the listening port of a server, just click the corresponding notepad-and-pen icon.
 
     ![Modify ports](assets/shot-16.png)
 
@@ -370,14 +318,12 @@ The pool you created has no members, so it is time to populate it.
 
     ![Apply changes to pool](assets/shot-17.png)
 
-    At this point, the load balancer should have its listener plus a pool
-    with two members.
+    At this point, the load balancer should have its listener plus a pool with two members.
 
     ![Pool is populated](assets/shot-18.png)
 === "OpenStack CLI"
-    Both our test servers are in the `subnet-fra1` subnet, one of them has
-    IP `10.15.25.105`, and the other one has IP `10.15.25.236`. To add
-    those two servers in pool `mylb-pool`, type:
+    Both our test servers are in the `subnet-fra1` subnet, one of them has IP `10.15.25.105`, and the other one has IP `10.15.25.236`.
+    To add those two servers in pool `mylb-pool`, type:
 
     ```bash
     openstack loadbalancer member create \
@@ -462,34 +408,31 @@ The pool you created has no members, so it is time to populate it.
 
 ## Assigning a floating IP
 
-Your load balancer has an internal IP chosen from the subnet you
-indicated earlier. This makes it reachable from other servers in the
-same subnet but not from the Internet. You probably want the load
-balancer to be reachable from anywhere, meaning you have to equip it
-with a floating IP.
+Your load balancer has an internal IP chosen from the subnet you indicated earlier.
+This makes it reachable from other servers in the same subnet but not from the Internet.
+You probably want the load balancer to be reachable from anywhere, meaning you have to equip it with a floating IP.
 
 === "{{gui}}"
-    While viewing your load balancer, click the three-dot icon on the
-    right. From the pop-up menu that appears, select _Modify Load Balancer_.
+    While viewing your load balancer, click the three-dot icon on the right.
+    From the pop-up menu that appears, select _Modify Load Balancer_.
 
     ![Modify load balancer](assets/shot-19.png)
 
-    The _Modify Load Balancer_ pane appears. For the _Floating IP_ option,
-    select _Create and attach IP_.
+    The _Modify Load Balancer_ pane appears.
+    For the _Floating IP_ option, select _Create and attach IP_.
 
     ![Create and attach floating IP](assets/shot-20.png)
 
-    A new pane slides over, named _Create a Floating IP_. For the _Region_
-    parameter, select the one the load balancer resides in. For the _Assign
-    to_ parameter, make sure you choose _Load Balancer_. In our example,
-    there's only one load balancer in the region we are working in, so the
-    parameter _Assign To_ is already set for us. To finalize the
-    assignment, click the green _Create and Assign_ button.
+    A new pane slides over, named _Create a Floating IP_.
+    For the _Region_ parameter, select the one the load balancer resides in.
+    For the _Assign to_ parameter, make sure you choose _Load Balancer_.
+    In our example, there's only one load balancer in the region we are working in, so the parameter _Assign To_ is already set for us.
+    To finalize the assignment, click the green _Create and Assign_ button.
 
     ![Configure attachment](assets/shot-21.png)
 
-    As you may see, your load balancer now has a floating IP. You can now
-    use that to test the balancer and make sure it works as expected.
+    As you may see, your load balancer now has a floating IP.
+    You can now use that to test the balancer and make sure it works as expected.
 
     ![Floating IP attached to load balancer](assets/shot-22.png)
 === "OpenStack CLI"
@@ -547,17 +490,13 @@ with a floating IP.
 
 ## Testing the load balancer
 
-Each of the two test servers runs `ncat` to continuously listen
-on port 61234/TCP and respond to clients with a simple message,
-revealing its hostname:
+Each of the two test servers runs `ncat` to continuously listen on port 61234/TCP and respond to clients with a simple message, revealing its hostname:
 
 ```bash
 ncat -kv -l 61234 -c 'echo Yello from $(hostname)!'
 ```
 
-Since the load balancer has a floating IP (`198.51.100.129`,
-in our example), and we know the port it listens to, we can
-try connecting to it via `wget` and see what happens:
+Since the load balancer has a floating IP (`198.51.100.129`, in our example), and we know the port it listens to, we can try connecting to it via `wget` and see what happens:
 
 ```bash
 wget -q 198.51.100.129:61234 -O -
@@ -567,10 +506,8 @@ wget -q 198.51.100.129:61234 -O -
 Yello from srv-lbaas-1!
 ```
 
-It looks like we talked to the first test server. If we run the
-exact same `wget` command for a second time, since the load balancer
-distributes client connection requests in a round-robin fashion,
-we expect to talk to the second server:
+It looks like we talked to the first test server.
+If we run the exact same `wget` command for a second time, since the load balancer distributes client connection requests in a round-robin fashion, we expect to talk to the second server:
 
 ```bash
 wget -q 198.51.100.129:61234 -O -
@@ -580,15 +517,10 @@ wget -q 198.51.100.129:61234 -O -
 Yello from srv-lbaas-2!
 ```
 
-During our testing, executing the `wget` command repeatedly, we were
-getting those two hostnames one after the other --- and that was
-proof our TCP load balancer was working as expected. But there is
-one more expectation of any load balancer: the ability to skip
-backend hosts when they are inaccessible.
+During our testing, executing the `wget` command repeatedly, we were getting those two hostnames one after the other --- and that was proof our TCP load balancer was working as expected.
+But there is one more expectation of any load balancer: the ability to skip backend hosts when they are inaccessible.
 
-To test our load balancer in this new scenario, let us first use
-`wget` to connect to port 61234 and jot down the backend server
-that will respond:
+To test our load balancer in this new scenario, let us first use `wget` to connect to port 61234 and jot down the backend server that will respond:
 
 ```bash
 wget -q 198.51.100.129:61234 -O -
@@ -598,13 +530,10 @@ wget -q 198.51.100.129:61234 -O -
 Yello from srv-lbaas-2!
 ```
 
-We see that `srv-lbaas-2` responded. That means the next time we
-try to connect, `srv-lbaas-1` will respond. But if we SSH into
-`srv-lbaas-1` and terminate `ncat`, then after connecting with
-`wget` we will get a response from `srv-lbaas-2` --- again. This,
-at least, is our expectation. So without further ado, we SSH into
-`srv-lbaas-1`, we terminate `ncat`, we log out, and from our local
-terminal, we type:
+We see that `srv-lbaas-2` responded. That means the next time we try to connect, `srv-lbaas-1` will respond.
+But if we SSH into `srv-lbaas-1` and terminate `ncat`, then after connecting with `wget` we will get a response from `srv-lbaas-2` --- again.
+This, at least, is our expectation.
+So without further ado, we SSH into `srv-lbaas-1`, we terminate `ncat`, we log out, and from our local terminal, we type:
 
 ```bash
 wget -q 198.51.100.129:61234 -O -
@@ -614,54 +543,40 @@ wget -q 198.51.100.129:61234 -O -
 Yello from srv-lbaas-2!
 ```
 
-Exactly as we expected, `srv-lbaas-2` has responded again, proving
-our load balancer behaves correctly. As an exercise, you might want
-to shutdown your `srv-lbaas-1` and/or re-enable `ncat`, and check
-the behavior of the load balancer. There should be no surprises.
+Exactly as we expected, `srv-lbaas-2` has responded again, proving our load balancer behaves correctly.
+As an exercise, you might want to shutdown your `srv-lbaas-1` and/or re-enable `ncat`, and check the behavior of the load balancer.
+There should be no surprises.
 
 ## Adding a health monitor
 
-You can add a health monitor to the pool of your load balancer,
-so whenever ---and for whatever reason--- one or more of the pool
-member services are inaccessible, the load balancer will know and
-won't even bother trying to redirect client requests to them. Of
-course, whenever an inaccessible service gets accessible again,
-the load balancer will take notice and start treating the
-corresponding pool member as a fully functional server.
+You can add a health monitor to the pool of your load balancer, so whenever ---and for whatever reason--- one or more of the pool member services are inaccessible, the load balancer will know and won't even bother trying to redirect client requests to them.
+Of course, whenever an inaccessible service gets accessible again, the load balancer will take notice and start treating the corresponding pool member as a fully functional server.
 
 === "{{gui}}"
-    In the detailed view of your load balancer, pull up the
-    _Pools_ tab. In the _Health Monitor_ column there is a "0",
-    for the pool has no health monitor yet.
+    In the detailed view of your load balancer, pull up the _Pools_ tab.
+    In the _Health Monitor_ column there is a "0", for the pool has no health monitor yet.
 
     ![There is no health monitor](assets/shot-23.png)
 
     To add a health monitor, click the notepad-and-pen icon.
-    A pane titled _Modify Pool_ slides over. Scroll down if
-    you have to, and stop when the _Health Monitor_ section is
-    fully visible. You will see a message saying, "No health
-    monitor created", so click the green _Create a Healthmonitor_
-    button to create one.
+    A pane titled _Modify Pool_ slides over.
+    Scroll down if you have to, and stop when the _Health Monitor_ section is fully visible.
+    You will see a message saying, "No health monitor created", so click the green _Create a Healthmonitor_ button to create one.
 
     ![Create new health monitor](assets/shot-24.png)
 
-    Pick a name for the new health monitor, and set its type to
-    TCP. That is the connection protocol that will be used to
-    determine whether pool member services are accessible.
-    Finalize your choices with a click on the green _Create_
-    button.
+    Pick a name for the new health monitor, and set its type to TCP.
+    That is the connection protocol that will be used to determine whether pool member services are accessible.
+    Finalize your choices with a click on the green _Create_ button.
 
     ![Define health monitor characteristics](assets/shot-25.png)
 
-    You will then see that in the _Health Monitor_ column there
-    is a "1" --- and that means the monitor is active. To see
-    real-time information regarding pool members operating status,
-    click over "1".
+    You will then see that in the _Health Monitor_ column there is a "1" --- and that means the monitor is active.
+    To see real-time information regarding pool members operating status, click over "1".
 
     ![Check members operating status](assets/shot-26.png)
 === "OpenStack CLI"
-    To create a health monitor for pool `mylb-pool` of load
-    balancer `mylb`, type something like the following:
+    To create a health monitor for pool `mylb-pool` of load balancer `mylb`, type something like the following:
 
     ```bash
     openstack loadbalancer healthmonitor create \
@@ -697,10 +612,8 @@ corresponding pool member as a fully functional server.
     +---------------------+--------------------------------------+
     ```
 
-    The name of the new health monitor is `mylb-pool-healthmon`,
-    and the TCP protocol will be used to check whether members
-    of pool `mylb-pool` are online or offline. To check the
-    provisioning status of the health monitor, type:
+    The name of the new health monitor is `mylb-pool-healthmon`, and the TCP protocol will be used to check whether members of pool `mylb-pool` are online or offline.
+    To check the provisioning status of the health monitor, type:
 
     ```bash
     openstack loadbalancer healthmonitor show \
@@ -715,8 +628,7 @@ corresponding pool member as a fully functional server.
     +---------------------+--------+
     ```
 
-    Once the health monitor is provisioned, you may at any time
-    check the pool members status like so:
+    Once the health monitor is provisioned, you may at any time check the pool members status like so:
 
     ```bash
     openstack loadbalancer member list mylb-pool
@@ -743,28 +655,19 @@ corresponding pool member as a fully functional server.
 
 ## Observing and testing the monitor
 
-Having a health monitor for your load balancer's pool up and
-running, whenever the service of interest in any of the pool
-members gets inaccessible, the monitor notices and immediately
-considers the corresponding member as offline. From then on,
-and until the same service gets accessible again, the load
-balancer does not even try to redirect client connections to
-the affected member. During our testing, we killed `ncat`
-running on `srv-lbaas-1`, and then took a look at the health
-monitor from the {{gui}} --- and also from a local terminal.
+Having a health monitor for your load balancer's pool up and running, whenever the service of interest in any of the pool members gets inaccessible, the monitor notices and immediately considers the corresponding member as offline.
+From then on, and until the same service gets accessible again, the load balancer does not even try to redirect client connections to the affected member.
+During our testing, we killed `ncat` running on `srv-lbaas-1`, and then took a look at the health monitor from the {{gui}} --- and also from a local terminal.
 
 === "{{gui}}"
-    In the detailed view of your load balancer, pull up the
-    _Pools_ tab and click anywhere on its line. After a second
-    or two, you will see information regarding all pool members.
-    Pay attention to the _Operating Status_ column, where you
-    can see the status of any of the pool members.
+    In the detailed view of your load balancer, pull up the _Pools_ tab and click anywhere on its line.
+    After a second or two, you will see information regarding all pool members.
+    Pay attention to the _Operating Status_ column, where you can see the status of any of the pool members.
 
     ![Operating status of all pool members](assets/shot-27.png)
 
 === "OpenStack CLI"
-    To check the operating status of any of the pool members
-    of your load balancer, type something like this:
+    To check the operating status of any of the pool members of your load balancer, type something like this:
 
     ```bash
     openstack loadbalancer member list mylb-pool
@@ -789,10 +692,8 @@ monitor from the {{gui}} --- and also from a local terminal.
     +-----------+-----------+------------+---------------------+-----------+---------------+------------------+--------+
     ```
 
-    In the example above, see the `operating_status` column,
-    specifically the status of server `srv-lbaas-1`. Regarding
-    the operating status of all pool members, you can always
-    limit the scope of your query like so:
+    In the example above, see the `operating_status` column, specifically the status of server `srv-lbaas-1`.
+    Regarding the operating status of all pool members, you can always limit the scope of your query like so:
 
     ```bash
     openstack loadbalancer member list mylb-pool \
@@ -808,8 +709,7 @@ monitor from the {{gui}} --- and also from a local terminal.
     +-------------+------------------+
     ```
 
-Finally, let us see what happens when we repeatedly try to
-access the remote service via the load balancer:
+Finally, let us see what happens when we repeatedly try to access the remote service via the load balancer:
 
 ```console
 $ wget -q 198.51.100.129:61234 -O -
@@ -822,9 +722,5 @@ $ wget -q 198.51.100.129:61234 -O -
 Yello from srv-lbaas-2!
 ```
 
-Since pool member `srv-lbaas-1` is offline to the health
-monitor, we keep getting an answer from `srv-lbaas-2`.
-Actually, while the service of interest in `srv-lbaas-1` is
-inaccessible, then no matter how many times we run the command
-above we will keep getting a response from `srv-lbaas-2` only.
-
+Since pool member `srv-lbaas-1` is offline to the health monitor, we keep getting an answer from `srv-lbaas-2`.
+Actually, while the service of interest in `srv-lbaas-1` is inaccessible, then no matter how many times we run the command above we will keep getting a response from `srv-lbaas-2` only.

--- a/docs/howto/openstack/octavia/metrics.md
+++ b/docs/howto/openstack/octavia/metrics.md
@@ -20,8 +20,7 @@ For that, use either the package manager of your operating system, or `pip`:
     apt install python3-octaviaclient
     ```
 === "Mac OS X with Homebrew"
-    This particular Python module is unavailable via `brew`, but you
-    can install it via `pip`.
+    This particular Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
     pip install python-octaviaclient

--- a/docs/howto/openstack/octavia/tls-lb.md
+++ b/docs/howto/openstack/octavia/tls-lb.md
@@ -1,25 +1,17 @@
 # HTTPS-terminating load balancers
 
-In {{brand}}’s load balancing service, [OpenStack
-Octavia](https://docs.openstack.org/octavia/latest/), you can
-configure load balancers so that they manage HTTPS termination. That
-is to say that the load balancer encrypts and decrypts HTTPS traffic,
-and forwards HTTP to and from a backend web server.
+In {{brand}}’s load balancing service, [OpenStack Octavia](https://docs.openstack.org/octavia/latest/), you can configure load balancers so that they manage HTTPS termination.
+That is to say that the load balancer encrypts and decrypts HTTPS traffic, and forwards HTTP to and from a backend web server.
 
-To do so, the load balancer must have access to encryption credentials
-(such as certificates and private keys), which it stores in Barbican.
+To do so, the load balancer must have access to encryption credentials (such as certificates and private keys), which it stores in Barbican.
 
 
 ## PKCS #12 Certificate Bundles
 
-The [PKCS #12](https://en.wikipedia.org/wiki/PKCS_12) archive format
-includes SSL certificates, certificate chains, and private keys all in
-one bundle. Most certificate providers give you the option of
-downloading certificate credentials using the PKCS #12 format.
+The [PKCS #12](https://en.wikipedia.org/wiki/PKCS_12) archive format includes SSL certificates, certificate chains, and private keys all in one bundle.
+Most certificate providers give you the option of downloading certificate credentials using the PKCS #12 format.
 
-In case your certificate provider has made your certificate chain and
-key available separately, using the PEM format, you can easily convert
-it to PKCS #12 using the following `openssl` command:
+In case your certificate provider has made your certificate chain and key available separately, using the PEM format, you can easily convert it to PKCS #12 using the following `openssl` command:
 
 ```bash
 openssl pkcs12 -export -inkey key.pem -in fullchain.pem -out bundle.p12
@@ -30,10 +22,7 @@ When prompted for an export password, use a blank one.
 
 ## Creating Barbican secrets from PKCS #12 bundles
 
-To create a secret from a stored PKCS #12 bundle, you need pass in the
-contents of the bundle, *pre-encoded with
-[Base64](https://en.wikipedia.org/wiki/Base64)*, as the secret’s
-payload.
+To create a secret from a stored PKCS #12 bundle, you need pass in the contents of the bundle, *pre-encoded with [Base64](https://en.wikipedia.org/wiki/Base64)*, as the secret’s payload.
 
 ```console
 $ openstack secret store \
@@ -59,13 +48,10 @@ $ openstack secret store \
 
 ## Creating HTTPS-enabled load balancer listeners
 
-Once you have created your secret containing your certificate data,
-you can create a load balancer *listener* with the following
-properties:
+Once you have created your secret containing your certificate data, you can create a load balancer *listener* with the following properties:
 
 * It uses the `TERMINATED_HTTPS` protocol,
-* It sets its “default TLS container” to the Barbican secret
-  containing the PKCS #12 bundle,
+* It sets its “default TLS container” to the Barbican secret containing the PKCS #12 bundle,
 * It listens on the standard HTTPS port, 443.
 
 
@@ -114,30 +100,24 @@ $ openstack loadbalancer listener create \
 
 ## Updating the TLS certificate for a HTTPS listener
 
-When the certificate associated with a `TERMINATED_HTTPS` listener is
-about to expire, you will need to replace it. You can do this online,
-with no user-noticeable interruption to your service.
+When the certificate associated with a `TERMINATED_HTTPS` listener is about to expire, you will need to replace it.
+You can do this online, with no user-noticeable interruption to your service.
 
-1. [Create a new PKCS#12 bundle](#pkcs-12-certificate-bundles) from
-   the updated key, certificate, and CA certificate.
-2. [Create a new Barbican
-   secret](#creating-barbican-secrets-from-pkcs-12-bundles) from the
-   bundle.
+1. [Create a new PKCS#12 bundle](#pkcs-12-certificate-bundles) from the updated key, certificate, and CA certificate.
+2. [Create a new Barbican secret](#creating-barbican-secrets-from-pkcs-12-bundles) from the bundle.
 3. List the listener(s) associated with your load balancer:
    ```bash
    openstack loadbalancer listener list \
      --loadbalancer <loadbalancer-name-or-id>
    ```
-4. For all listeners using the `TERMINATED_HTTPS` protocol, run the
-   following command:
+4. For all listeners using the `TERMINATED_HTTPS` protocol, run the following command:
    ```bash
    openstack loadbalancer listener set \
      --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/e2d8acc1-c6b9-4c01-9373-cc167b075c25  \
      <listener-name-or-id>
    ```
 
-Once all your load balancer listeners have completed the update, you
-may proceed to delete the old, now-unused secret:
+Once all your load balancer listeners have completed the update, you may proceed to delete the old, now-unused secret:
 
 ```bash
 openstack secret delete \


### PR DESCRIPTION
We reformat all How-Tos in the octavia subcategory of the openstack category, to follow the one sentence per line policy.