### PR TITLE
chore: Apply the one sentence per line policy in the support category

### DIFF
--- a/docs/howto/support/raise-issues.md
+++ b/docs/howto/support/raise-issues.md
@@ -47,7 +47,8 @@ Available options include:
 
 #### Issues
 
-Issues are used to report ongoing problems. Available option:
+Issues are used to report ongoing problems.
+Available option:
 
 - **Incident**:
     - Report ongoing incidents that disrupt normal operations.
@@ -88,10 +89,12 @@ The interface dynamically displays fields depending on the selections you make.
 1. Visit the [{{support}} portal](https://{{support_domain}}/servicedesk).
 2. Log in if prompted.  
 3. Navigate to the relevant service project.
-     - A user can have access to several service projects. You should select the project that relates to your request.
+     - A user can have access to several service projects.
+       You should select the project that relates to your request.
 4. Select the **Issue type** that best matches your request.
 5. Fill in the required fields and any additional fields that appear dynamically based on your selections.
-6. If you're part of an organization and want the ticket visible to others, select **Share with [organization name]** at the bottom of the form. Otherwise, choose **Private request**.  
+6. If you're part of an organization and want the ticket visible to others, select **Share with [organization name]** at the bottom of the form.
+   Otherwise, choose **Private request**.
 7. Click **Create** to submit your ticket.
 
 > **Tip**: Use the **search bar** at the top of the portal page to quickly find your tickets or search our knowledge base for helpful articles.
@@ -101,7 +104,8 @@ The interface dynamically displays fields depending on the selections you make.
 If you choose to raise a ticket by email, please follow these guidelines:
 
 1. **Email address**: Send your email to [{{support_email}}](mailto:{{support_email}}) from an account [matching your profile information](../account-billing/change-account-data.md).
-2. **Language**: Use English for quicker responses. While some staff speak other languages, using languages other than English may delay responses.
+2. **Language**: Use English for quicker responses.
+   While some staff speak other languages, using languages other than English may delay responses.
 3. **Subject**: Provide a clear and descriptive subject line, e.g., "Request to increase project quota" or "Unable to log in to {{gui}}."
 4. **Details**: Include as much information as possible, especially:
      - Steps you’ve taken to resolve the issue.
@@ -113,10 +117,12 @@ If you choose to raise a ticket by email, please follow these guidelines:
 
 Once your ticket is created, here’s what to expect:
 
-1. **Confirmation email**: You will receive an email confirming your ticket submission. To add more details, reply directly to this email.
+1. **Confirmation email**: You will receive an email confirming your ticket submission.
+   To add more details, reply directly to this email.
 2. **Support engineer assignment**: A Technical Support Engineer will review your case, confirm the details, and take the necessary steps to resolve or fulfill your request.  
 3. **Additional information requests**: Be prepared to provide additional details if requested by the Support Engineer.
 
-Regardless of your support plan, you will receive email notifications for updates to your ticket. You can always reply to these notifications to provide additional information or updates.
+Regardless of your support plan, you will receive email notifications for updates to your ticket.
+You can always reply to these notifications to provide additional information or updates.
 
 > For customers with a paid support package, you can only use the **{{support}} portal** for all communication.


### PR DESCRIPTION
We reformat all How-Tos in the support category,
so we follow the one sentence per line policy.