### PR TITLE
chore: Apply the one sentence per line policy in the reference section

### DIFF
--- a/docs/reference/api/cc/index.md
+++ b/docs/reference/api/cc/index.md
@@ -3,21 +3,12 @@ description: Cleura Cloud provides automatically generated documentation for its
 ---
 # Cleura Cloud REST API reference documentation
 
-You may at any time make good use of the {{rest_api}} with a
-tool like `curl`. Regarding documentation, there is a detailed,
-[automatically generated page](https://apidoc.cleura.cloud),
-which you turn to for advice on endpoints and how to use them.
+You may at any time make good use of the {{rest_api}} with a tool like `curl`.
+Regarding documentation, there is a detailed, [automatically generated page](https://apidoc.cleura.cloud), which you turn to for advice on endpoints and how to use them.
 
-> To access the API, you need to have an
-[account in {{brand}}](../../../howto/getting-started/create-account.md),
-and also create
-[a valid access token](../../../howto/getting-started/accessing-cc-rest-api.md).
+> To access the API, you need to have an [account in {{brand}}](../../../howto/getting-started/create-account.md), and also create [a valid access token](../../../howto/getting-started/accessing-cc-rest-api.md).
 
-All actions exposed via the {{gui}} are also available through the
-{{rest_api}}. One of the most common use cases is taking advantage
-of it for programmatically pulling all sorts of information for
-further processing. For instance, see how you can
-[retrieve invoice data](../../../howto/account-billing/rest-invoice-data.md)
-via the API. For any other use of the {{rest_api}}, please see
-the sections in the
-[documentation page](https://apidoc.cleura.cloud).
+All actions exposed via the {{gui}} are also available through the {{rest_api}}.
+One of the most common use cases is taking advantage of it for programmatically pulling all sorts of information for further processing.
+For instance, see how you can [retrieve invoice data](../../../howto/account-billing/rest-invoice-data.md) via the API.
+For any other use of the {{rest_api}}, please see the sections in the [documentation page](https://apidoc.cleura.cloud).

--- a/docs/reference/api/openstack/index.md
+++ b/docs/reference/api/openstack/index.md
@@ -8,8 +8,7 @@ Individual service APIs have their own detailed API reference documentation page
 
 You may also be interested in the [API Quick Start Guide](https://docs.openstack.org/api-quick-start/api-quick-start.html) for information about how to authenticate against the OpenStack API, and send API requests.
 
-> To access the OpenStack API in {{brand}}, you need to have an [account](../../../howto/getting-started/create-account.md), and also download a valid credentials file, as you would for
-[enabling the OpenStack CLI](../../../howto/getting-started/enable-openstack-cli.md).
+> To access the OpenStack API in {{brand}}, you need to have an [account](../../../howto/getting-started/create-account.md), and also download a valid credentials file, as you would for [enabling the OpenStack CLI](../../../howto/getting-started/enable-openstack-cli.md).
 > All actions exposed via the OpenStack CLI are also available by calling the API directly.
 
 ## OpenStack SDKs

--- a/docs/reference/features/index.md
+++ b/docs/reference/features/index.md
@@ -5,13 +5,10 @@ description: Our services constantly evolve, and we gradually add features to re
 
 {{page.meta.description}}
 
-This page lists the cloud features available in each {{brand}}
-region.
+This page lists the cloud features available in each {{brand}} region.
 
-* [Public Cloud](public.md): features supported in our
-  {{brand_public}} regions.
+* [Public Cloud](public.md): features supported in our {{brand_public}} regions.
 
-* [Compliant Cloud](compliant.md): features supported in our
-  {{brand_compliant}} regions.
+* [Compliant Cloud](compliant.md): features supported in our {{brand_compliant}} regions.
 
 Please note that certain support [limitations](../limitations/index.md) apply to some features.

--- a/docs/reference/flavors/index.md
+++ b/docs/reference/flavors/index.md
@@ -3,57 +3,42 @@ description: Using flavors, you define a server’s performance characteristics 
 ---
 # Flavors
 
-Any server instance running in {{brand}} has a **flavor**,
-which defines the number of virtual CPU cores, the amount of virtual
-RAM, and other performance-related factors.
+Any server instance running in {{brand}} has a **flavor**, which defines the number of virtual CPU cores, the amount of virtual RAM, and other performance-related factors.
 
 {{page.meta.description}}
 
 ## Naming convention
 
-Flavor names in {{brand}} follow a convention, which can be
-summarized as `X.YcZgb`:
+Flavor names in {{brand}} follow a convention, which can be summarized as `X.YcZgb`:
 
-* `X` stands for a lowercase letter identifying the [compute
-  tier](#compute-tiers), with `b` representing the general-purpose
-  tier. It is always followed by a full-stop (`.`).
-* `Y` stands for the number of virtual CPU cores. This number is
-  always followed by the letter `c`.
-* `Z` stands for the allocated amount of virtual RAM, in
-  [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)). This
-  number is always followed by the string `gb`.
+* `X` stands for a lowercase letter identifying the [compute tier](#compute-tiers), with `b` representing the general-purpose tier.
+   It is always followed by a full-stop (`.`).
+* `Y` stands for the number of virtual CPU cores.
+   This number is always followed by the letter `c`.
+* `Z` stands for the allocated amount of virtual RAM, in [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)).
+   This number is always followed by the string `gb`.
 
-For example, the flavor named `b.4c32gb` would be used for a
-general-purpose compute instance with 4 cores and 32 GiB RAM.
+For example, the flavor named `b.4c32gb` would be used for a general-purpose compute instance with 4 cores and 32 GiB RAM.
 
 
 ## Compute tiers
 
 {{brand}} defines the following compute tiers:
 
-* `b`: General purpose. This is the default compute tier. Instances
-  launched with matching flavors use highly available network-attached
-  storage. This makes them flexible to migrate within the
-  {{brand}} infrastructure, without interruption.
-  Some
-  [limitations](../../howto/openstack/cinder/encrypted-volumes.md#block-device-encryption-caveats)
-  apply to instances with attached [encrypted
-  volumes](../../howto/openstack/cinder/encrypted-volumes.md).
-* `s`: High-performance local storage. Instances
-  launched with matching flavors use local, directly-attached
-  storage. This generally provides higher throughput and lower
-  latency for I/O intensive applications, but instances launched with
-  these flavors must configure their own high availability and data
-  replication.
-* `c`: Physical CPUs. Instances launched with matching flavors will be
-  assigned physical CPU cores, rather then virtual ones. These flavors
-  are recommended for CPU-intensive workloads, or when there is a
-  requirement for guaranteed CPU resources.
+* `b`: General purpose.
+  This is the default compute tier.
+  Instances launched with matching flavors use highly available network-attached storage.
+  This makes them flexible to migrate within the {{brand}} infrastructure, without interruption.
+  Some [limitations](../../howto/openstack/cinder/encrypted-volumes.md#block-device-encryption-caveats) apply to instances with attached [encrypted volumes](../../howto/openstack/cinder/encrypted-volumes.md).
+* `s`: High-performance local storage.
+  Instances launched with matching flavors use local, directly-attached storage.
+  This generally provides higher throughput and lower latency for I/O intensive applications, but instances launched with these flavors must configure their own high availability and data replication.
+* `c`: Physical CPUs.
+  Instances launched with matching flavors will be assigned physical CPU cores, rather then virtual ones.
+  These flavors are recommended for CPU-intensive workloads, or when there is a requirement for guaranteed CPU resources.
 
-Some tiers are only available in select {{brand}}
-regions. For details on tier availability, see the [Feature support
-matrix](../features/index.md).
+Some tiers are only available in select {{brand}} regions.
+For details on tier availability, see the [Feature support matrix](../features/index.md).
 
-The general-purpose tier is always available to all {{brand}}
-customers. For access to other tiers, contact our
-[{{support}}](https://{{support_domain}}/servicedesk).
+The general-purpose tier is always available to all {{brand}} customers.
+For access to other tiers, contact our [{{support}}](https://{{support_domain}}/servicedesk).

--- a/docs/reference/images/index.md
+++ b/docs/reference/images/index.md
@@ -45,17 +45,11 @@ In particular, {{brand}} aims to set image properties according to the [metadata
 
 ## Community images
 
-At {{brand}}, we regularly update and rotate our images to always provide
-secure public images.
+At {{brand}}, we regularly update and rotate our images to always provide secure public images.
 
-During rotation, we change an image's visibility from `public` to `community`,
-while keeping its image name. This enables tools like
-[Heat](https://docs.openstack.org/heat/) or [Terraform](https://www.terraform.io/)
-to pass validation checks without attempting to alter environments.
+During rotation, we change an image's visibility from `public` to `community`, while keeping its image name.
+This enables tools like [Heat](https://docs.openstack.org/heat/) or [Terraform](https://www.terraform.io/) to pass validation checks without attempting to alter environments.
 
-You can retrieve an image's original build date (for images with both
-`public` and `community` visibility) by checking its `build_date` tag or
-`image_build_date` property.
+You can retrieve an image's original build date (for images with both `public` and `community` visibility) by checking its `build_date` tag or `image_build_date` property.
 
-> Usage of community images is not recommended and is always upon
-> full responsibility of the user.
+> Usage of community images is not recommended and is always upon full responsibility of the user.

--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -47,7 +47,8 @@ In {{k8s_management_service}}-managed clusters, we do not support `loadbalancer.
 ### Persistent volumes (PVs)
 
 In {{k8s_management_service}}-managed Kubernetes clusters, the supported PV [access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) are `ReadWriteOnce` (`RWO`), and `ReadWriteOncePod` (`RWOP`).
-Note that `RWO` enables multiple Pods to access the same volume, as long as they are [configured to run on the same node](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). Use `RWOP` to restrict the volume to one pod only.
+Note that `RWO` enables multiple Pods to access the same volume, as long as they are [configured to run on the same node](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+Use `RWOP` to restrict the volume to one pod only.
 
 You cannot use `ReadWriteMany` (`RWX`) or `ReadOnlyMany` (`ROX`) PVs.
 

--- a/docs/reference/limitations/object-storage.md
+++ b/docs/reference/limitations/object-storage.md
@@ -33,7 +33,8 @@ We do not support `GOVERNANCE` mode.
 
 ### SSE-KMS
 
-There is currently no support for SSE-KMS in {{brand}}. SSE-C, in contrast, [is fully supported](../../howto/object-storage/s3/sse-c.md).
+There is currently no support for SSE-KMS in {{brand}}.
+SSE-C, in contrast, [is fully supported](../../howto/object-storage/s3/sse-c.md).
 
 ### Request checksum calculation
 

--- a/docs/reference/quotas/openstack.md
+++ b/docs/reference/quotas/openstack.md
@@ -6,7 +6,8 @@ description: Resource limits (quotas) for OpenStack resources
 Most of the OpenStack resources you create in {{brand}} are subject to quotas.
 Once you hit a quota limit, the creation of new resources of that type will fail, until you either reduce your resource utilization or your quota is raised.
 
-{{brand}} applies most quotas on a per-project basis. Your {{brand}} _account_ can manage up to 3 projects.
+{{brand}} applies most quotas on a per-project basis.
+Your {{brand}} _account_ can manage up to 3 projects.
 
 The following quotas apply in any of your {{brand}} projects by default:
 

--- a/docs/reference/volumes/index.md
+++ b/docs/reference/volumes/index.md
@@ -12,7 +12,8 @@ If you create a volume without specifying a volume type, then the default volume
 | `cbs`                          | :material-check: | :material-close:                                                | 10000           |
 | `cbs-encrypted`                | :material-close: | :material-check:                                                | 10000           |
 
-[^iops]: The maximum IOPS specification is essentially a cap, which creates an upper bound for individual device performance under *ideal* conditions. Actual IOPS may vary based on system load and utilization. IOPS limits are only enforced in [{{brand_public}} regions](../features/public.md).
+[^iops]: The maximum IOPS specification is essentially a cap, which creates an upper bound for individual device performance under *ideal* conditions.
+Actual IOPS may vary based on system load and utilization. IOPS limits are only enforced in [{{brand_public}} regions](../features/public.md).
 
 It is possible --- though somewhat involved --- to [change the type of an existing volume](../../howto/openstack/cinder/retype-volumes.md) (also known as retyping).
 


### PR DESCRIPTION
We reformat all reference markdown files,
so they follow the one sentence per line policy.