### PR TITLE
chore: Apply the one sentence per line policy in the contrib section

### DIFF
--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -1,59 +1,32 @@
 # Contribution Guide
 
-See something on this site that is inaccurate, missing, or that could
-simply be improved? There are multiple ways for you to help make this
-site better, and we welcome all of them.
+See something on this site that is inaccurate, missing, or that could simply be improved?
+There are multiple ways for you to help make this site better, and we welcome all of them.
 
-You can make modifications and contributions [using
-Git](modifications.md), and we apply certain [checks](quality.md) to ensure
-consistent documentation quality.
+You can make modifications and contributions [using Git](modifications.md), and we apply certain [checks](quality.md) to ensure consistent documentation quality.
 
 ## Technical Writing Resources
 
-Whether you are an experienced technical writer, a regular (or
-not-so-regular) open source contributor, or you’re making your very
-first writing contribution, there are a ton of helpful resources on
-technical writing. Here are a few:
+Whether you are an experienced technical writer, a regular (or not-so-regular) open source contributor, or you’re making your very first writing contribution, there are a ton of helpful resources on technical writing.
+Here are a few:
 
-* [Digital Ocean](https://www.digitalocean.com/)’s [Technical Writing
-  Guidelines](https://www.digitalocean.com/community/tutorials/digitalocean-s-technical-writing-guidelines)
-* [Red Hat](https://www.redhat.com)’s [Writing Style
-  Guide](https://github.com/StyleGuides/WritingStyleGuide)
-* [Gareth Dwyer](https://dwyer.co.za/)’s [Technical
-  Writing](https://github.com/sixhobbits/technical-writing) repository
+* [Digital Ocean](https://www.digitalocean.com/)’s [Technical Writing Guidelines](https://www.digitalocean.com/community/tutorials/digitalocean-s-technical-writing-guidelines)
+* [Red Hat](https://www.redhat.com)’s [Writing Style Guide](https://github.com/StyleGuides/WritingStyleGuide)
+* [Gareth Dwyer](https://dwyer.co.za/)’s [Technical Writing](https://github.com/sixhobbits/technical-writing) repository
 * Bolaji Ayodeji’s [Awesome Technical Writing](https://github.com/BolajiAyodeji/awesome-technical-writing) collection
 
 
 ## Markdown
 
-The documentation on this site uses
-[Markdown](https://en.wikipedia.org/wiki/Markdown). Markdown is a
-documentation format that is rich enough to be useful for good
-technical documentation, and yet simpler and easier to learn than
-other formats like
-[reStructuredText](https://en.wikipedia.org/wiki/ReStructuredText) or
-[DocBook](https://en.wikipedia.org/wiki/DocBook) XML.
+The documentation on this site uses [Markdown](https://en.wikipedia.org/wiki/Markdown).
+Markdown is a documentation format that is rich enough to be useful for good technical documentation, and yet simpler and easier to learn than other formats like [reStructuredText](https://en.wikipedia.org/wiki/ReStructuredText) or [DocBook](https://en.wikipedia.org/wiki/DocBook) XML.
 
-If you’re unfamiliar with Markdown, you can read up on its basics in
-[this classic article by John
-Gruber](https://daringfireball.net/projects/markdown/) if you’re
-interested, but chances are that you’ll also find all the information
-you’ll need in [this cheat sheet by Adam
-Pritchard](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet),
-or the [Start Writing guide from
-GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+If you’re unfamiliar with Markdown, you can read up on its basics in [this classic article by John Gruber](https://daringfireball.net/projects/markdown/) if you’re interested, but chances are that you’ll also find all the information you’ll need in [this cheat sheet by Adam Pritchard](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet), or the [Start Writing guide from GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
-Or you simply look at the source of one of the pages on this site (try
-the Edit button on this one!) and figure it out as you go along — it’s
-really pretty straightforward.
+Or you simply look at the source of one of the pages on this site (try the Edit button on this one!) and figure it out as you go along — it’s really pretty straightforward.
 
 
 ## License
 
-With the sole exception of trademarks like “{{company}}” and the
-{{company}} logo, the content on this site is available under the
-[{{legal_docs.cc_by_sa.name}}]({{legal_docs.cc_by_sa.url}}) license,
-as you can see from the
-![{{legal_docs.cc_by_sa.short_name}}](https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg)
-icon at the bottom of each page. Please keep in mind that you are
-making your contribution under those terms.
+With the sole exception of trademarks like “{{company}}” and the {{company}} logo, the content on this site is available under the [{{legal_docs.cc_by_sa.name}}]({{legal_docs.cc_by_sa.url}}) license, as you can see from the ![{{legal_docs.cc_by_sa.short_name}}](https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg) icon at the bottom of each page.
+Please keep in mind that you are making your contribution under those terms.

--- a/docs/contrib/modifications.md
+++ b/docs/contrib/modifications.md
@@ -13,8 +13,7 @@ This facilitates the review of your change, and it also helps you notice long ru
 **Headings:** Keep headings concise, under 80 characters.
 
 **Screenshots:** If you are contributing a change that contains screenshots from {{gui}}, they should have a resolution of 1920×1080 pixels (1080p).
-If your screen has a larger resolution, use [Firefox Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/)
-or [Chrome/Chromium Device Mode](https://developer.chrome.com/docs/devtools/device-mode/) to configure your browser with 1080p.
+If your screen has a larger resolution, use [Firefox Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/) or [Chrome/Chromium Device Mode](https://developer.chrome.com/docs/devtools/device-mode/) to configure your browser with 1080p.
 
 Screenshots should be added to a directory named `assets`, located in the same directory as the Markdown file you are adding or editing.
 

--- a/docs/contrib/quality.md
+++ b/docs/contrib/quality.md
@@ -1,39 +1,25 @@
 # Quality checks
 
-There are a few checks that we apply to the configuration of this
-site. These checks run automatically via GitHub Actions workflows when
-you [send your PR](modifications.md):
+There are a few checks that we apply to the configuration of this site.
+These checks run automatically via GitHub Actions workflows when you [send your PR](modifications.md):
 
-* We check the commit message with
-  [gitlint](https://jorisroovers.com/gitlint/), and enforce the
-  [Conventional
-  Commits](https://www.conventionalcommits.org/en/v1.0.0/) commit
-  message style.
-* We check whether the documentation still builds correctly, with your
-  change applied.
-* We apply [pymarkdownlnt](https://github.com/jackdewinter/pymarkdown)
-  checks for Markdown consistency and to encourage some good
-  documentation practices.
-* We check to make sure that no internal or external links in the
-  documentation are dead. This is one example where the checks might
-  fail through no fault of yours — some external link may have
-  disappeared between the most recent change and your contribution, by
-  pure coincidence. When that happens, we’ll fix it together.
-* We check some YAML conventions with
-  [yamllint](https://yamllint.readthedocs.io/en/stable/). However,
-  most contributions would probably only touch Markdown files and not
-  YAML, so you’re unlikely to trip over this.
+* We check the commit message with [gitlint](https://jorisroovers.com/gitlint/), and enforce the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) commit message style.
+* We check whether the documentation still builds correctly, with your change applied.
+* We apply [pymarkdownlnt](https://github.com/jackdewinter/pymarkdown) checks for Markdown consistency and to encourage some good documentation practices.
+* We check to make sure that no internal or external links in the documentation are dead.
+  This is one example where the checks might fail through no fault of yours — some external link may have disappeared between the most recent change and your contribution, by pure coincidence.
+  When that happens, we’ll fix it together.
+* We check some YAML conventions with [yamllint](https://yamllint.readthedocs.io/en/stable/).
+  However, most contributions would probably only touch Markdown files and not YAML, so you’re unlikely to trip over this.
 
-If you’re working in your local Git repository and your work
-environment has [tox](https://tox.wiki/en/latest/) installed, you can
-also run the checks locally:
+If you’re working in your local Git repository and your work environment has [tox](https://tox.wiki/en/latest/) installed, you can also run the checks locally:
 
 ```bash
 tox
 ```
 
-You can also configure your local checkout to run quality checks on
-each commit. To do that, run:
+You can also configure your local checkout to run quality checks on each commit.
+To do that, run:
 
 ```bash
 git config core.hooksPath .githooks


### PR DESCRIPTION
We reformat all contribution guides,
so they follow the one sentence per line policy.