### PR TITLE
fix: Use console blocks consistently

### DIFF
--- a/docs/howto/openstack/magnum/kubectl.md
+++ b/docs/howto/openstack/magnum/kubectl.md
@@ -52,11 +52,9 @@ If you are currently managing only one cluster, and you already have its kubecon
 You may now use `kubectl` to run commands against your cluster.
 See, for instance, all cluster nodes...
 
-```bash
-kubectl get nodes
-```
+```console
+$ kubectl get nodes
 
-```plain
 NAME                           STATUS   ROLES    AGE    VERSION
 bangor-id6nijycp2wy-master-0   Ready    master   113m   v1.18.6
 bangor-id6nijycp2wy-node-0     Ready    <none>   111m   v1.18.6
@@ -64,11 +62,9 @@ bangor-id6nijycp2wy-node-0     Ready    <none>   111m   v1.18.6
 
 ...or all running pods in every namespace:
 
-```bash
-kubectl get pods --all-namespaces
-```
+```console
+$ kubectl get pods --all-namespaces
 
-```plain
 NAMESPACE     NAME                                         READY   STATUS    RESTARTS   AGE
 kube-system   coredns-786ffb7797-tw2hg                     1/1     Running   0          167m
 kube-system   coredns-786ffb7797-vbqwn                     1/1     Running   0          167m

--- a/docs/howto/openstack/neutron/delete-network.md
+++ b/docs/howto/openstack/neutron/delete-network.md
@@ -24,10 +24,9 @@ Unless you already have the ID or know the name of the network you wish to delet
 === "OpenStack CLI"
     To list all available networks in the region you are currently in, type the following:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -57,10 +56,9 @@ Let us see what the situation is with network `carmacks`.
 === "OpenStack CLI"
     To quickly check whether network `carmacks` has a subnet or not, type:
 
-    ```bash
-    openstack network show carmacks -c subnets
-    ```
-    ```plain
+    ```console
+    $ openstack network show carmacks -c subnets
+
     +---------+--------------------------------------+
     | Field   | Value                                |
     +---------+--------------------------------------+
@@ -77,10 +75,9 @@ Let us see what the situation is with network `carmacks`.
 
     What about a router in front of `carmacks`? You might try checking the output of this command:
 
-    ```bash
-    openstack network show carmacks
-    ```
-    ```plain
+    ```console
+    $ openstack network show carmacks
+
     +---------------------------+--------------------------------------+
     | Field                     | Value                                |
     +---------------------------+--------------------------------------+
@@ -119,10 +116,9 @@ Let us see what the situation is with network `carmacks`.
     In cases like this, try looking at things from a different vantage point.
     Try, in particular, to list all routers:
 
-    ```bash
-    openstack router list
-    ```
-    ```plain
+    ```console
+    $ openstack router list
+
     +------------------------+-----------------+--------+-------+------------------------+------+
     | ID                     | Name            | Status | State | Project                | HA   |
     +------------------------+-----------------+--------+-------+------------------------+------+
@@ -135,10 +131,9 @@ Let us see what the situation is with network `carmacks`.
 
     The name of the second router says it all, but since it is just a name, it doesn't hurt to verify the role of this router:
 
-    ```bash
-    openstack router show carmacks-router -c interfaces_info
-    ```
-    ```plain
+    ```console
+    $ openstack router show carmacks-router -c interfaces_info
+
     +-----------------+--------------------------------------------------------------------------------+
     | Field           | Value                                                                          |
     +-----------------+--------------------------------------------------------------------------------+
@@ -153,14 +148,12 @@ Let us see what the situation is with network `carmacks`.
     > There will be times when router names won't help much.
     > Then, try a more exhaustive search approach:
     >
-    > ```bash
-    > for i in $(openstack router list -f value -c Name); \
-    >     do echo Checking router "$i"; \
-    >     openstack router show "$i" -f json -c interfaces_info \
-    >     | grep "$SUBNET_ID"; \
+    > ```console
+    > $ for i in $(openstack router list -f value -c Name); do
+    >     echo Checking router "$i"
+    >     openstack router show "$i" -f json -c interfaces_info | grep "$SUBNET_ID"
     > done
-    > ```
-    > ```plain
+    > 
     > Checking router carmacks-router
     >       "subnet_id": "7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5"
     > Checking router router-kna1
@@ -228,10 +221,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
 === "OpenStack CLI"
     First, take a look at all available subnets:
 
-    ```bash
-    openstack subnet list
-    ```
-    ```plain
+    ```console
+    $ openstack subnet list
+
     +-------------------------------+-----------------+--------------------------------+---------------+
     | ID                            | Name            | Network                        | Subnet        |
     +-------------------------------+-----------------+--------------------------------+---------------+
@@ -247,10 +239,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     As you would expect, included on the list is subnet `carmacks-subnet`, which you are about to delete.
     That's easier said than done, though:
 
-    ```bash
-    openstack subnet delete $SUBNET_ID
-    ```
-    ```plain
+    ```console
+    $ openstack subnet delete $SUBNET_ID
+
     Failed to delete subnet with name or ID '7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5': ConflictException: 409:
     Client Error for url: kna1.{{brand_domain}}:9696/v2.0/subnets/7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5,
     Unable to complete operation on subnet 7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5:
@@ -274,10 +265,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
 
     Again, no command output means success, but we suggest you check yourself:
 
-    ```bash
-    openstack subnet list
-    ```
-    ```plain
+    ```console
+    $ openstack subnet list
+
     +--------------------------------+---------------+---------------------------------+---------------+
     | ID                             | Name          | Network                         | Subnet        |
     +--------------------------------+---------------+---------------------------------+---------------+
@@ -292,10 +282,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     Next is network `carmacks`, which you should be able to delete by now.
     First, take a look at all available networks:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -315,10 +304,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
 
     No command output signals success, but it never hurts to verify yourself:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -336,10 +324,9 @@ Then, you will move on to deleting the subnet and the network, and after that, y
 
     There is no output on the terminal, and yet the router is gone:
 
-    ```bash
-    openstack router list
-    ```
-    ```plain
+    ```console
+    $ openstack router list
+
     +-----------------------------+-------------+--------+-------+------------------------------+------+
     | ID                          | Name        | Status | State | Project                      | HA   |
     +-----------------------------+-------------+--------+-------+------------------------------+------+
@@ -372,10 +359,9 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
 === "OpenStack CLI"
     Let us first take a look at all available networks...
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -387,10 +373,9 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
 
     ...and at all available subnets:
 
-    ```bash
-    openstack subnet list
-    ```
-    ```plain
+    ```console
+    $ openstack subnet list
+
     +--------------------------------+---------------+---------------------------------+---------------+
     | ID                             | Name          | Network                         | Subnet        |
     +--------------------------------+---------------+---------------------------------+---------------+
@@ -410,10 +395,9 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     There is no command output.
     This is expected, but why not check yourself?
 
-    ```bash
-    openstack subnet list
-    ```
-    ```plain
+    ```console
+    $ openstack subnet list
+
     +---------------------------------+-------------+----------------------------------+---------------+
     | ID                              | Name        | Network                          | Subnet        |
     +---------------------------------+-------------+----------------------------------+---------------+
@@ -431,10 +415,9 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     The absence of any output means the command was successful.
     Take a look yourself:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -456,10 +439,9 @@ For our demonstration, we created a network named `mayo`, with no subnet and no 
 === "OpenStack CLI"
     Once more, take a look at all remaining networks:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
@@ -476,10 +458,9 @@ For our demonstration, we created a network named `mayo`, with no subnet and no 
 
     And, yes, it is still a good idea to check yourself:
 
-    ```bash
-    openstack network list --internal
-    ```
-    ```plain
+    ```console
+    $ openstack network list --internal
+
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -77,11 +77,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
     Begin by creating a new
     [IKE](https://en.wikipedia.org/wiki/Internet_Key_Exchange) policy:
 
-    ```bash
-    openstack vpn ike policy create ike-pol-fra1
-    ```
+    ```console
+    $ openstack vpn ike policy create ike-pol-fra1
 
-    ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
     +-------------------------------+--------------------------------------+
@@ -101,11 +99,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Then, create a new [IPSec](https://en.wikipedia.org/wiki/IPsec) policy:
 
-    ```bash
-    openstack vpn ipsec policy create ipsec-pol-fra1
-    ```
+    ```console
+    $ openstack vpn ipsec policy create ipsec-pol-fra1
 
-    ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
     +-------------------------------+--------------------------------------+
@@ -125,11 +121,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     You are ready to create a new VPN service:
 
-    ```bash
-    openstack vpn service create --router router-fra1 vpn-service-fra1
-    ```
+    ```console
+    $ openstack vpn service create --router router-fra1 vpn-service-fra1
 
-    ```plain
     +----------------+--------------------------------------+
     | Field          | Value                                |
     +----------------+--------------------------------------+
@@ -161,12 +155,10 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
     More specifically, on either side of the connection, there should be one end-point group for the local subnet and one end-point group for the peer (remote) subnet.
     You are now on the left side of the connection (region `fra1`), so begin with the left local end-point group...
 
-    ```bash
-    openstack vpn endpoint group create \
+    ```console
+    $ openstack vpn endpoint group create \
         --type subnet --value subnet-fra1 local-epg-fra1
-    ```
 
-    ```plain
     +-------------+------------------------------------------+
     | Field       | Value                                    |
     +-------------+------------------------------------------+
@@ -182,12 +174,10 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     ...and then move on to creating the left peer end-point group:
 
-    ```bash
-    openstack vpn endpoint group create \
+    ```console
+    $ openstack vpn endpoint group create \
         --type cidr --value $SUBNET_KNA1 peer-epg-fra1
-    ```
 
-    ```plain
     +-------------+--------------------------------------+
     | Field       | Value                                |
     +-------------+--------------------------------------+
@@ -209,11 +199,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Create a new IKE policy:
 
-    ```bash
-    openstack vpn ike policy create ike-pol-kna1
-    ```
+    ```console
+    $ openstack vpn ike policy create ike-pol-kna1
 
-    ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
     +-------------------------------+--------------------------------------+
@@ -233,11 +221,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Create a new IPSec policy:
 
-    ```bash
-    openstack vpn ipsec policy create ipsec-pol-kna1
-    ```
+    ```console
+    $ openstack vpn ipsec policy create ipsec-pol-kna1
 
-    ```plain
     +-------------------------------+--------------------------------------+
     | Field                         | Value                                |
     +-------------------------------+--------------------------------------+
@@ -257,11 +243,9 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Create a new VPN service:
 
-    ```bash
-    openstack vpn service create --router router-kna1 vpn-service-kna1
-    ```
+    ```console
+    $ openstack vpn service create --router router-kna1 vpn-service-kna1
 
-    ```plain
     +----------------+--------------------------------------+
     | Field          | Value                                |
     +----------------+--------------------------------------+
@@ -288,12 +272,10 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Create a local end-point group:
 
-    ```bash
-    openstack vpn endpoint group create \
+    ```console
+    $ openstack vpn endpoint group create \
         --type subnet --value subnet-kna1 local-epg-kna1
-    ```
 
-    ```plain
     +-------------+------------------------------------------+
     | Field       | Value                                    |
     +-------------+------------------------------------------+
@@ -309,12 +291,10 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Create a peer (remote) end-point group:
 
-    ```bash
-    openstack vpn endpoint group create \
+    ```console
+    $ openstack vpn endpoint group create \
         --type cidr --value $SUBNET_FRA1 peer-epg-kna1
-    ```
 
-    ```plain
     +-------------+--------------------------------------+
     | Field       | Value                                |
     +-------------+--------------------------------------+
@@ -349,8 +329,8 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     To create a VPN connection from left to right, i.e., from region `fra1` to region `kna1`, issue the following command:
 
-    ```bash
-    openstack vpn ipsec site connection create \
+    ```console
+    $ openstack vpn ipsec site connection create \
       --vpnservice vpn-service-fra1 \
       --ikepolicy ike-pol-fra1 \
       --ipsecpolicy ipsec-pol-fra1 \
@@ -360,9 +340,7 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
       --peer-endpoint-group peer-epg-fra1 \
       --psk $PRE_SHARED_KEY \
       vpn-conn-to-kna1
-    ```
 
-    ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
     +--------------------------+----------------------------------------------------+
@@ -395,8 +373,8 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
 
     Similarly, to create a VPN connection from right to left, i.e., from region `kna1` to region `fra1`, issue the following command:
 
-    ```bash
-    openstack vpn ipsec site connection create \
+    ```console
+    $ openstack vpn ipsec site connection create \
       --vpnservice vpn-service-kna1 \
       --ikepolicy ike-pol-kna1 \
       --ipsecpolicy ipsec-pol-kna1 \
@@ -406,9 +384,7 @@ Should you decide to follow the OpenStack CLI route instead, please make sure yo
       --peer-endpoint-group peer-epg-kna1 \
       --psk $PRE_SHARED_KEY \
       vpn-conn-to-fra1
-    ```
 
-    ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
     +--------------------------+----------------------------------------------------+
@@ -456,11 +432,9 @@ No matter if you use the {{gui}} or the OpenStack CLI, you may at any time list 
     You can list all IPSec VPN connections working from any of the two regions involved.
     See, for example, the view from `fra1`:
 
-    ```bash
-    openstack vpn ipsec site connection list
-    ```
+    ```console
+    $ openstack vpn ipsec site connection list
 
-    ```plain
     +--------------------------+------------------+---------------+--------------------------+--------+
     | ID                       | Name             | Peer Address  | Authentication Algorithm | Status |
     +--------------------------+------------------+---------------+--------------------------+--------+
@@ -471,11 +445,9 @@ No matter if you use the {{gui}} or the OpenStack CLI, you may at any time list 
 
     If you want more information regarding a specific connection, type something like this:
 
-    ```bash
-    openstack vpn ipsec site connection show vpn-conn-to-kna1
-    ```
+    ```console
+    $ openstack vpn ipsec site connection show vpn-conn-to-kna1
 
-    ```plain
     +--------------------------+----------------------------------------------------+
     | Field                    | Value                                              |
     +--------------------------+----------------------------------------------------+
@@ -563,11 +535,9 @@ You may, at any time, disable an active site-to-site VPN connection.
     Suppose you are on the left side of the connection (region `fra1`), and for whatever reason, you want to disable the site-to-site connection between left and right (regions `fra1` and `kna1`).
     First, you might want to remember the name of the VPN connection to the right:
 
-    ```bash
-    openstack vpn ipsec site connection list
-    ```
+    ```console
+    $ openstack vpn ipsec site connection list
 
-    ```plain
     +--------------------------+------------------+---------------+--------------------------+--------+
     | ID                       | Name             | Peer Address  | Authentication Algorithm | Status |
     +--------------------------+------------------+---------------+--------------------------+--------+
@@ -585,11 +555,9 @@ You may, at any time, disable an active site-to-site VPN connection.
 
     Check if it is really disabled:
 
-    ```bash
-    openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
-    ```
+    ```console
+    $ openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
 
-    ```plain
     +--------+-------+
     | Field  | Value |
     +--------+-------+
@@ -608,11 +576,9 @@ You may, at any time, disable an active site-to-site VPN connection.
 
     Now, get on the right side of the connection (region `kna1`), optionally look for the name of the VPN connection to the left (in our example, that would be `vpn-conn-to-fra1`), and check its status:
 
-    ```bash
-    openstack vpn ipsec site connection show vpn-conn-to-fra1 -c Status
-    ```
+    ```console
+    $ openstack vpn ipsec site connection show vpn-conn-to-fra1 -c Status
 
-    ```plain
     +--------+-------+
     | Field  | Value |
     +--------+-------+
@@ -654,11 +620,9 @@ You can easily enable an inactive site-to-site VPN connection.
     According to the example scenario we described in the previous section, that would be the left side (region `fra1`), and the name of the disabled connection would be `vpn-conn-to-kna1`.
     Make sure the connection status is `DOWN`:
 
-    ```bash
-    openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
-    ```
+    ```console
+    $ openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
 
-    ```plain
     +--------+-------+
     | Field  | Value |
     +--------+-------+
@@ -675,11 +639,9 @@ You can easily enable an inactive site-to-site VPN connection.
 
     Check the connection status --- it should be `ACTIVE`:
 
-    ```bash
-    openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
-    ```
+    ```console
+    $ openstack vpn ipsec site connection show vpn-conn-to-kna1 -c Status
 
-    ```plain
     +--------+--------+
     | Field  | Value  |
     +--------+--------+

--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -72,11 +72,9 @@ In the following, we show how to perform the conversion using the {{gui}} or the
 === "OpenStack CLI"
     To take a snapshot of the server, all you have to do is type something like the following:
 
-    ```bash
-    openstack server image create --name nanisivik_snap nanisivik
-    ```
+    ```console
+    $ openstack server image create --name nanisivik_snap nanisivik
 
-    ```plain
     +------------+-------------------------------------------------------------------------------------+
     | Field      | Value                                                                               |
     +------------+-------------------------------------------------------------------------------------+
@@ -143,11 +141,9 @@ In the following, we show how to perform the conversion using the {{gui}} or the
     In our example, the size of the snapshot is `50` [gibibytes](https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)).
     Now, go ahead and create a volume slightly larger than the size of the snapshot:
 
-    ```bash
-    openstack volume create --size 56 --image nanisivik_snap nanisivik_vol
-    ```
+    ```console
+    $ openstack volume create --size 56 --image nanisivik_snap nanisivik_vol
 
-    ```plain
     +---------------------+--------------------------------------+
     | Field               | Value                                |
     +---------------------+--------------------------------------+
@@ -195,11 +191,9 @@ In the following, we show how to perform the conversion using the {{gui}} or the
 === "OpenStack CLI"
     To view all details regarding the volume you just created off of the boot-from-image server snapshot, type the following:
 
-    ```bash
-    openstack volume show nanisivik_vol
-    ```
+    ```console
+    $ openstack volume show nanisivik_vol
 
-    ```plain
     +------------------------------+-------------------------------------------------------------------+
     | Field                        | Value                                                             |
     +------------------------------+-------------------------------------------------------------------+
@@ -322,11 +316,9 @@ In the following, we show how to perform the conversion using the {{gui}} or the
 === "OpenStack CLI"
     You may see all details regarding the new boot-from-volume server, by typing something like the following:
 
-    ```bash
-    openstack server show nanisivik
-    ```
+    ```console
+    $ openstack server show nanisivik
 
-    ```plain
     +-----------------------------+----------------------------------------------------------+
     | Field                       | Value                                                    |
     +-----------------------------+----------------------------------------------------------+

--- a/docs/howto/openstack/nova/new-server.md
+++ b/docs/howto/openstack/nova/new-server.md
@@ -195,11 +195,9 @@ On the other hand, if you prefer to work with the OpenStack CLI, please do not f
     You need at least one network in the region you're about to create your new server (`NETWORK_NAME`).
     To get the names of all available (internal) networks, type:
 
-    ```bash
-    openstack network list --internal -c Name
-    ```
+    ```console
+    $ openstack network list --internal -c Name
 
-    ```plain
     +----------------+
     | Name           |
     +----------------+
@@ -215,11 +213,9 @@ On the other hand, if you prefer to work with the OpenStack CLI, please do not f
 
     Regarding the security group (`SEC_GROUP_NAME`), unless you have already created one yourself, you will find only one per region:
 
-    ```bash
-    openstack security group list -c Name -c Description
-    ```
+    ```console
+    $ openstack security group list -c Name -c Description
 
-    ```plain
     +---------+------------------------+
     | Name    | Description            |
     +---------+------------------------+

--- a/docs/howto/openstack/octavia/lbaas-l7pol.md
+++ b/docs/howto/openstack/octavia/lbaas-l7pol.md
@@ -75,15 +75,13 @@ $ openstack loadbalancer listener list
 
 You may now add `mylb-listener-http`, a new HTTP-based listener for `mylb`:
 
-```bash
-openstack loadbalancer listener create \
+```console
+$ openstack loadbalancer listener create \
     --name mylb-listener-http \
     --protocol HTTP \
     --protocol-port 80 \
     mylb
-```
 
-```plain
 +-----------------------------+--------------------------------------+
 | Field                       | Value                                |
 +-----------------------------+--------------------------------------+
@@ -122,11 +120,9 @@ openstack loadbalancer listener create \
 
 To check the provisioning status of `mylb-listener-http`, type:
 
-```bash
-openstack loadbalancer listener show mylb-listener-http -c provisioning_status
-```
+```console
+$ openstack loadbalancer listener show mylb-listener-http -c provisioning_status
 
-```plain
 +---------------------+--------+
 | Field               | Value  |
 +---------------------+--------+
@@ -136,11 +132,9 @@ openstack loadbalancer listener show mylb-listener-http -c provisioning_status
 
 Have a look at both listeners of `mylb`:
 
-```bash
-openstack loadbalancer listener list
-```
+```console
+$ openstack loadbalancer listener list
 
-```plain
 +-------------+-----------------+-------------+-------------+-------------+---------------+----------------+
 | id          | default_pool_id | name        | project_id  | protocol    | protocol_port | admin_state_up |
 +-------------+-----------------+-------------+-------------+-------------+---------------+----------------+
@@ -161,15 +155,13 @@ openstack loadbalancer listener list
 
 Create `mylb-listener-http-policy`, a policy for `mylb-listener-http`:
 
-```bash
-openstack loadbalancer l7policy create \
+```console
+$ openstack loadbalancer l7policy create \
     --action REDIRECT_PREFIX \
     --redirect-prefix https://whoogle.example.com \
     --name mylb-listener-http-policy \
     mylb-listener-http
-```
 
-```plain
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -196,11 +188,9 @@ openstack loadbalancer l7policy create \
 
 Make sure the policy is active:
 
-```bash
-openstack loadbalancer l7policy list -c name -c provisioning_status
-```
+```console
+$ openstack loadbalancer l7policy list -c name -c provisioning_status
 
-```plain
 +---------------------------+---------------------+
 | name                      | provisioning_status |
 +---------------------------+---------------------+
@@ -210,15 +200,13 @@ openstack loadbalancer l7policy list -c name -c provisioning_status
 
 Then, add a single rule to `mylb-listener-http-policy`:
 
-```bash
-openstack loadbalancer l7rule create \
+```console
+$ openstack loadbalancer l7rule create \
     --compare-type EQUAL_TO \
     --type HOST_NAME \
     --value whoogle.example.com \
     mylb-listener-http-policy
-```
 
-```plain
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -240,11 +228,9 @@ openstack loadbalancer l7rule create \
 
 Check the provisioning status of the new rule:
 
-```bash
-openstack loadbalancer l7policy list -c name -c provisioning_status
-```
+```console
+$ openstack loadbalancer l7policy list -c name -c provisioning_status
 
-```plain
 +---------------------------+---------------------+
 | name                      | provisioning_status |
 +---------------------------+---------------------+
@@ -255,11 +241,9 @@ openstack loadbalancer l7policy list -c name -c provisioning_status
 From now on, all client attempts to reach `http://whoogle.example.com` will end up at `https://whoogle.example.com`.
 You may confirm this is the case with any web browser or from your terminal, e.g., using `curl` like this:
 
-```bash
-curl -IL http://whoogle.example.com
-```
+```console
+$ curl -IL http://whoogle.example.com
 
-```plain
 HTTP/1.1 302 Found
 content-length: 0
 location: https://whoogle.example.com/

--- a/docs/howto/openstack/octavia/lbaas-tcp.md
+++ b/docs/howto/openstack/octavia/lbaas-tcp.md
@@ -498,22 +498,18 @@ ncat -kv -l 61234 -c 'echo Yello from $(hostname)!'
 
 Since the load balancer has a floating IP (`198.51.100.129`, in our example), and we know the port it listens to, we can try connecting to it via `wget` and see what happens:
 
-```bash
-wget -q 198.51.100.129:61234 -O -
-```
+```console
+$ wget -q 198.51.100.129:61234 -O -
 
-```plain
 Yello from srv-lbaas-1!
 ```
 
 It looks like we talked to the first test server.
 If we run the exact same `wget` command for a second time, since the load balancer distributes client connection requests in a round-robin fashion, we expect to talk to the second server:
 
-```bash
-wget -q 198.51.100.129:61234 -O -
-```
+```console
+$ wget -q 198.51.100.129:61234 -O -
 
-```plain
 Yello from srv-lbaas-2!
 ```
 
@@ -522,11 +518,9 @@ But there is one more expectation of any load balancer: the ability to skip back
 
 To test our load balancer in this new scenario, let us first use `wget` to connect to port 61234 and jot down the backend server that will respond:
 
-```bash
-wget -q 198.51.100.129:61234 -O -
-```
+```console
+$ wget -q 198.51.100.129:61234 -O -
 
-```plain
 Yello from srv-lbaas-2!
 ```
 
@@ -535,11 +529,9 @@ But if we SSH into `srv-lbaas-1` and terminate `ncat`, then after connecting wit
 This, at least, is our expectation.
 So without further ado, we SSH into `srv-lbaas-1`, we terminate `ncat`, we log out, and from our local terminal, we type:
 
-```bash
-wget -q 198.51.100.129:61234 -O -
-```
+```console
+$ wget -q 198.51.100.129:61234 -O -
 
-```plain
 Yello from srv-lbaas-2!
 ```
 
@@ -578,14 +570,12 @@ Of course, whenever an inaccessible service gets accessible again, the load bala
 === "OpenStack CLI"
     To create a health monitor for pool `mylb-pool` of load balancer `mylb`, type something like the following:
 
-    ```bash
-    openstack loadbalancer healthmonitor create \
+    ```console
+    $ openstack loadbalancer healthmonitor create \
         --name=mylb-pool-healthmon --type=TCP \
         --delay=10 --timeout=5 --max-retries=1 \
         mylb-pool
-    ```
 
-    ```plain
     +---------------------+--------------------------------------+
     | Field               | Value                                |
     +---------------------+--------------------------------------+
@@ -615,12 +605,10 @@ Of course, whenever an inaccessible service gets accessible again, the load bala
     The name of the new health monitor is `mylb-pool-healthmon`, and the TCP protocol will be used to check whether members of pool `mylb-pool` are online or offline.
     To check the provisioning status of the health monitor, type:
 
-    ```bash
-    openstack loadbalancer healthmonitor show \
+    ```console
+    $ openstack loadbalancer healthmonitor show \
         mylb-pool-healthmon -c provisioning_status
-    ```
 
-    ```plain
     +---------------------+--------+
     | Field               | Value  |
     +---------------------+--------+
@@ -630,11 +618,9 @@ Of course, whenever an inaccessible service gets accessible again, the load bala
 
     Once the health monitor is provisioned, you may at any time check the pool members status like so:
 
-    ```bash
-    openstack loadbalancer member list mylb-pool
-    ```
+    ```console
+    $ openstack loadbalancer member list mylb-pool
 
-    ```plain
     +-----------+-----------+------------+---------------------+-----------+---------------+------------------+--------+
     | id        | name      | project_id | provisioning_status | address   | protocol_port | operating_status | weight |
     +-----------+-----------+------------+---------------------+-----------+---------------+------------------+--------+
@@ -669,11 +655,9 @@ During our testing, we killed `ncat` running on `srv-lbaas-1`, and then took a l
 === "OpenStack CLI"
     To check the operating status of any of the pool members of your load balancer, type something like this:
 
-    ```bash
-    openstack loadbalancer member list mylb-pool
-    ```
+    ```console
+    # openstack loadbalancer member list mylb-pool
 
-    ```plain
     +-----------+-----------+------------+---------------------+-----------+---------------+------------------+--------+
     | id        | name      | project_id | provisioning_status | address   | protocol_port | operating_status | weight |
     +-----------+-----------+------------+---------------------+-----------+---------------+------------------+--------+
@@ -695,12 +679,10 @@ During our testing, we killed `ncat` running on `srv-lbaas-1`, and then took a l
     In the example above, see the `operating_status` column, specifically the status of server `srv-lbaas-1`.
     Regarding the operating status of all pool members, you can always limit the scope of your query like so:
 
-    ```bash
-    openstack loadbalancer member list mylb-pool \
+    ```console
+    $ openstack loadbalancer member list mylb-pool \
         -c name -c operating_status
-    ```
 
-    ```plain
     +-------------+------------------+
     | name        | operating_status |
     +-------------+------------------+


### PR DESCRIPTION
There are several instances where we use the bash/plain code block combination to represent a command with its corresponding terminal output. Instead, we use the console code block.

While at it, we fix a bug where backslash characters erroneously follow the semicolon of a for-loop, and hence are visible in the rendered code block.