### PR TITLE
fix: Accurately reflect endpoint schema, use correct bucket names

### DIFF
--- a/docs/howto/object-storage/s3/credentials.md
+++ b/docs/howto/object-storage/s3/credentials.md
@@ -121,7 +121,7 @@ How exactly you do that depends on your preferred client:
     env_auth = false
     access_key_id = <access key id>
     secret_access_key = <secret key>
-    endpoint = <region>.{{brand_domain}}
+    endpoint = s3-<region>.{{brand_domain}}
     acl = private
     ```
 

--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -145,7 +145,7 @@ To download an object from your public Swift container, you can use the followin
 
 === "OpenStack CLI"
     ```console
-    $ openstack object save --file - private-container testobj.txt
+    $ openstack object save --file - public-container testobj.txt
     hello world
     ```
     The `--file -` option prints the file contents to stdout.
@@ -154,7 +154,7 @@ To download an object from your public Swift container, you can use the followin
     If you omit the `--file` argument altogether, `openstack object save` will create a local file named like the object you are downloading (in this case, `testobj.txt`).
 === "Swift CLI"
     ```console
-    $ swift download -o - private-container testobj.txt
+    $ swift download -o - public-container testobj.txt
     hello world
     ```
     The `-o -` option prints the file contents to stdout.


### PR DESCRIPTION
We accurately reflect a specific endpoint schema in the S3-compatible credentials guide. We also make sure to use the correct bucket names ::in the Working with a public Swift container guide.