### PR TITLE
fix: Mention setting the digest algorithm for Swift TempURLs

### DIFF
--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -79,10 +79,10 @@ Then, use `swift tempurl` and specify
 * the HTTP method for which the TempURL should apply (usually `GET`),
 * the TempURL lifetime, in seconds,
 * the full path to the object including
-  * the `/v1` prefix,
-  * the account identifier starting with `AUTH_`,
-  * the container name,
-  * the object name,
+    * the `/v1` prefix,
+    * the account identifier starting with `AUTH_`,
+    * the container name,
+    * the object name,
 * the TempURL key.
 
 When specified in this way, the command returns a path similar to the following:

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -75,6 +75,7 @@ The example below uses 1 hour (3,600 seconds).
 
 Then, use `swift tempurl` and specify
 
+* the digest algorithm (`sha1`)
 * the HTTP method for which the TempURL should apply (usually `GET`),
 * the TempURL lifetime, in seconds,
 * the full path to the object including
@@ -87,7 +88,7 @@ Then, use `swift tempurl` and specify
 When specified in this way, the command returns a path similar to the following:
 
 ```console
-$ swift tempurl GET 3600 \
+$ swift tempurl --digest sha1 GET 3600 \
     /v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt     \
     tooNgeiNgieJe6bohg7teik8eiDeeMai
 /v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -7,6 +7,9 @@ fi
 
 DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
 
+# Remove whenever kubernetes.io becomes reliable again
+DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*kubernetes.io.*"
+
 if test `basename $0` = "linkcheck-local.sh"; then
     DOCS_SITE_URL="http://localhost:8000"
 elif test `basename $0` = "linkcheck-production.sh"; then


### PR DESCRIPTION
The object storage infrastructure in Cleura Cloud currently exposes the Swift API without support for the SHA256 digest algorithm that is the default used by recent versions of the CLI.

Thus, in order for Swift TempURLs to work, we must specify the SHA1 digest alorithm, by using the `--digest sha1` option with the `swift tempurl` command.

This change should be reverted once all object storage servers in Cleura Cloud support SHA256 for TempURLs.
