### PR TITLE
build: Add GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+---
+gh-pages:
+  stage: deploy
+  pages:
+    path_prefix: "$CI_COMMIT_BRANCH"
+    publish: "."
+    expire_in: 4 weeks
+  script: "true"
+  only:
+    - gh-pages
+  artifacts:
+    name: public
+    paths:
+      - .
+    exclude:
+      - .git/**
+      - .gitlab-ci.yml


### PR DESCRIPTION
For the eventuality of this branch being built in GitLab (as opposed
to GitHub, where the gh-pages branch is treated specially by default),
add a minimal GitLab CI pipeline.
