### PR TITLE
fix: Replace hardcoded references to regions

### DIFF
--- a/docs/howto/object-storage/s3/presign.md
+++ b/docs/howto/object-storage/s3/presign.md
@@ -92,11 +92,11 @@ To ensure that an object named `bar.pdf` in a bucket named `foo` is always downl
 
      You can set the attribute on object creation:
      ```bash
-     mc cp --attr Content-Disposition='attachment;filename="bar.pdf"' bar.pdf kna1/foo/
+     mc cp --attr Content-Disposition='attachment;filename="bar.pdf"' bar.pdf {{api_region|lower}}/foo/
      ```
      However, `mc` cuts off the `Content-Disposition` header at the semicolon, rendering it useless:
      ```console
-     $ mc stat kna1/foo/bar.pdf
+     $ mc stat {{api_region|lower}}/foo/bar.pdf
      Name      : bar.pdf
      Date      : 2023-01-12 12:53:52 CET
      Size      : 57 KiB

--- a/docs/howto/openstack/barbican/generic-secret.md
+++ b/docs/howto/openstack/barbican/generic-secret.md
@@ -48,8 +48,8 @@ $ openstack secret list
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 | Secret href                                                                    | Name     | Created                   | Status | Content types                           | Algorithm | Bit length | Secret type | Mode | Expiration |
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
-| https://fra1.{{api_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba | mysecret | 2021-04-29T10:33:18+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | passphrase  | cbc  | None       |
-| https://fra1.{{api_domain}}:9311/v1/secrets/ad628532-53b8-4d2f-91e5-0097b51da4e | None     | 2021-04-27T13:52:10+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | symmetric   | None | None       |
+| https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/33ef0985-f89e-4bf0-b318-887ecac0cba | mysecret | 2021-04-29T10:33:18+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | passphrase  | cbc  | None       |
+| https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/ad628532-53b8-4d2f-91e5-0097b51da4e | None     | 2021-04-27T13:52:10+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | symmetric   | None | None       |
 +--------------------------------------------------------------------------------+----------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
 ```
 

--- a/docs/howto/openstack/cinder/retype-volumes.md
+++ b/docs/howto/openstack/cinder/retype-volumes.md
@@ -92,7 +92,7 @@ If you attempt to re-attach the volume while it is still retyping, you will rece
 
 ```console
 $ openstack server add volume testsrv testvol
-BadRequestException: 400: Client Error for url: https://sto2.{{api_domain}}:8774/v2.1/servers/b6a26b0e-f911-4ea2-8e45-51f16442da03/os-volume_attachments, Invalid input received: Invalid volume: Volume e233e7f3-f33b-4d7a-8f5b-785b34f670bf status must be available or downloading to reserve, but the current status is retyping. (HTTP 400) (Request-ID: req-36c4f2e5-ef2f-4ff4-b912-0baed2594f4d)
+BadRequestException: 400: Client Error for url: https://{{api_region|lower}}.{{api_domain}}:8774/v2.1/servers/b6a26b0e-f911-4ea2-8e45-51f16442da03/os-volume_attachments, Invalid input received: Invalid volume: Volume e233e7f3-f33b-4d7a-8f5b-785b34f670bf status must be available or downloading to reserve, but the current status is retyping. (HTTP 400) (Request-ID: req-36c4f2e5-ef2f-4ff4-b912-0baed2594f4d)
 ```
 
 You must now wait until the volume status changes back from `retyping` to `available`.

--- a/docs/howto/openstack/keystone/app-creds.md
+++ b/docs/howto/openstack/keystone/app-creds.md
@@ -234,7 +234,7 @@ $ openstack application credential show practical_swanson
 
 You need to instantiate four `OS_` variables:
 
-* `OS_AUTH_URL`, which, in our example, is set to `https://fra1.citycloud.com:5000`,
+* `OS_AUTH_URL`, which, in our example, is set to `https://{{api_region|lower}}.{{api_domain}}:5000`,
 * `OS_AUTH_TYPE`, which should be set to `v3applicationcredential`,
 * `OS_APPLICATION_CREDENTIAL_ID`, which should be set to the value of `id` (as displayed in the table above),
 * `OS_APPLICATION_CREDENTIAL_SECRET`, which should be set to `$PRETTY_GOOD_SECRET`.
@@ -245,7 +245,7 @@ You need to instantiate four `OS_` variables:
 Create a new file named `acRC`, with the following content:
 
 ```bash
-export OS_AUTH_URL=https://fra1.citycloud.com:5000
+export OS_AUTH_URL=https://{{api_region|lower}}.{{api_domain}}:5000
 export OS_AUTH_TYPE=v3applicationcredential
 export OS_APPLICATION_CREDENTIAL_ID=3e04d504d754445e8b8d503e0e7af3c5
 export OS_APPLICATION_CREDENTIAL_SECRET=<value_of_PRETTY_GOOD_SECRET>

--- a/docs/howto/openstack/neutron/delete-network.md
+++ b/docs/howto/openstack/neutron/delete-network.md
@@ -33,7 +33,7 @@ Unless you already have the ID or know the name of the network you wish to delet
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
     | 9b127d2c-01d7-4803-994f-f88292870c1d | teslin       | bd1d0ff2-7270-4a9a-a7ad-fff47e997e7b |
     | cb0a298a-bbb6-4ad6-832a-1456dafe45db | carmacks     | 7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5 |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -122,7 +122,7 @@ Let us see what the situation is with network `carmacks`.
     +------------------------+-----------------+--------+-------+------------------------+------+
     | ID                     | Name            | Status | State | Project                | HA   |
     +------------------------+-----------------+--------+-------+------------------------+------+
-    | 5ac45739-a379-4936-    | router-kna1     | ACTIVE | UP    | 94109c764a754e24ac0f6b | True |
+    | 5ac45739-a379-4936-    | router-{{api_region|lower}}     | ACTIVE | UP    | 94109c764a754e24ac0f6b | True |
     | 8b1b-67d10e017f4d      |                 |        |       | 01aef82359             |      |
     | 79ff91ae-91b5-4991-    | carmacks-router | ACTIVE | UP    | 94109c764a754e24ac0f6b | True |
     | af61-91e923fac87b      |                 |        |       | 01aef82359             |      |
@@ -156,7 +156,7 @@ Let us see what the situation is with network `carmacks`.
     > 
     > Checking router carmacks-router
     >       "subnet_id": "7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5"
-    > Checking router router-kna1
+    > Checking router router-{{api_region|lower}}
     > ```
 
 ## Tearing down networks
@@ -227,7 +227,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     +-------------------------------+-----------------+--------------------------------+---------------+
     | ID                            | Name            | Network                        | Subnet        |
     +-------------------------------+-----------------+--------------------------------+---------------+
-    | 421d8fd2-dd7f-4f7c-9a51-      | subnet-kna1     | e0c4ce17-2722-4777-8140-       | 10.15.20.0/24 |
+    | 421d8fd2-dd7f-4f7c-9a51-      | subnet-{{api_region|lower}}     | e0c4ce17-2722-4777-8140-       | 10.15.20.0/24 |
     | 42ef4a866dd9                  |                 | d6c87479e190                   |               |
     | 7fa9e5a2-7d5a-466e-b120-      | carmacks-subnet | cb0a298a-bbb6-4ad6-832a-       | 10.1.0.0/24   |
     | 7d2bffb99ce5                  |                 | 1456dafe45db                   |               |
@@ -243,7 +243,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     $ openstack subnet delete $SUBNET_ID
 
     Failed to delete subnet with name or ID '7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5': ConflictException: 409:
-    Client Error for url: kna1.{{api_domain}}:9696/v2.0/subnets/7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5,
+    Client Error for url: {{api_region|lower}}.{{api_domain}}:9696/v2.0/subnets/7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5,
     Unable to complete operation on subnet 7fa9e5a2-7d5a-466e-b120-7d2bffb99ce5:
     One or more ports have an IP allocation from this subnet.
     1 of 1 subnets failed to delete.
@@ -271,7 +271,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     +--------------------------------+---------------+---------------------------------+---------------+
     | ID                             | Name          | Network                         | Subnet        |
     +--------------------------------+---------------+---------------------------------+---------------+
-    | 421d8fd2-dd7f-4f7c-9a51-       | subnet-kna1   | e0c4ce17-2722-4777-8140-        | 10.15.20.0/24 |
+    | 421d8fd2-dd7f-4f7c-9a51-       | subnet-{{api_region|lower}}   | e0c4ce17-2722-4777-8140-        | 10.15.20.0/24 |
     | 42ef4a866dd9                   |               | d6c87479e190                    |               |
     | bd1d0ff2-7270-4a9a-a7ad-       | teslin-subnet | 9b127d2c-01d7-4803-994f-        | 10.254.0.0/24 |
     | fff47e997e7b                   |               | f88292870c1d                    |               |
@@ -291,7 +291,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
     | 9b127d2c-01d7-4803-994f-f88292870c1d | teslin       | bd1d0ff2-7270-4a9a-a7ad-fff47e997e7b |
     | cb0a298a-bbb6-4ad6-832a-1456dafe45db | carmacks     |                                      |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -312,7 +312,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     +--------------------------------------+--------------+--------------------------------------+
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
     | 9b127d2c-01d7-4803-994f-f88292870c1d | teslin       | bd1d0ff2-7270-4a9a-a7ad-fff47e997e7b |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -330,7 +330,7 @@ Then, you will move on to deleting the subnet and the network, and after that, y
     +-----------------------------+-------------+--------+-------+------------------------------+------+
     | ID                          | Name        | Status | State | Project                      | HA   |
     +-----------------------------+-------------+--------+-------+------------------------------+------+
-    | 5ac45739-a379-4936-8b1b-    | router-kna1 | ACTIVE | UP    | 94109c764a754e24ac0f6b01aef8 | True |
+    | 5ac45739-a379-4936-8b1b-    | router-{{api_region|lower}} | ACTIVE | UP    | 94109c764a754e24ac0f6b01aef8 | True |
     | 67d10e017f4d                |             |        |       | 2359                         |      |
     +-----------------------------+-------------+--------+-------+------------------------------+------+
     ```
@@ -367,7 +367,7 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     +--------------------------------------+--------------+--------------------------------------+
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
     | 9b127d2c-01d7-4803-994f-f88292870c1d | teslin       | bd1d0ff2-7270-4a9a-a7ad-fff47e997e7b |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -379,7 +379,7 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     +--------------------------------+---------------+---------------------------------+---------------+
     | ID                             | Name          | Network                         | Subnet        |
     +--------------------------------+---------------+---------------------------------+---------------+
-    | 421d8fd2-dd7f-4f7c-9a51-       | subnet-kna1   | e0c4ce17-2722-4777-8140-        | 10.15.20.0/24 |
+    | 421d8fd2-dd7f-4f7c-9a51-       | subnet-{{api_region|lower}}   | e0c4ce17-2722-4777-8140-        | 10.15.20.0/24 |
     | 42ef4a866dd9                   |               | d6c87479e190                    |               |
     | bd1d0ff2-7270-4a9a-a7ad-       | teslin-subnet | 9b127d2c-01d7-4803-994f-        | 10.254.0.0/24 |
     | fff47e997e7b                   |               | f88292870c1d                    |               |
@@ -401,7 +401,7 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     +---------------------------------+-------------+----------------------------------+---------------+
     | ID                              | Name        | Network                          | Subnet        |
     +---------------------------------+-------------+----------------------------------+---------------+
-    | 421d8fd2-dd7f-4f7c-9a51-        | subnet-kna1 | e0c4ce17-2722-4777-8140-         | 10.15.20.0/24 |
+    | 421d8fd2-dd7f-4f7c-9a51-        | subnet-{{api_region|lower}} | e0c4ce17-2722-4777-8140-         | 10.15.20.0/24 |
     | 42ef4a866dd9                    |             | d6c87479e190                     |               |
     +---------------------------------+-------------+----------------------------------+---------------+
     ```
@@ -422,7 +422,7 @@ For our demonstration, we created network `teslin`, with subnet `teslin-subnet` 
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -446,7 +446,7 @@ For our demonstration, we created a network named `mayo`, with no subnet and no 
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
     | 1f94d315-7ca1-4d44-acc1-09c6c650df74 | mayo         |                                      |
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 
@@ -464,7 +464,7 @@ For our demonstration, we created a network named `mayo`, with no subnet and no 
     +--------------------------------------+--------------+--------------------------------------+
     | ID                                   | Name         | Subnets                              |
     +--------------------------------------+--------------+--------------------------------------+
-    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-kna1 | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
+    | e0c4ce17-2722-4777-8140-d6c87479e190 | network-{{api_region|lower}} | 421d8fd2-dd7f-4f7c-9a51-42ef4a866dd9 |
     +--------------------------------------+--------------+--------------------------------------+
     ```
 

--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -294,7 +294,7 @@ In the following, we show how to perform the conversion using the {{gui}} or the
     openstack server create \
         --flavor b.2c4gb \
         --volume nanisivik_vol \
-        --network network-kna1 \
+        --network network-{{api_region|lower}} \
         --security-group default \
         --key-name karlskrona \
         --wait \
@@ -331,7 +331,7 @@ In the following, we show how to perform the conversion using the {{gui}} or the
     | OS-SRV-USG:terminated_at    | None                                                     |
     | accessIPv4                  |                                                          |
     | accessIPv6                  |                                                          |
-    | addresses                   | network-kna1=10.15.20.165                                |
+    | addresses                   | network-{{api_region|lower}}=10.15.20.165                                |
     | config_drive                |                                                          |
     | created                     | 2023-05-10T15:06:20Z                                     |
     | flavor                      | b.2c4gb (2d49822b-a1d8-4f9c-a12c-cba8150611d1)           |

--- a/docs/howto/openstack/octavia/lbaas-tcp.md
+++ b/docs/howto/openstack/octavia/lbaas-tcp.md
@@ -56,7 +56,7 @@ We will also need a listener and a pool, but first things first.
 
     In the same pane, scroll down a bit if you have to and activate the _Subnet_ radio button.
     Then, from the _Subnet_ dropdown menu below, select an appropriate subnet for the new load balancer to move in front of.
-    In our example, the two test servers we have are members of the `network-fra1` internal network, and `subnet-fra1` is the name of the corresponding subnet.
+    In our example, the two test servers we have are members of the `network-{{api_region|lower}}` internal network, and `subnet-{{api_region|lower}}` is the name of the corresponding subnet.
     Click the green _Create_ button below to instantiate the new load balancer.
 
     ![Select a subnet for the new LB](assets/shot-03.png)
@@ -71,7 +71,7 @@ We will also need a listener and a pool, but first things first.
 
     ```bash
     openstack loadbalancer create \
-        --name mylb --vip-subnet-id subnet-fra1
+        --name mylb --vip-subnet-id subnet-{{api_region|lower}}
     ```
 
     ```text
@@ -102,7 +102,7 @@ We will also need a listener and a pool, but first things first.
     +---------------------+--------------------------------------+
     ```
 
-    In the example above, the name of the load balancer is `mylb`, and the subnet it will be in front of is named `subnet-fra1` (this is the subnet our two test servers are members of).
+    In the example above, the name of the load balancer is `mylb`, and the subnet it will be in front of is named `subnet-{{api_region|lower}}` (this is the subnet our two test servers are members of).
     You will notice in the command output that, at first, the `provisioning_status` is `PENDING_CREATE`.
     To make sure the load balancer has been successfully created, try this command a couple of times:
 
@@ -322,12 +322,12 @@ The pool you created has no members, so it is time to populate it.
 
     ![Pool is populated](assets/shot-18.png)
 === "OpenStack CLI"
-    Both our test servers are in the `subnet-fra1` subnet, one of them has IP `10.15.25.105`, and the other one has IP `10.15.25.236`.
+    Both our test servers are in the `subnet-{{api_region|lower}}` subnet, one of them has IP `10.15.25.105`, and the other one has IP `10.15.25.236`.
     To add those two servers in pool `mylb-pool`, type:
 
     ```bash
     openstack loadbalancer member create \
-        --subnet-id subnet-fra1 --address 10.15.25.105 \
+        --subnet-id subnet-{{api_region|lower}} --address 10.15.25.105 \
         --protocol-port 61234 mylb-pool
     ```
 
@@ -356,7 +356,7 @@ The pool you created has no members, so it is time to populate it.
 
     ```bash
     openstack loadbalancer member create \
-        --subnet-id subnet-fra1 --address 10.15.25.236 \
+        --subnet-id subnet-{{api_region|lower}} --address 10.15.25.236 \
         --protocol-port 61234 mylb-pool
     ```
 

--- a/docs/howto/openstack/octavia/tls-lb.md
+++ b/docs/howto/openstack/octavia/tls-lb.md
@@ -33,7 +33,7 @@ $ openstack secret store \
 +---------------+---------------------------------------------------------------------------------+
 | Field         | Value                                                                           |
 +---------------+---------------------------------------------------------------------------------+
-| Secret href   | https://kna1.citycloud.com:9311/v1/secrets/69bd82f5-60c9-4764-99ec-7a3dff05d2aa |
+| Secret href   | https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/69bd82f5-60c9-4764-99ec-7a3dff05d2aa |
 | Name          | tls_secret1                                                                     |
 | Created       | None                                                                            |
 | Status        | None                                                                            |
@@ -62,7 +62,7 @@ $ openstack loadbalancer listener create \
   --protocol-port 443 \
   --protocol TERMINATED_HTTPS \
   --name listener1 \
-  --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae  \
+  --default-tls-container-ref=https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae  \
   <loadbalancer-name-or-id>
 +-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Field                       | Value                                                                                                                                                                                                                                                                              |
@@ -71,7 +71,7 @@ $ openstack loadbalancer listener create \
 | connection_limit            | -1                                                                                                                                                                                                                                                                                 |
 | created_at                  | 2021-01-20T11:51:46                                                                                                                                                                                                                                                                |
 | default_pool_id             | None                                                                                                                                                                                                                                                                               |
-| default_tls_container_ref   | https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae                                                                                                                                                                                                    |
+| default_tls_container_ref   | https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae                                                                                                                                                                                                    |
 | description                 |                                                                                                                                                                                                                                                                                    |
 | id                          | 4ec6b23d-d08a-4de0-9e12-54ac690ee1ec                                                                                                                                                                                                                                               |
 | insert_headers              | None                                                                                                                                                                                                                                                                               |
@@ -113,7 +113,7 @@ You can do this online, with no user-noticeable interruption to your service.
 4. For all listeners using the `TERMINATED_HTTPS` protocol, run the following command:
    ```bash
    openstack loadbalancer listener set \
-     --default-tls-container-ref=https://kna1.citycloud.com:9311/v1/secrets/e2d8acc1-c6b9-4c01-9373-cc167b075c25  \
+     --default-tls-container-ref=https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/e2d8acc1-c6b9-4c01-9373-cc167b075c25  \
      <listener-name-or-id>
    ```
 
@@ -121,5 +121,5 @@ Once all your load balancer listeners have completed the update, you may proceed
 
 ```bash
 openstack secret delete \
-  https://kna1.citycloud.com:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae
+  https://{{api_region|lower}}.{{api_domain}}:9311/v1/secrets/dacfbec1-fbed-403f-a4dc-303e28942dae
 ```


### PR DESCRIPTION
* Replace a few remaining references to `fra1`, `kna1`, and `sto2` with an `api_region` variable reference. (The Neutron VPNaaS how-to is omitted; there the specific references to two distinct regions are deliberate.)
* Replace a few remaining references to `citycloud.com` with an `api_domain` variable reference.