### PR TITLE
feat: Include endpoint list in API reference

### DIFF
--- a/docs/reference/api/openstack/index.md
+++ b/docs/reference/api/openstack/index.md
@@ -11,6 +11,24 @@ You may also be interested in the [API Quick Start Guide](https://docs.openstack
 > To access the OpenStack API in {{brand}}, you need to have an [account](../../../howto/getting-started/create-account.md), and also download a valid credentials file, as you would for [enabling the OpenStack CLI](../../../howto/getting-started/enable-openstack-cli.md).
 > All actions exposed via the OpenStack CLI are also available by calling the API directly.
 
+## OpenStack API endpoints
+
+The {{brand}} {{api_region}} region exposes the following OpenStack API endpoints:
+
+| Service Name | Service Type    | URL                                                             |
+| ------------ | ------------    | ---                                                             |
+| barbican     | key-manager     | <https://{{api_region|lower}}.{{api_domain}}:9311/>             |
+| cinderv3     | volumev3        | <https://{{api_region|lower}}.{{api_domain}}:8776/v3/>          |
+| octavia      | load-balancer   | <https://{{api_region|lower}}.{{api_domain}}:9876/>             |
+| keystone     | identity        | <https://{{api_region|lower}}.{{api_domain}}:5000/>             |
+| radosgw      | object-store    | <https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/> |
+| placement    | placement       | <https://{{api_region|lower}}.{{api_domain}}:8780/>             |
+| heat         | orchestration   | <https://{{api_region|lower}}.{{api_domain}}:8004/v1/>          |
+| neutron      | network         | <https://{{api_region|lower}}.{{api_domain}}:9696/>             |
+| nova         | compute         | <https://{{api_region|lower}}.{{api_domain}}:8774/v2.1/>        |
+| glance       | image           | <https://{{api_region|lower}}.{{api_domain}}:9292/>             |
+| magnum       | container-infra | <https://{{api_region|lower}}.{{api_domain}}:9511/>             |
+
 ## OpenStack SDKs
 
 Although the OpenStack API is perfectly usable via direct HTTP/HTTPS requests to the API endpoints, *most* developers prefer to use one of the Software Development Kits (SDKs) that wrap the OpenStack API.

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -7,7 +7,10 @@ fi
 
 DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
 
-# Remove whenever kubernetes.io becomes reliable again
+# Ignore placeholder links
+DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*fixme.*"
+
+# Remove this whenever kubernetes.io becomes reliable again
 DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*kubernetes.io.*"
 
 if test `basename $0` = "linkcheck-local.sh"; then


### PR DESCRIPTION
This has been requested several times, but up to this point we had only included it in the v2 docs. Add it to main, so that it subsequently becomes available for all regions.
