### PR TITLE
build: Disable the update-gh-pages GitLab CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,14 +34,7 @@ update-gh-pages:
   script:
     - git fetch origin gh-pages
     - tox -e mike -- --push
-  only:
-    - main
-    - kna1
-    - sto2
-    - fra1
-    - sto1hs
-    - sto2hs
-    - sto-com
+  only: []  # Disabled
 
 .pages:
   stage: deploy


### PR DESCRIPTION
This job is intended for updating a branch named `gh-pages` while running in GitLab. As long as we're using GitHub Actions workflows in production, there is no need to do that from GitLab CI pipelines.
