### PR TITLE
fix: Drop version paths from OpenStack endpoint URLs

### DIFF
--- a/docs/reference/api/openstack/index.md
+++ b/docs/reference/api/openstack/index.md
@@ -18,14 +18,14 @@ The {{brand}} {{api_region}} region exposes the following OpenStack API endpoint
 | Service Name | Service Type    | URL                                                             |
 | ------------ | ------------    | ---                                                             |
 | barbican     | key-manager     | <https://{{api_region|lower}}.{{api_domain}}:9311/>             |
-| cinderv3     | volumev3        | <https://{{api_region|lower}}.{{api_domain}}:8776/v3/>          |
+| cinderv3     | volumev3        | <https://{{api_region|lower}}.{{api_domain}}:8776/>             |
 | octavia      | load-balancer   | <https://{{api_region|lower}}.{{api_domain}}:9876/>             |
 | keystone     | identity        | <https://{{api_region|lower}}.{{api_domain}}:5000/>             |
 | radosgw      | object-store    | <https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/> |
 | placement    | placement       | <https://{{api_region|lower}}.{{api_domain}}:8780/>             |
-| heat         | orchestration   | <https://{{api_region|lower}}.{{api_domain}}:8004/v1/>          |
+| heat         | orchestration   | <https://{{api_region|lower}}.{{api_domain}}:8004/>             |
 | neutron      | network         | <https://{{api_region|lower}}.{{api_domain}}:9696/>             |
-| nova         | compute         | <https://{{api_region|lower}}.{{api_domain}}:8774/v2.1/>        |
+| nova         | compute         | <https://{{api_region|lower}}.{{api_domain}}:8774/>             |
 | glance       | image           | <https://{{api_region|lower}}.{{api_domain}}:9292/>             |
 | magnum       | container-infra | <https://{{api_region|lower}}.{{api_domain}}:9511/>             |
 

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -10,6 +10,9 @@ DOCS_LINKCHECK_IGNORE='.*github\.com.*/edit/.*'
 # Ignore placeholder links
 DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*fixme.*"
 
+# Ignore Swift API endpoints
+DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*/swift/.*"
+
 # Remove this whenever kubernetes.io becomes reliable again
 DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*kubernetes.io.*"
 


### PR DESCRIPTION
Although it is correct (per the OpenStack catalog) to include the URL path's `/v<version>` prefix in the endpoint definition, the OpenStack APIs return HTTP 401 "Unauthorized" when the prefix is used. This breaks our link checker.

Not using the prefix instead yields a HTTP 200, listing the available version endpoints, and doesn't break the link checker.

The one exception from this is the radosgw Swift API, which will return HTTP 405 "Method Not Allowed" even when accessing the bare URI. This we have to specifically exclude from the link checks.
