### PR TITLE
feat: Fully enable Mike-based documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           pip install tox
       - env:
+          DOCS_DEPLOY_DEFAULT_BRANCH: "kna1"
           GIT_COMMITTER_EMAIL: "${{ github.actor }}@users.noreply.github.com"
           GIT_COMMITTER_NAME: "${{ github.actor }}"
         name: Deploy to gh-pages
@@ -26,7 +27,6 @@ name: deploy
 'on':
   push:
     branches:
-      - main
       - kna1
       - fra1
       - sto2

--- a/scripts/run-mike.py
+++ b/scripts/run-mike.py
@@ -18,8 +18,15 @@ VERSION_TITLE_MAP = {
 }
 
 
+# The argument list we were originally invoked with.
+#
+# Remembering this is necessary because mike gives us no option to
+# populate its command-line arguments other, than overriding sys.argv.
+ORIG_ARGS = sys.argv[1:]
+
+
 def run_mike(args):
-    mike_argv = ['mike'] + args + sys.argv[1:]
+    mike_argv = ['mike'] + args + ORIG_ARGS
 
     logging.debug("Invoking %s", mike_argv)
 
@@ -31,6 +38,8 @@ def main():
     logging.basicConfig(
         level=os.getenv("DOCS_LOGLEVEL", "WARNING").upper()
     )
+
+    logging.debug("Invoked with arguments: %s", ORIG_ARGS)
 
     # Set the default branch name (all-lowercase)
     mike_default_version_name = os.getenv("DOCS_DEPLOY_DEFAULT_BRANCH", "main")
@@ -57,12 +66,11 @@ def main():
     ]
     run_mike(mike_deploy_args)
 
-    # TODO: Re-enable when deploying the mike-versioned docs to production
-    mike_set_default_args = [  # noqa: F841
+    mike_set_default_args = [
         "set-default",
         mike_default_version_name,
     ]
-    # run_mike(mike_set_default_args)
+    run_mike(mike_set_default_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make Kna1 the default region.

This means that:

* Visiting https://docs.cleura.cloud/ will redirect the reader to   https://docs.cleura.cloud/kna1/ and explain that they are reading
the docs for Kna1, and need to switch to a different region if that's what they're interested in.
* Visiting any other "old", non-region-specific link (like https://docs.cleura.cloud/howto) will still work.

At a later date, we will remove the old links from the `gh-pages` branch, at which point they will become 404s.
