### PR TITLE
fix: Drop :8080 port suffix from Swift how-to guides

### DIFF
--- a/docs/howto/object-storage/swift/public-container.md
+++ b/docs/howto/object-storage/swift/public-container.md
@@ -176,22 +176,22 @@ Rather than composing the public URL manually, you can also retrieve it by parsi
     ```console
     $ openstack object show --debug public-container testobj.txt 2>&1 \
       | grep -o "https://.*testobj.txt"
-    https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
-    https://swift-{{api_region|lower}}.{{api_domain}}:8080 "HEAD /swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
-    https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    https://swift-{{api_region|lower}}.{{api_domain}} "HEAD /swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
     ```
 === "Swift CLI"
     ```console
     $ swift stat --debug public-container testobj.txt 2>&1 \
       | grep -o "https://.*testobj.txt"
-    https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+    https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
     ```
 
 Once you have retrieved your public URL, you can fetch the object's contents using the client of your choice.
 This example uses `curl`:
 
 ```console
-$ curl https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
+$ curl https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt
 hello world
 ```
 
@@ -201,5 +201,5 @@ Once you make a container public via the Swift API, its objects also become acce
 
 Thus, the following URL paths allow you to retrieve the same public object:
 
-* `https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt`
-* `https://s3-{{api_region|lower}}.{{api_domain}}:8080/30a7768a0ffc40359d6110f21a6e7d88:public-container/testobj.txt`
+* `https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/public-container/testobj.txt`
+* `https://s3-{{api_region|lower}}.{{api_domain}}/30a7768a0ffc40359d6110f21a6e7d88:public-container/testobj.txt`

--- a/docs/howto/object-storage/swift/tempurl.md
+++ b/docs/howto/object-storage/swift/tempurl.md
@@ -100,14 +100,14 @@ You must then use your freshly generated TempURL path as the path in a URL point
 This will enable you to fetch the object using a simple HTTP client, like `curl`:
 
 ```console
-$ curl 'https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
+$ curl 'https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
 hello world
 ```
 
 If you (or someone else) were to attempt to fetch the same URL *after* its lifetime expired, they would be met with an [HTTP 401](https://http.cat/401) error:
 
 ```console
-$ curl -i 'https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
+$ curl -i 'https://swift-{{api_region|lower}}.{{api_domain}}/swift/v1/AUTH_30a7768a0ffc40359d6110f21a6e7d88/private-container/testobj.txt?temp_url_sig=995d136bf2a8b1140d4b26886c9a8fc73bfb6c0d&temp_url_expires=1670250048'
 HTTP/1.1 401 Unauthorized
 content-length: 12
 x-trans-id: tx0000001113c5020d8a1de-00638df0ea-301ddeb-default

--- a/docs/reference/api/openstack/index.md
+++ b/docs/reference/api/openstack/index.md
@@ -21,7 +21,7 @@ The {{brand}} {{api_region}} region exposes the following OpenStack API endpoint
 | cinderv3     | volumev3        | <https://{{api_region|lower}}.{{api_domain}}:8776/>             |
 | octavia      | load-balancer   | <https://{{api_region|lower}}.{{api_domain}}:9876/>             |
 | keystone     | identity        | <https://{{api_region|lower}}.{{api_domain}}:5000/>             |
-| radosgw      | object-store    | <https://swift-{{api_region|lower}}.{{api_domain}}:8080/swift/> |
+| radosgw      | object-store    | <https://swift-{{api_region|lower}}.{{api_domain}}/swift/>      |
 | placement    | placement       | <https://{{api_region|lower}}.{{api_domain}}:8780/>             |
 | heat         | orchestration   | <https://{{api_region|lower}}.{{api_domain}}:8004/>             |
 | neutron      | network         | <https://{{api_region|lower}}.{{api_domain}}:9696/>             |


### PR DESCRIPTION
Now that the service catalog endpoints for object-storage have been updated to drop the :8080 port suffix, we can eliminate that suffix from the how-to guides for Swift and the API reference.