### PR TITLE
fix: Modify references to non-existent volume types

### DIFF
--- a/docs/howto/openstack/cinder/encrypted-volumes.md
+++ b/docs/howto/openstack/cinder/encrypted-volumes.md
@@ -19,12 +19,11 @@ $ openstack volume type list
 | ID                                   | Name                  | Is Public |
 +--------------------------------------+-----------------------+-----------+
 | a479a6b0-b283-41a5-b38b-5b08e7f902ca | cbs-encrypted         | True      |
-| d9dfa98a-238d-4ca0-9abf-701fceb05623 | __DEFAULT__           | True      |
 | 86796611-fb12-4628-b6b1-e09469e301d7 | cbs                   | True      |
 +--------------------------------------+-----------------------+-----------+
 ```
 
-> In {{brand}}, all volume types that support encryption use the suffix `_encrypted`.
+> In {{brand}}, all volume types that support encryption use the suffix `-encrypted`.
 
 To create a volume with encryption, you need to explicitly specify the `--type` option to the `openstack volume create` command.
 The following example creates a volume using the `cbs-encrypted` type, naming it `enc_drive` and setting its size to 10 GiB:

--- a/docs/howto/openstack/cinder/retype-volumes.md
+++ b/docs/howto/openstack/cinder/retype-volumes.md
@@ -4,8 +4,6 @@ description: Changing the type of a volume ("retyping") is an offline operation 
 # Changing a volume's type
 
 You may occasionally need to change the type of a volume.
-This may be due to a volume type being phased out on {{brand}}'s part, necessitating data migration.
-Or you might want to enable or disable [volume-level encryption](encrypted-volumes.md).
 
 {{page.meta.description}}
 The resulting downtime may be quite substantial, particularly for large volumes.
@@ -27,13 +25,13 @@ $ openstack volume list --long
 +----------------+---------+--------+------+---------+----------+----------------+------------+
 | ID             | Name    | Status | Size | Type    | Bootable | Attached to    | Properties |
 +----------------+---------+--------+------+---------+----------+----------------+------------+
-| e233e7f3-f33b- | testvol | in-use |   50 | default | false    | Attached to    |            |
+| e233e7f3-f33b- | testvol | in-use |   50 | cbs     | false    | Attached to    |            |
 | 4d7a-8f5b-785b |         |        |      |         |          | testsrv on     |            |
 | 34f670bf       |         |        |      |         |          | /dev/vdb       |            |
 +----------------+---------+--------+------+---------+----------+----------------+------------+
 ```
 
-In this example, this volume status is `in-use`, meaning it is currently attached to a server, and the volume type is `default`.
+In this example, this volume status is `in-use`, meaning it is currently attached to a server, and the volume type is `cbs`.
 
 ## Detaching the volume
 
@@ -69,22 +67,29 @@ $ openstack volume list
 ## Retyping the volume
 
 With the volume safely detached, you can now change its volume type.
-If you were to change the volume type from `default` to `ceph_hdd`, you would proceed as follows:
+If you were to change the volume type from `cbs` to `<new-vol-type>`, you would proceed as follows:
 
 ```console
-$ openstack volume set --type ceph_hdd --retype-policy on-demand testvol
+$ openstack volume set --type <new-vol-type> --retype-policy on-demand testvol
 
 $ openstack volume list --long
 +---------------+---------+----------+------+---------+----------+-------------+------------+
 | ID            | Name    | Status   | Size | Type    | Bootable | Attached to | Properties |
 +---------------+---------+----------+------+---------+----------+-------------+------------+
-| e233e7f3-f33b | testvol | retyping |   50 | default | false    |             |            |
+| e233e7f3-f33b | testvol | retyping |   50 | cbs     | false    |             |            |
 | -4d7a-8f5b-78 |         |          |      |         |          |             |            |
 | 5b34f670bf    |         |          |      |         |          |             |            |
 +---------------+---------+----------+------+---------+----------+-------------+------------+
 ```
 
 Note that the volume status changes from `available` to `retyping`: this status change kicks off the actual data migration, which might take a significant amount of time.
+
+> You **cannot** use retyping to convert an [encrypted volume](encrypted-volumes.md) to an unencrypted one, or vice versa.
+> Instead, you will need to move your data:
+>
+> * Attach a new volume to a running VM that **also** has the original volume attached,
+>
+> * copy data over to the new volume.
 
 ## Re-attaching the volume
 

--- a/docs/howto/openstack/cinder/sync-volumes.md
+++ b/docs/howto/openstack/cinder/sync-volumes.md
@@ -24,13 +24,13 @@ $ openstack volume list --long
 +---------------+-----------+--------+------+---------+----------+---------------+------------+
 | ID            | Name      | Status | Size | Type    | Bootable | Attached to   | Properties |
 +---------------+-----------+--------+------+---------+----------+---------------+------------+
-| 526f7741-2c44 | sourcevol | in-use |   50 | default | false    | Attached to   |            |
+| 526f7741-2c44 | sourcevol | in-use |   50 | cbs     | false    | Attached to   |            |
 | -4d04-a0c8-86 |           |        |      |         |          | testsrv on    |            |
 | b8d039e674    |           |        |      |         |          | /dev/vdb      |            |
 +---------------+-----------+--------+------+---------+----------+---------------+------------+
 ```
 
-In this example, the volume status is `in-use` (meaning the volume is currently attached to a server), and the volume type is `default`.
+In this example, the volume status is `in-use` (meaning the volume is currently attached to a server), and the volume type is `cbs`.
 
 ## Taking a snapshot of the source volume
 
@@ -99,7 +99,7 @@ $ openstack volume create --snapshot sourcevol-snap targetvol
 | snapshot_id         | 05ece580-4fb0-45dd-96e8-06a46399c38e |
 | source_volid        | None                                 |
 | status              | creating                             |
-| type                | default                              |
+| type                | cbs                                  |
 | updated_at          | None                                 |
 | user_id             | 51ce99c11f9e4ed08e92acca176c33ca     |
 +---------------------+--------------------------------------+
@@ -225,7 +225,7 @@ $ openstack volume show sourcevol
 | snapshot_id                  | None                                 |
 | source_volid                 | None                                 |
 | status                       | available                            |
-| type                         | default                              |
+| type                         | cbs                                  |
 | updated_at                   | 2023-01-05T16:03:55.000000           |
 | user_id                      | 51ce99c11f9e4ed08e92acca176c33ca     |
 +------------------------------+--------------------------------------+

--- a/docs/howto/openstack/nova/boot-image-volume.md
+++ b/docs/howto/openstack/nova/boot-image-volume.md
@@ -163,7 +163,7 @@ In the following, we show how to perform the conversion using the {{gui}} or the
     | snapshot_id         | None                                 |
     | source_volid        | None                                 |
     | status              | creating                             |
-    | type                | ceph_hdd                             |
+    | type                | cbs                                  |
     | updated_at          | None                                 |
     | user_id             | c096cf99f65a4d22a6954b67d2ec11d7     |
     +---------------------+--------------------------------------+
@@ -214,7 +214,7 @@ In the following, we show how to perform the conversion using the {{gui}} or the
     | snapshot_id                  | None                                                              |
     | source_volid                 | None                                                              |
     | status                       | available                                                         |
-    | type                         | ceph_hdd                                                          |
+    | type                         | cbs                                                               |
     | updated_at                   | 2023-05-10T13:39:05.000000                                        |
     | user_id                      | c096cf99f65a4d22a6954b67d2ec11d7                                  |
     | volume_image_metadata        | {'hw_qemu_guest_agent': 'yes', 'base_image_ref':                  |


### PR DESCRIPTION
We no longer support the "default" and "ceph_hdd" Cinder volume types. Thus, we modify references to the aforementioned with references to generic or supported volume types.

While at it, we point out that using retyping to convert an encrypted volume to an unencrypted one, or vice versa, is not possible. Instead, we suggest a simple two-step procedure for (manually) copying data between an encrypted volume and an unencrypted one.