### PR TITLE
feat: Add an "unavailable" placeholder

### DIFF
--- a/unavailable.md
+++ b/unavailable.md
@@ -1,0 +1,5 @@
+# Unavailable
+
+The {{brand}} {{api_region}} region does not support this feature.
+
+Please select another region from the drop-down menu.


### PR DESCRIPTION
Add a Markdown file that states that the given feature is unavailable.

The purpose of this file is as follows:

* If a feature is unavailable in one Cleura Cloud region, then we can replace the Markdown file(s) in that branch with a symlink to the placeholder, and also remove the links from the navigation.
* That way, no internal links break. For example, if we have a how-to guide for a feature, and that how-to guide is replaced with the "unavailable" placeholder, then a background explainer or a cross-reference from the reference section needn't be updated.
* At the same time, we don't pollute the search index for a region with content that isn't applicable to that region.
