### PR TITLE
fix: Update documentation in light of OpenStack Epoxy

### DIFF
--- a/docs/reference/versions/index.md
+++ b/docs/reference/versions/index.md
@@ -14,7 +14,7 @@ This section lists the cloud API service versions available in each {{brand}} re
 [OpenStack releases](https://releases.openstack.org) are named in alphabetical order, and occur on a six-month release schedule.
 In {{brand_public}} we upgrade OpenStack releases annually; this means that we normally deploy every other OpenStack release and skip the intervening one.
 
-{{brand}} currently runs OpenStack [Caracal](https://releases.openstack.org/caracal/) in all regions.
+{{brand}} currently runs OpenStack [Caracal](https://releases.openstack.org/caracal/) and [Epoxy](https://releases.openstack.org/epoxy/).
 
 
 ## Ceph Services

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1    | Sto2    | Fra1    |
-| ------------------------------ | ------- | ------  | ------- |
-| Barbican (secret storage)      | Caracal | Caracal | Caracal |
-| Cinder (block storage)         | Caracal | Caracal | Caracal |
-| Glance (image management)      | Caracal | Caracal | Caracal |
-| Heat (orchestration)           | Caracal | Caracal | Caracal |
-| Keystone (identity management) | Caracal | Caracal | Caracal |
-| Magnum (container management)  | Caracal | Caracal | Caracal |
-| Neutron (networking)           | Caracal | Caracal | Caracal |
-| Nova (server virtualization)   | Caracal | Caracal | Caracal |
-| Octavia (load balancing)       | Caracal | Caracal | Caracal |
+|                                | Kna1    | Sto2    | Fra1  |
+| ------------------------------ | ------- | ------  | ----- |
+| Barbican (secret storage)      | Caracal | Caracal | Epoxy |
+| Cinder (block storage)         | Caracal | Caracal | Epoxy |
+| Glance (image management)      | Caracal | Caracal | Epoxy |
+| Heat (orchestration)           | Caracal | Caracal | Epoxy |
+| Keystone (identity management) | Caracal | Caracal | Epoxy |
+| Magnum (container management)  | Caracal | Caracal | Epoxy |
+| Neutron (networking)           | Caracal | Caracal | Epoxy |
+| Nova (server virtualization)   | Caracal | Caracal | Epoxy |
+| Octavia (load balancing)       | Caracal | Caracal | Epoxy |
 
 
 ## Ceph Services


### PR DESCRIPTION
Fra1 is the first region we run Epoxy, so we update the documentation accordingly.