### PR TITLE
Introduce feature-first naming for OpenStack components

### DIFF
--- a/docs/howto/openstack/.pages
+++ b/docs/howto/openstack/.pages
@@ -1,1 +1,10 @@
 title: OpenStack
+nav:
+  - nova
+  - neutron
+  - octavia
+  - cinder
+  - glance
+  - magnum
+  - keystone
+  - barbican

--- a/docs/howto/openstack/barbican/.pages
+++ b/docs/howto/openstack/barbican/.pages
@@ -1,1 +1,1 @@
-title: Barbican (secret storage)
+title: Secret storage (Barbican)

--- a/docs/howto/openstack/cinder/.pages
+++ b/docs/howto/openstack/cinder/.pages
@@ -1,4 +1,4 @@
-title: "Cinder (persistent block storage)"
+title: "Block storage (Cinder)"
 nav:
   - resize-volumes.md
   - encrypted-volumes.md

--- a/docs/howto/openstack/glance/.pages
+++ b/docs/howto/openstack/glance/.pages
@@ -1,4 +1,4 @@
-title: Glance (image service)
+title: Image management (Glance)
 nav:
   - index.md
   - examine.md

--- a/docs/howto/openstack/keystone/.pages
+++ b/docs/howto/openstack/keystone/.pages
@@ -1,4 +1,4 @@
-title: Keystone (identity service)
+title: Identity (Keystone)
 nav:
   - app-creds.md
   - api-user-passwd.md

--- a/docs/howto/openstack/magnum/.pages
+++ b/docs/howto/openstack/magnum/.pages
@@ -1,4 +1,4 @@
-title: "Magnum (Kubernetes cluster management)"
+title: "Kubernetes management (Magnum)"
 nav:
   - new-k8s-cluster.md
   - kubectl.md

--- a/docs/howto/openstack/neutron/.pages
+++ b/docs/howto/openstack/neutron/.pages
@@ -1,4 +1,4 @@
-title: "Neutron (networking service)"
+title: "Networking (Neutron)"
 nav:
   - new-network.md
   - create-security-groups.md

--- a/docs/howto/openstack/nova/.pages
+++ b/docs/howto/openstack/nova/.pages
@@ -1,4 +1,4 @@
-title: Nova (compute service)
+title: Compute (Nova)
 nav:
   - new-server.md
   - new-server-cnw.md

--- a/docs/howto/openstack/octavia/.pages
+++ b/docs/howto/openstack/octavia/.pages
@@ -1,4 +1,4 @@
-title: Octavia (load balancing)
+title: Load balancing (Octavia)
 nav:
   - lbaas-tcp.md
   - tls-lb.md


### PR DESCRIPTION
This naming convention would be more appropriate for newcomers in OpenStack, who do not necessarily know the "esoteric" names of otherwise known services.