### PR TITLE
feat: Add missing index pages in howto section

### DIFF
--- a/docs/howto/account-billing/.pages
+++ b/docs/howto/account-billing/.pages
@@ -1,5 +1,6 @@
 title: Account & Billing
 nav:
+  - index.md
   - forgot-your-password.md
   - change-account-data.md
   - change-credit-card.md

--- a/docs/howto/account-billing/index.md
+++ b/docs/howto/account-billing/index.md
@@ -1,0 +1,3 @@
+# Account & Billing
+
+This section contains information related to maintaining your {{brand}} account, updating billing data, and managing invoices.

--- a/docs/howto/object-storage/index.md
+++ b/docs/howto/object-storage/index.md
@@ -1,0 +1,7 @@
+# Object Storage
+
+{{brand}} gives you the option of storing your data in RESTful object storage.
+
+If your application allows it, using object storage is often a cost-effective alternative to storing your data in virtual [block devices](../openstack/cinder/index.md) attached to [virtual machines](../openstack/nova/index.md).
+
+You can use two different APIs to interact with object storage in {{brand}}: the [S3 API](s3/index.md), and the [OpenStack Swift API](swift/index.md).

--- a/docs/howto/openstack/.pages
+++ b/docs/howto/openstack/.pages
@@ -1,5 +1,6 @@
 title: OpenStack
 nav:
+  - index.md
   - nova
   - neutron
   - octavia

--- a/docs/howto/openstack/cinder/.pages
+++ b/docs/howto/openstack/cinder/.pages
@@ -1,5 +1,6 @@
 title: "Block storage (Cinder)"
 nav:
+  - index.md
   - resize-volumes.md
   - encrypted-volumes.md
   - retype-volumes.md

--- a/docs/howto/openstack/cinder/index.md
+++ b/docs/howto/openstack/cinder/index.md
@@ -1,0 +1,5 @@
+# Block storage (Cinder)
+
+**[Cinder](https://docs.openstack.org/cinder/)** is an important OpenStack component responsible for providing persistent block storage to [virtual servers](../nova/index.md).
+
+{{brand}} uses Cinder to provide unencrypted persistent block storage devices ("volumes") to virtual servers be default, with [encrypted volumes](encrypted-volumes.md) being an available option.

--- a/docs/howto/openstack/glance/index.md
+++ b/docs/howto/openstack/glance/index.md
@@ -1,4 +1,4 @@
-# Managing operating system images with Glance
+# Image management (Glance)
 
 **[Glance](https://docs.openstack.org/glance/latest/)** is OpenStack's operating system image management facility.
 In {{brand}}, you use Glance images to rapidly [create servers](../nova/new-server.md) using any of our [supported base images](../../../reference/images/index.md).

--- a/docs/howto/openstack/index.md
+++ b/docs/howto/openstack/index.md
@@ -1,0 +1,17 @@
+# OpenStack
+
+{{brand}} is built around the [OpenStack](https://www.openstack.org/) Infrastructure-as-a-Service (IaaS) platform.
+
+Thus, most {{brand}} components correspond to OpenStack services:
+
+* [Compute (Nova)](nova/index.md) is the service you use for launching and managing virtual servers.
+* [Networking (Neutron)](neutron/index.md) allows you to manage virtual networks and connectivity.
+* [Load balancing (Octavia)](octavia/index.md) is for managing load balancers supporting the TCP and HTTP(S) protocols.
+* [Block storage (Cinder)](cinder/index.md) provides persistent block storage for virtual servers.
+* [Image management (Glance)](glance/index.md) provides ready-to-launch, preconfigured operating system images for virtual servers.
+* [Kubernetes management (Magnum)](magnum/index.md) enables you to launch and manage Kubernetes clusters.
+  This is one of two ways you can manage Kubernetes clusters in {{brand}}; the other is [Gardener](../kubernetes/gardener/index.md).
+* [Identity (Keystone)](keystone/index.md) is for managing credentials and authentication.
+* [Secret storage (Barbican)](barbican/index.md) provides key and secret management.
+
+{{brand}} does not natively implement [OpenStack Swift](https://docs.openstack.org/swift/), but it does support [object storage](../object-storage/index.md) that is compatible with the [Swift API](../object-storage/swift/index.md).

--- a/docs/howto/openstack/keystone/.pages
+++ b/docs/howto/openstack/keystone/.pages
@@ -1,4 +1,5 @@
 title: Identity (Keystone)
 nav:
+  - index.md
   - app-creds.md
   - api-user-passwd.md

--- a/docs/howto/openstack/keystone/index.md
+++ b/docs/howto/openstack/keystone/index.md
@@ -1,0 +1,5 @@
+# Identity (Keystone)
+
+**[Keystone](https://docs.openstack.org/keystone/)** is OpenStack's identity management and authentication facility.
+
+Keystone authentication is required for any interactions with {{brand}} via the [OpenStack CLI](../../getting-started/enable-openstack-cli.md) or API, using either a [username and password](api-user-passwd.md) or [application credentials](app-creds.md).

--- a/docs/howto/openstack/magnum/.pages
+++ b/docs/howto/openstack/magnum/.pages
@@ -1,4 +1,5 @@
 title: "Kubernetes management (Magnum)"
 nav:
+  - index.md
   - new-k8s-cluster.md
   - kubectl.md

--- a/docs/howto/openstack/magnum/index.md
+++ b/docs/howto/openstack/magnum/index.md
@@ -1,0 +1,7 @@
+# Kubernetes management (Magnum)
+
+[Magnum](https://docs.openstack.org/magnum/) is OpenStack's native service for container orchestration.
+It enables you to launch and manage Kubernetes clusters.
+
+Magnum is one of two ways you can manage Kubernetes clusters in {{brand}}; the other is [Gardener](../../kubernetes/gardener/index.md).
+

--- a/docs/howto/openstack/neutron/.pages
+++ b/docs/howto/openstack/neutron/.pages
@@ -1,5 +1,6 @@
 title: "Networking (Neutron)"
 nav:
+  - index.md
   - new-network.md
   - create-security-groups.md
   - multiple-public-ips.md

--- a/docs/howto/openstack/neutron/index.md
+++ b/docs/howto/openstack/neutron/index.md
@@ -1,0 +1,6 @@
+# Networking (Neutron)
+
+**[Neutron](https://docs.openstack.org/neutron/)** is an important OpenStack component responsible for **virtual networking**.
+Using Neutron, you can create and manage virtual networks, subnets, public and private IP addresses, and virtual routers.
+
+In {{brand}}, you can interact with Neutron using [either the OpenStack CLI, or the {{gui}}](../../../background/gui-vs-api.md).

--- a/docs/howto/openstack/nova/.pages
+++ b/docs/howto/openstack/nova/.pages
@@ -1,5 +1,6 @@
 title: Compute (Nova)
 nav:
+  - index.md
   - new-server.md
   - new-server-cnw.md
   - server-group.md

--- a/docs/howto/openstack/nova/index.md
+++ b/docs/howto/openstack/nova/index.md
@@ -1,0 +1,5 @@
+# Compute (Nova)
+
+**[Nova](https://docs.openstack.org/nova/)** is a central OpenStack component responsible for managing **servers**, also known as *virtual machines* or *instances*.
+
+In {{brand}}, you can interact with Nova using [either the OpenStack CLI, or the {{gui}}](../../../background/gui-vs-api.md).

--- a/docs/howto/openstack/octavia/.pages
+++ b/docs/howto/openstack/octavia/.pages
@@ -1,5 +1,6 @@
 title: Load balancing (Octavia)
 nav:
+  - index.md
   - lbaas-tcp.md
   - tls-lb.md
   - lbaas-l7pol.md

--- a/docs/howto/openstack/octavia/index.md
+++ b/docs/howto/openstack/octavia/index.md
@@ -1,0 +1,5 @@
+# Load balancing (Octavia)
+
+**[Octavia](https://docs.openstack.org/octavia/)** is an peripheral OpenStack component responsible for **load balancing**.
+
+Using Octavia, you can create and manage load balancing proxy servers in front of TCP or HTTP(S) services.

--- a/docs/howto/support/index.md
+++ b/docs/howto/support/index.md
@@ -1,0 +1,3 @@
+# Support
+
+This section contains information about submitting and handling {{brand}} support issues via our {{support}}.


### PR DESCRIPTION
Without this change, multiple subsections in our howto section lack an index page. This is ugly and not very user-friendly, so add them.
