### PR TITLE
fix: Add overview information for Sto-Com to all regions

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -12,37 +12,37 @@
 
 ## Block storage
 
-|                                                                 | Sto1HS           | Sto2HS           |
-| ------------------------------                                  | ---------------- | ---------------- |
-| Highly available storage                                        | :material-check: | :material-check: |
-| [High-performance local storage](../flavors/index.md#compute-tiers)  | :material-check: | :material-check: |
-| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: |
+|                                                                 | Sto1HS           | Sto2HS           | Sto-Com          |
+| ------------------------------                                  | ---------------- | ---------------- | ---------------- |
+| Highly available storage                                        | :material-check: | :material-check: | :material-check: |
+| [High-performance local storage](../flavors/index.md#compute-tiers)  | :material-check: | :material-check: | :material-check: |
+| [Volume encryption](../../howto/openstack/cinder/encrypted-volumes.md) | :material-check: | :material-check: | :material-check: |
 
 
 ## Object storage
 
-|                                                         | Sto1HS           | Sto2HS           |
-| ------------------------------                          | ---------------- | ---------------- |
-| S3 API                                                  | :material-check: | :material-check: |
-| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-check: |
-| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-check: |
-| Swift API                                               | :material-check: | :material-check: |
+|                                                         | Sto1HS           | Sto2HS           | Sto-Com          |
+| ------------------------------                          | ---------------- | ---------------- | ---------------- |
+| S3 API                                                  | :material-check: | :material-check: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-check: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-check: | :material-check: |
+| Swift API                                               | :material-check: | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)
 
-|                      | Sto1HS           | Sto2HS           |
-| -------------------- | ---------------- | ---------------- |
-| IPv4 (with NAT)      | :material-check: | :material-check: |
-| IPv6                 | :material-timer-sand: | :material-close: |
-| VPN (IPsec with PSK) | :material-check: | :material-check: |
+|                      | Sto1HS           | Sto2HS           | Sto-Com          |
+| -------------------- | ---------------- | ---------------- | ---------------- |
+| IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: |
+| IPv6                 | :material-timer-sand: | :material-close: | :material-close: |
+| VPN (IPsec with PSK) | :material-check: | :material-check: | :material-close: |
 
 
 ## Load Balancers
 
-|                                                                                                             | Sto1HS           | Sto2HS           |
-| --------------------------------------------------------------------                                        | ---------------- | ---------------- |
-| Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: |
-| Application layer (HTTP)                                                                                    | :material-check: | :material-check: |
-| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: |
-| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                | :material-check: | :material-check: |
+|                                                                                                             | Sto1HS           | Sto2HS           | Sto-Com          |
+| --------------------------------------------------------------------                                        | ---------------- | ---------------- | ---------------- |
+| Transport layer (TCP/UDP)                                                                                   | :material-check: | :material-check: | :material-close: |
+| Application layer (HTTP)                                                                                    | :material-check: | :material-check: | :material-check: |
+| Application layer ([HTTPS, with secrets management for TLS certificates](../../howto/openstack/octavia/tls-lb.md)) | :material-check: | :material-check: | :material-check: |
+| [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                | :material-check: | :material-check: | :material-check: |

--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -2,23 +2,23 @@
 
 ## OpenStack Services
 
-|                                | Sto1HS  | Sto2HS  |
-| ------------------------------ | ------- | ------- |
-| Barbican (secret storage)      | Caracal | Caracal |
-| Cinder (block storage)         | Caracal | Caracal |
-| Glance (image management)      | Caracal | Caracal |
-| Heat (orchestration)           | Caracal | Caracal |
-| Keystone (identity management) | Caracal | Caracal |
-| Magnum (container management)  | Caracal | Caracal |
-| Neutron (networking)           | Caracal | Caracal |
-| Nova (server virtualization)   | Caracal | Caracal |
-| Octavia (load balancing)       | Caracal | Caracal |
+|                                | Sto1HS  | Sto2HS  | Sto-Com |
+| ------------------------------ | ------- | ------- | ------- |
+| Barbican (secret storage)      | Caracal | Caracal | Caracal |
+| Cinder (block storage)         | Caracal | Caracal | Caracal |
+| Glance (image management)      | Caracal | Caracal | Caracal |
+| Heat (orchestration)           | Caracal | Caracal | Caracal |
+| Keystone (identity management) | Caracal | Caracal | Caracal |
+| Magnum (container management)  | Caracal | Caracal | Caracal |
+| Neutron (networking)           | Caracal | Caracal | Caracal |
+| Nova (server virtualization)   | Caracal | Caracal | Caracal |
+| Octavia (load balancing)       | Caracal | Caracal | Caracal |
 
 
 ## Ceph Services
 
-|                               | Sto1HS | Sto2HS |
-| --------------------------    | ------ | ------ |
-| Block storage (for OpenStack) | Reef   | Reef   |
-| Object storage (Swift API)    | Reef   | Reef   |
-| Object storage (S3 API)       | Reef   | Reef   |
+|                               | Sto1HS | Sto2HS | Sto-Com |
+| --------------------------    | ------ | ------ | ------- |
+| Block storage (for OpenStack) | Reef   | Reef   | Reef    |
+| Object storage (Swift API)    | Reef   | Reef   | Reef    |
+| Object storage (S3 API)       | Reef   | Reef   | Reef    |


### PR DESCRIPTION
With the per-region format, it no longer makes sense to restrict reference information about features and versions in Sto-Com to just that region.

Thus, add that information to the main branch.
