### PR TITLE
fix: Update latest Kubernetes version installable with Gardener

### DIFF
--- a/docs/background/kubernetes/index.md
+++ b/docs/background/kubernetes/index.md
@@ -14,7 +14,7 @@ For more details on the relative merits of both options, refer to the sections b
 | -------------                                                   | ----------------             | ----------------                      |
 | Kubernetes Cloud Provider                                       | OpenStack                    | OpenStack                             |
 | Base operating system for nodes                                 | Garden Linux                 | Fedora CoreOS                         |
-| Latest installable Kubernetes minor release                     | 1.31                         | 1.27                                  |
+| Latest installable Kubernetes minor release                     | 1.32                         | 1.27                                  |
 
 
 ## API and CLI support

--- a/docs/reference/limitations/kubernetes.md
+++ b/docs/reference/limitations/kubernetes.md
@@ -33,7 +33,7 @@ You cannot use `ReadWriteOncePod` (`RWOP`), `ReadWriteMany` (`RWX`), or `ReadOnl
 
 ### Kubernetes version
 
-The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.31.
+The latest Kubernetes version you can install in {{brand}} with {{k8s_management_service}} is 1.32.
 
 ### IP version
 


### PR DESCRIPTION
Currently, the latest Kubernetes version that customers can install with Gardener is 1.32.7. Update the reference section accordingly.
