### PR TITLE
fix: Correct gui_domain and rest_api_domain for Compliant Cloud

### DIFF
--- a/docs/howto/getting-started/create-account.md
+++ b/docs/howto/getting-started/create-account.md
@@ -1,45 +1,6 @@
 ---
-description: How to create a new Cleura Cloud account
+description: How to create a new Cleura Compliant Cloud account
 ---
 # Creating a new account
 
-For access to {{brand}}, you first have to create a new account.
-For that, navigate to <https://{{gui_domain}}/register>.
-
-![Type in necessary details](assets/02-type-email-country.png)
-
-Select the new account type (*Company* or *Private*), type in a valid email address, and choose your country.
-Please be sure to read the {{ legal_docs.tos.name}} and our {{ legal_docs.cdpa.name}}.
-
-Agree to these documents (select *Yes*), check the *I'm not a robot* box, and then click on the *Create* button.
-
-This will redirect you to the {{gui}}, and since you are logging in from a new account for the first time, you now have to take three steps.
-
-![Three steps to take](assets/03-step-1.png)
-
-* **Step 1 - Confirm your email**.
-  Check your inbox or your spam/junk folder for an email from `no-reply@cleura.com` with the subject *Thank you for your registration - Cleura Cloud*.
-  Open that email, and click on the link in the message body.
-
-![Three steps to take](assets/04-conf-email.png)
-
-* **Step 2 - Account information**.
-  After clicking on the confirmation link you move on to step two, where you enter the information that uniquely identifies the brand-new account.
-  Type in a username for the account user, and define a strong password.
-  (We recommend using a password manager.)
-  Please note that all fields are mandatory.
-  In case you have a voucher code, click on *I have a voucher code* and type it in below.
-  When you are done, click on the *Save* button.
-
-![Confirm account information](assets/05-step-2.png)
-
-* **Step 3 - Account verification**.
-  To make your account fully operational, you have to take one more verification step.
-  You do that either by entering valid credit card information, or by placing a phone call.
-  Verifying by credit card does *not* incur charges.
-  If you prefer to verify by phone (available only for *Company* accounts), you may do so during business hours (08:00 – 17:00 CET/CEST UTC+1/UTC+2).
-  During the verification call, you will be asked for the username of the new account.
-
-![Account verification](assets/06-step-3.png)
-
-After the account verification is complete, you can start using [{{gui}}](https://{{gui_domain}}).
+For access to {{brand_compliant}} in the {{api_region}} region, contact your {{company}} Customer Engagement representative.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ extra:
   company: "Cleura"
   company_domain: "cleura.com"
   gui: "Cleura Cloud Management Panel"
-  gui_domain: "cleura.cloud"
+  gui_domain: "compliant.cleura.cloud"
   k8s_management_service: Gardener
   legal_docs:
     cc_by_sa:
@@ -41,7 +41,7 @@ extra:
       name: "Transfer Form"
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"
   rest_api: "Cleura Cloud REST API"
-  rest_api_domain: "rest.cleura.cloud"
+  rest_api_domain: "rest.compliant.cleura.cloud"
   support: "Service Center"
   support_domain: "servicecenter.cleura.cloud"
   support_email: "support@cleura.com"

--- a/scripts/linkcheck.sh
+++ b/scripts/linkcheck.sh
@@ -13,6 +13,9 @@ DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*fixme.*"
 # Ignore Swift API endpoints
 DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*/swift/.*"
 
+# Ignore Compliant Cloud API endpoints, which are rate-limited
+DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*//sto1hs.citycloud.com.*"
+
 # www.terraform.io links to developer.hashicorp.com, which is rate-limited
 DOCS_LINKCHECK_IGNORE="$DOCS_LINKCHECK_IGNORE .*www.terraform.io.*"
 


### PR DESCRIPTION
With per-region documentation, it makes more sense to directly use the CCMP and CCMS domain names for Compliant Cloud, in the relevant regions.
