### PR TITLE
fix: Update docs in light of OpenStack Epoxy in Sto1HS

### DIFF
--- a/docs/reference/versions/compliant.md
+++ b/docs/reference/versions/compliant.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Sto1HS  | Sto2HS  | Sto-Com |
-| ------------------------------ | ------- | ------- | ------- |
-| Barbican (secret storage)      | Caracal | Caracal | Caracal |
-| Cinder (block storage)         | Caracal | Caracal | Caracal |
-| Glance (image management)      | Caracal | Caracal | Caracal |
-| Heat (orchestration)           | Caracal | Caracal | Caracal |
-| Keystone (identity management) | Caracal | Caracal | Caracal |
-| Magnum (container management)  | Caracal | Caracal | :material-close: |
-| Neutron (networking)           | Caracal | Caracal | Caracal |
-| Nova (server virtualization)   | Caracal | Caracal | Caracal |
-| Octavia (load balancing)       | Caracal | Caracal | Caracal |
+|                                | Sto1HS | Sto2HS  | Sto-Com |
+| ------------------------------ | ------ | ------- | ------- |
+| Barbican (secret storage)      | Epoxy  | Caracal | Caracal |
+| Cinder (block storage)         | Epoxy  | Caracal | Caracal |
+| Glance (image management)      | Epoxy  | Caracal | Caracal |
+| Heat (orchestration)           | Epoxy  | Caracal | Caracal |
+| Keystone (identity management) | Epoxy  | Caracal | Caracal |
+| Magnum (container management)  | Epoxy  | Caracal | :material-close: |
+| Neutron (networking)           | Epoxy  | Caracal | Caracal |
+| Nova (server virtualization)   | Epoxy  | Caracal | Caracal |
+| Octavia (load balancing)       | Epoxy  | Caracal | Caracal |
 
 
 ## Ceph Services


### PR DESCRIPTION
Sto1HS runs Epoxy now, so we update the docs accordingly.