### PR TITLE
fix: Correct information on IPv6 availability in Compliant Cloud

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -34,7 +34,7 @@
 |                      | Sto1HS           | Sto2HS           | Sto-Com          |
 | -------------------- | ---------------- | ---------------- | ---------------- |
 | IPv4 (with NAT)      | :material-check: | :material-check: | :material-check: |
-| IPv6                 | :material-timer-sand: | :material-close: | :material-close: |
+| IPv6                 | :material-timer-sand: | :material-close: | :material-check: |
 | VPN (IPsec with PSK) | :material-check: | :material-check: | :material-close: |
 
 


### PR DESCRIPTION
For some reason, our feature reference listed IPv6 as being unavailable in Sto-Com. That is incorrect. Fix the feature reference to mark IPv6 as available.
