### PR TITLE
feat: Add DNS to feature reference in Public Cloud

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -48,6 +48,18 @@
 | [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                       | :material-check: | :material-check: | :material-check: |
 
 
+## DNS
+
+|                      | Kna1             | Sto2             | Fra1                  |
+| -------------------- | ---------------- | ---------------- | ----------------      |
+| Zones                | :material-close: | :material-close: | :material-timer-sand: |
+| A records            | :material-close: | :material-close: | :material-timer-sand: |
+| AAAA records         | :material-close: | :material-close: | :material-timer-sand: |
+| PTR records          | :material-close: | :material-close: | :material-close:      |
+| SRV records          | :material-close: | :material-close: | :material-timer-sand: |
+| TXT records          | :material-close: | :material-close: | :material-timer-sand: |
+
+
 ## Kubernetes management
 |                            | Kna1             | Sto2             | Fra1             |
 | -----------------          | ---------------- | ---------------- | ---------------- |


### PR DESCRIPTION
Add a section adding to the feature reference (for the Public Cloud regions, for the time being).

Designate is currently in beta in Fra1.
