### PR TITLE
fix: Align Designate navigation title with index page

### DIFF
--- a/docs/howto/openstack/designate/.pages
+++ b/docs/howto/openstack/designate/.pages
@@ -1,4 +1,4 @@
-title: "Designate (DNS)"
+title: "DNS (Designate)"
 nav:
   - index.md
   - zones.md


### PR DESCRIPTION
Make sure we have the same title in the subsection navigation, and in the title of that subsection's `index.md` page.
