### PR TITLE
feat: Add DNS to feature reference in Compliant Cloud

### DIFF
--- a/docs/reference/features/compliant.md
+++ b/docs/reference/features/compliant.md
@@ -48,6 +48,18 @@
 | [Metrics endpoint](../../howto/openstack/octavia/metrics.md)                                                | :material-check: | :material-check: | :material-check: |
 
 
+## DNS
+
+|                      | Sto1HS                | Sto2HS           | Sto-Com          |
+| -------------------- | ----------------      | ---------------- | ---------------- |
+| Zones                | :material-timer-sand: | :material-close: | :material-close: |
+| A records            | :material-timer-sand: | :material-close: | :material-close: |
+| AAAA records         | :material-timer-sand: | :material-close: | :material-close: |
+| PTR records          | :material-close:      | :material-close: | :material-close: |
+| SRV records          | :material-timer-sand: | :material-close: | :material-close: |
+| TXT records          | :material-timer-sand: | :material-close: | :material-close: |
+
+
 ## Kubernetes management
 |                            | Sto1HS           | Sto2HS           | Sto-Com          |
 | -----------------          | ---------------- | ---------------- | ---------------- |


### PR DESCRIPTION
Add a section on Designate to the feature reference for the Compliant Cloud regions.

Designate is currently in beta in Sto1HS.
