### PR TITLE
fix: Update docs in light of OpenStack Epoxy in Kna1

### DIFF
--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -2,17 +2,17 @@
 
 ## OpenStack Services
 
-|                                | Kna1    | Sto2  | Fra1  |
-| ------------------------------ | ------- | ----- | ----- |
-| Barbican (secret storage)      | Caracal | Epoxy | Epoxy |
-| Cinder (block storage)         | Caracal | Epoxy | Epoxy |
-| Glance (image management)      | Caracal | Epoxy | Epoxy |
-| Heat (orchestration)           | Caracal | Epoxy | Epoxy |
-| Keystone (identity management) | Caracal | Epoxy | Epoxy |
-| Magnum (container management)  | Caracal | Epoxy | Epoxy |
-| Neutron (networking)           | Caracal | Epoxy | Epoxy |
-| Nova (server virtualization)   | Caracal | Epoxy | Epoxy |
-| Octavia (load balancing)       | Caracal | Epoxy | Epoxy |
+|                                | Kna1  | Sto2  | Fra1  |
+| ------------------------------ | ----- | ----- | ----- |
+| Barbican (secret storage)      | Epoxy | Epoxy | Epoxy |
+| Cinder (block storage)         | Epoxy | Epoxy | Epoxy |
+| Glance (image management)      | Epoxy | Epoxy | Epoxy |
+| Heat (orchestration)           | Epoxy | Epoxy | Epoxy |
+| Keystone (identity management) | Epoxy | Epoxy | Epoxy |
+| Magnum (container management)  | Epoxy | Epoxy | Epoxy |
+| Neutron (networking)           | Epoxy | Epoxy | Epoxy |
+| Nova (server virtualization)   | Epoxy | Epoxy | Epoxy |
+| Octavia (load balancing)       | Epoxy | Epoxy | Epoxy |
 
 
 ## Ceph Services


### PR DESCRIPTION
Kna1 runs Epoxy now, so we update the docs accordingly.