### PR TITLE
fix: Update reference for object storage in Sto2

### DIFF
--- a/docs/reference/features/public.md
+++ b/docs/reference/features/public.md
@@ -23,12 +23,12 @@
 
 
 ## Object storage
-|                                                                | Kna1             | Sto2                  | Fra1             |
-| ------------------------------                                 | ---------------- | ----------------      | ---------------- |
-| S3 API                                                         | :material-check: | :material-timer-sand: | :material-check: |
-| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-timer-sand: | :material-check: |
-| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-timer-sand: | :material-check: |
-| Swift API                                                      | :material-check: | :material-timer-sand: | :material-check: |
+|                                                                | Kna1             | Sto2             | Fra1             |
+| ------------------------------                                 | ---------------- | ---------------- | ---------------- |
+| S3 API                                                         | :material-check: | :material-check: | :material-check: |
+| S3 [SSE-C](../../howto/object-storage/s3/sse-c.md)             | :material-check: | :material-check: | :material-check: |
+| S3 [object lock](../../howto/object-storage/s3/object-lock.md) | :material-check: | :material-check: | :material-check: |
+| Swift API                                                      | :material-check: | :material-check: | :material-check: |
 
 
 ## Networking (Layer 2/3)

--- a/docs/reference/versions/public.md
+++ b/docs/reference/versions/public.md
@@ -17,8 +17,8 @@
 
 ## Ceph Services
 
-|                               | Kna1   | Sto2             | Fra1  |
-| --------------------------    | ------ | ------           | ----- |
-| Block storage (for OpenStack) | Reef   | Reef             | Reef  |
-| Object storage (Swift API)    | Reef   | :material-close: | Reef  |
-| Object storage (S3 API)       | Reef   | :material-close: | Reef  |
+|                               | Kna1   | Sto2   | Fra1  |
+| --------------------------    | ------ | ------ | ----- |
+| Block storage (for OpenStack) | Reef   | Reef   | Reef  |
+| Object storage (Swift API)    | Reef   | Reef   | Reef  |
+| Object storage (S3 API)       | Reef   | Reef   | Reef  |


### PR DESCRIPTION
Now that object storage is available in Sto2, update the reference
information accordingly.
