### PR TITLE
build: Disable fail-fast in matrix strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           name: build-${{ matrix.python-version }}-${{ github.sha }}
           path: site/
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '3.10'


### PR DESCRIPTION
Frequently, our jobs fail while running the link checker, because of an upstream link being temporarily unavailable. With `fail-fast` enabled (which it is by default), this causes all other jobs in same matrix to be immediately cancelled. This means that we subsequently need to re-run not only the failed job, but also the cancelled ones.

Thus, disable `fail-fast`.

Reference:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast
