### PR TITLE
build: Drop Python 3.12 and 3.13, add 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
       matrix:
         python-version:
           - '3.10'
-          - '3.12'
-          - '3.13'
+          - '3.14'
 
 name: build
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Set up Python 3.12
+      - name: "Set up Python 3.14"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install Python dependencies
         run: |
           pip install tox

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.12
+      - name: "Set up Python 3.14"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install Python dependencies
         run: |
           pip install tox


### PR DESCRIPTION
We want to build on the Python version that is in the latest Ubuntu
LTS (currently 3.10 on Ubuntu Noble), and the latest Python release
(currently 3.14).

Update the GitHub Actions workflows accordingly.
