### PR TITLE
feat: Add new Designate reference section

### DIFF
--- a/docs/howto/openstack/designate/recordsets.md
+++ b/docs/howto/openstack/designate/recordsets.md
@@ -158,6 +158,9 @@ nuuk.example.com.  3600    IN  AAAA    2001:db8:ffff:ffff:ffff:ffff:ffff:ffff
 ;; MSG SIZE  rcvd: 78
 ```
 
+> For extra resilience, the two name servers in any zone reside in different geographic locations.
+> You may see the location of a name server [in the Reference section](../../../reference/designate/index.md).
+
 ## Deleting recordsets
 
 To delete a recordset, you use the `openstack recordset delete` command and specify the name of the zone, together with the `id` of the recordset.

--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -3,6 +3,7 @@ nav:
   - index.md
   - features
   - limitations
+  - designate
   - flavors
   - volumes
   - images

--- a/docs/reference/designate/index.md
+++ b/docs/reference/designate/index.md
@@ -1,0 +1,23 @@
+# DNS servers
+
+## Server regions
+
+By default, each new zone you create with Designate comes equipped with two name servers.
+The names of those servers, like `cloud-ns1.fra1-pub.cleura.cloud.` and `cloud-ns2.kna1-pub.cleura.cloud.`, are indicative of the regions whose DNS zones and records they handle and *not* of any server's physical location.
+
+The following matrix shows where each name server is located.
+
+| Name server                        | Location  |
+| ---------------------------------- | ----------|
+| `cloud-ns1.fra1-pub.cleura.cloud.` | Frankfurt |
+| `cloud-ns2.fra1-pub.cleura.cloud.` | Stockholm |
+| `cloud-ns1.kna1-pub.cleura.cloud.` | Frankfurt |
+| `cloud-ns2.kna1-pub.cleura.cloud.` | Stockholm |
+| `cloud-ns1.sto2-pub.cleura.cloud.` | Frankfurt |
+| `cloud-ns2.sto2-pub.cleura.cloud.` | Stockholm |
+| `cloud-ns1.sto1-com.cleura.cloud.` | Frankfurt |
+| `cloud-ns2.sto1-com.cleura.cloud.` | Stockholm |
+| `cloud-ns1.sto2-com.cleura.cloud.` | Frankfurt |
+| `cloud-ns2.sto2-com.cleura.cloud.` | Stockholm |
+| `cloud-ns1.sto-com.cleura.cloud.`  | Frankfurt |
+| `cloud-ns2.sto-com.cleura.cloud.`  | Stockholm |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,8 @@ It serves to provide general reference information about {{brand}} services.
 
 * The **[Limitations](limitations/index.md)** section lists support limitations for specific {{brand}} services.
 
+* The **[DNS servers](designate/index.md)** reference offers clarifications regarding the physical locations of the name servers used by Designate.
+
 * The **[Flavors](flavors/index.md)** reference explains our naming convention for pre-defined CPU/RAM/disk configurations ("flavors") for server instances, and their availability across {{brand}} regions.
 
 * The **[Volume Types](volumes/index.md)** reference lists the available persistent block storage ("volume") types.


### PR DESCRIPTION
Each Designate zone comes with two name servers. The names of those servers seem to indicate the regions they are in. This is not the case, so we provide a matrix showing which region each name server resides in.