### PR TITLE
fix: Improve Designate reference

### DIFF
--- a/docs/howto/openstack/designate/recordsets.md
+++ b/docs/howto/openstack/designate/recordsets.md
@@ -159,7 +159,7 @@ nuuk.example.com.  3600    IN  AAAA    2001:db8:ffff:ffff:ffff:ffff:ffff:ffff
 ```
 
 > For extra resilience, the two name servers in any zone reside in different geographic locations.
-> You may see the location of a name server [in the Reference section](../../../reference/designate/index.md).
+> You may see the location of a name server [in the Reference section](../../../reference/dns/index.md).
 
 ## Deleting recordsets
 

--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -3,10 +3,10 @@ nav:
   - index.md
   - features
   - limitations
-  - designate
   - flavors
   - volumes
   - images
+  - DNS: dns
   - quotas
   - versions
   - api

--- a/docs/reference/dns/index.md
+++ b/docs/reference/dns/index.md
@@ -1,8 +1,11 @@
+---
+description: Reference information on DNS management in Cleura Cloud
+---
 # DNS servers
 
 ## Server regions
 
-By default, each new zone you create with Designate comes equipped with two name servers.
+By default, each [new zone](../../howto/openstack/designate/zones.md) you create with Designate comes equipped with two name servers.
 The names of those servers, like `cloud-ns1.fra1-pub.cleura.cloud.` and `cloud-ns2.kna1-pub.cleura.cloud.`, are indicative of the regions whose DNS zones and records they handle and *not* of any server's physical location.
 
 The following matrix shows where each name server is located.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,11 +9,11 @@ It serves to provide general reference information about {{brand}} services.
 
 * The **[Limitations](limitations/index.md)** section lists support limitations for specific {{brand}} services.
 
-* The **[DNS servers](designate/index.md)** reference offers clarifications regarding the physical locations of the name servers used by Designate.
-
 * The **[Flavors](flavors/index.md)** reference explains our naming convention for pre-defined CPU/RAM/disk configurations ("flavors") for server instances, and their availability across {{brand}} regions.
 
 * The **[Volume Types](volumes/index.md)** reference lists the available persistent block storage ("volume") types.
+
+* The **[DNS servers](dns/index.md)** reference offers clarifications regarding the physical locations of the name servers used by Designate.
 
 * Our **[Service Version Matrix](versions/index.md)** lists the open source software versions running in our {{brand}} regions.
 


### PR DESCRIPTION
* Rename the navigation entry from "Designate" to the generic "DNS", in line with the other subsections in the Reference section.
* Add a backlink to the "Managing zones" how-to guide.
* Add YAML frontmatter for the page description.
