### PR TITLE
fix: Mention correct model name in AI reference section

### DIFF
--- a/docs/reference/ai/llms.md
+++ b/docs/reference/ai/llms.md
@@ -11,5 +11,5 @@ Refer to the table below for information about each model's origin, and their re
 | faster-whisper-large-v3 | OpenAI        | Speech recognition and translation  |
 | gemma-3-27b             | Google        | Text and image processing           |
 | gpt-oss-120b            | OpenAI        | Complex reasoning                   |
-| qwen3-coder-30          | Alibaba Cloud | Coding                              |
+| qwen3-coder-30b         | Alibaba Cloud | Coding                              |
 | qwen3-embedding-8b      | Alibaba Cloud | Semantic search, document ranking   |


### PR DESCRIPTION
The qwen3-coder-30b model was incorrectly referred to in the LLM
reference as "qwen3-coder-30". Update the page to include the correct
model name.
