### PR TITLE
build: Restrict MkDocs to version 1.6.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = yamllint,flake8,bashate,markdownlint,build
 skip_install = True
 passenv = DOCS_*
 deps =
-  mkdocs<2
+  mkdocs<=1.6.1
   mkdocs-awesome-pages-plugin
   mkdocs-git-authors-plugin>=0.6.5
   mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
To steer clear of the mkdocs/properdocs kerfuffle, restrict MkDocs to
the 1.6.1 release until we move to Zensical.
