### PR TITLE
build: Restrict mike to version 2.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+cairosvg
+mike<=2.1.4
+mkdocs-awesome-pages-plugin
+mkdocs-git-authors-plugin>=0.6.5
+mkdocs-git-revision-date-localized-plugin
+mkdocs-glightbox
+mkdocs-macros-plugin
+mkdocs-material>=9.5.3
+mkdocs-redirects
+mkdocs<=1.6.1
+pillow

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
   mkdocs-macros-plugin
   mkdocs-material>=9.5.3
   mkdocs-redirects
-  mike
+  mike<=2.1.4
   pillow
   cairosvg
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,7 @@ envlist = yamllint,flake8,bashate,markdownlint,build
 [testenv]
 skip_install = True
 passenv = DOCS_*
-deps =
-  mkdocs<=1.6.1
-  mkdocs-awesome-pages-plugin
-  mkdocs-git-authors-plugin>=0.6.5
-  mkdocs-git-revision-date-localized-plugin
-  mkdocs-glightbox
-  mkdocs-macros-plugin
-  mkdocs-material>=9.5.3
-  mkdocs-redirects
-  mike<=2.1.4
-  pillow
-  cairosvg
+deps = -rrequirements.txt
 commands =
   mkdocs {posargs}
 allowlist_externals =


### PR DESCRIPTION
Apparently, restricting mkdocs to version 1.6.1 is not enough; we need
to restrict mike to the 2.1.4 version as well.
