### PR TITLE
refactor: Add ai_api_domain variable

### DIFF
--- a/docs/howto/ai/openwebui.md
+++ b/docs/howto/ai/openwebui.md
@@ -21,13 +21,13 @@ A window labeled _Add Connection_ pops up.
 ![Add new API connection](assets/openwebui-add-connection.png)
 
 * Set _Connection Type_ to _External_.
-* Set _URL_ to `https://ai.cleura.cloud/v1`.
+* Set _URL_ to `https://{{ai_api_domain}}/v1`.
 * Set _Auth_ to _Bearer_.
 
 In the text field right of _Bearer_, paste your API key's bearer token.
 Then, click the _Save_ button.
 
-The _Add Connection_ window closes, and below the _Manage OpenAI API Connections_ list you see that `https://ai.cleura.cloud/v1` is included.
+The _Add Connection_ window closes, and below the _Manage OpenAI API Connections_ list you see that `https://{{ai_api_domain}}/v1` is included.
 
 ![Add new API connection](assets/openwebui-connection-added.png)
 

--- a/docs/howto/ai/stt.md
+++ b/docs/howto/ai/stt.md
@@ -25,7 +25,7 @@ from openai import OpenAI
 
 client = OpenAI(
     api_key="<your-bearer-token>",
-    base_url="https://ai.cleura.cloud/v1"
+    base_url="https://{{ai_api_domain}}/v1"
 )
 
 with open("/path/to/the-audio-file.mp3", "rb") as audio_file:

--- a/docs/reference/ai/index.md
+++ b/docs/reference/ai/index.md
@@ -11,14 +11,14 @@ Here you may find information on the API documentation and endpoints, and a list
 
 ## API documentation and API endpoints
 
-All links to the API documentation and API endpoint URLs are at the [{{brand_ai}} Gateway](https://ai.cleura.cloud/swagger) page.
+All links to the API documentation and API endpoint URLs are at the [{{brand_ai}} Gateway](https://{{ai_api_domain}}/swagger) page.
 
 ## OpenAI compatible API paths and documentation
 
-| Path                        | URL                                               | Documentation |
-| ----                        | ---                                               | ------------- |
-| `/v1/models`                | `https://ai.cleura.cloud/v1/models`               | [models](https://developers.openai.com/api/reference/resources/models) |
-| `/v1/chat/completions`      | `https://ai.cleura.cloud/v1/chat/completions`     | [chat completions](https://developers.openai.com/api/reference/resources/chat/subresources/completions) |
-| `/v1/completions`           | `https://ai.cleura.cloud/v1/completions`          | [completions](https://developers.openai.com/api/reference/resources/completions) |
-| `/v1/embeddings`            | `https://ai.cleura.cloud/v1/embeddings`           | [embeddings](https://developers.openai.com/api/reference/resources/embeddings/methods/create) |
-| `/v1/audio/transcriptions`  | `https://ai.cleura.cloud/v1/audio/transcriptions` | [transcriptions](https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create) |
+| Path                       | URL                                                 | Documentation                                                                                                            |
+|----------------------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `/v1/models`               | `https://{{ai_api_domain}}/v1/models`               | [models](https://developers.openai.com/api/reference/resources/models)                                                   |
+| `/v1/chat/completions`     | `https://{{ai_api_domain}}/v1/chat/completions`     | [chat completions](https://developers.openai.com/api/reference/resources/chat/subresources/completions)                  |
+| `/v1/completions`          | `https://{{ai_api_domain}}/v1/completions`          | [completions](https://developers.openai.com/api/reference/resources/completions)                                         |
+| `/v1/embeddings`           | `https://{{ai_api_domain}}/v1/embeddings`           | [embeddings](https://developers.openai.com/api/reference/resources/embeddings/methods/create)                            |
+| `/v1/audio/transcriptions` | `https://{{ai_api_domain}}/v1/audio/transcriptions` | [transcriptions](https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ edit_uri: ./edit/main/docs
 extra:
   academy: "Cleura Cloud Academy"
   academy_domain: "academy.cleura.cloud"
+  ai_api_domain: "ai.cleura.cloud"
   analytics:
     domain: docs.cleura.cloud
     provider: plausible


### PR DESCRIPTION
Since we have different domain names for Cleura AI in Public and Compliant Cloud, introduce a variable and replace the hardcoded references with macros.
