### PR TITLE
Update dependencies; drop social cards plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,9 +91,6 @@ plugins:
       version_selector: true
   - privacy
   - search
-  - social:
-      # yamllint disable-line rule:truthy
-      cards: !ENV [DOCS_ENABLE_SOCIAL_CARDS, True]
   - redirects:
       redirect_maps:
         'background/disaster-recovery.md': 'background/recovery-service.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cairosvg
 mike<=2.1.4
 mkdocs-awesome-pages-plugin
 mkdocs-git-authors-plugin>=0.6.5
@@ -8,5 +7,4 @@ mkdocs-macros-plugin
 mkdocs-material>=9.5.3
 mkdocs-redirects
 mkdocs<=1.6.1
-pillow
 tzdata

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mkdocs-material>=9.5.3
 mkdocs-redirects
 mkdocs<=1.6.1
 pillow
+tzdata


### PR DESCRIPTION
- **build: Add tzdata dependency**
  When building on some platforms (example: Alpine), the build breaks
  because of a missing tzdata module.
  
  Thus, explicitly include it as a dependency in requirements.txt.
  

- **fix: Remove social cards**
  Social cards are a non-essential feature that is currently not
  available in Zensical, and will likely work differently in Zensical
  than it does in Mkdocs-Material.
  
  To facilitate the subsequent transition, drop this plugin for the time
  being.
  
  Reference:
  https://zensical.org/docs/setup/social-cards/
  