### PR TITLE
fix: Add .pages files to yamllint; fix YAML errors

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -19,3 +19,8 @@ rules:
     max: 90
   truthy:
     level: error
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+  - '.pages'

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,3 +1,4 @@
+---
 nav:
   - "Start Here!": index.md
   - howto

--- a/docs/background/.pages
+++ b/docs/background/.pages
@@ -1,4 +1,4 @@
-title: "Background"
+---
 nav:
   - index.md
   - "CCMP vs. OpenStack API": gui-vs-api.md
@@ -8,3 +8,4 @@ nav:
   - AI: ai
   - kubernetes
   - Marketplace: marketplace.md
+title: "Background"

--- a/docs/contrib/.pages
+++ b/docs/contrib/.pages
@@ -1,7 +1,8 @@
-title: "You can help!"
+---
 nav:
   - issues.md
   - modifications.md
   - quality.md
   - style.md
   - ai.md
+title: "You can help!"

--- a/docs/contrib/.pages
+++ b/docs/contrib/.pages
@@ -1,5 +1,6 @@
 ---
 nav:
+  - index.md
   - issues.md
   - modifications.md
   - quality.md

--- a/docs/howto/.pages
+++ b/docs/howto/.pages
@@ -1,4 +1,4 @@
-title: "How-To Guides"
+---
 nav:
   - index.md
   - getting-started
@@ -9,3 +9,4 @@ nav:
   - marketplace
   - account-billing
   - support
+title: "How-To Guides"

--- a/docs/howto/account-billing/.pages
+++ b/docs/howto/account-billing/.pages
@@ -1,4 +1,4 @@
-title: Account & Billing
+---
 nav:
   - index.md
   - forgot-your-password.md
@@ -8,3 +8,4 @@ nav:
   - e-invoice.md
   - rest-invoice-data.md
   - delete-account.md
+title: Account & Billing

--- a/docs/howto/ai/.pages
+++ b/docs/howto/ai/.pages
@@ -1,4 +1,4 @@
-title: "AI"
+---
 nav:
   - index.md
   - "Reviewing models": models.md
@@ -6,3 +6,4 @@ nav:
   - api-keys.md
   - openwebui.md
   - stt.md
+title: "AI"

--- a/docs/howto/getting-started/.pages
+++ b/docs/howto/getting-started/.pages
@@ -1,8 +1,8 @@
-title: Getting Started
+---
 nav:
   - create-account.md
   - enable-openstack-cli.md
   - accessing-cc-rest-api.md
   - launching-resources.md
   - launch-pad
-
+title: Getting Started

--- a/docs/howto/getting-started/launch-pad/.pages
+++ b/docs/howto/getting-started/launch-pad/.pages
@@ -1,1 +1,2 @@
+---
 title: Cleura Cloud Launch Pad

--- a/docs/howto/kubernetes/gardener/.pages
+++ b/docs/howto/kubernetes/gardener/.pages
@@ -1,4 +1,4 @@
-title: Gardener
+---
 nav:
   - index.md
   - create-shoot-cluster.md
@@ -6,3 +6,4 @@ nav:
   - high-avail.md
   - hibernate-shoot-cluster.md
   - rolling-upgrades.md
+title: Gardener

--- a/docs/howto/marketplace/.pages
+++ b/docs/howto/marketplace/.pages
@@ -1,1 +1,2 @@
+---
 title: Marketplace

--- a/docs/howto/marketplace/bareos/.pages
+++ b/docs/howto/marketplace/bareos/.pages
@@ -1,4 +1,5 @@
-title: Bareos
+---
 nav:
   - deploy.md
   - delete.md
+title: Bareos

--- a/docs/howto/marketplace/clavister/.pages
+++ b/docs/howto/marketplace/clavister/.pages
@@ -1,4 +1,5 @@
-title: Clavister NetWall
+---
 nav:
   - deploy.md
   - delete.md
+title: Clavister NetWall

--- a/docs/howto/marketplace/grafana/.pages
+++ b/docs/howto/marketplace/grafana/.pages
@@ -1,4 +1,5 @@
-title: Grafana
+---
 nav:
   - deploy.md
   - delete.md
+title: Grafana

--- a/docs/howto/marketplace/harbor/.pages
+++ b/docs/howto/marketplace/harbor/.pages
@@ -1,4 +1,5 @@
-title: Harbor
+---
 nav:
   - deploy.md
   - delete.md
+title: Harbor

--- a/docs/howto/marketplace/keycloak/.pages
+++ b/docs/howto/marketplace/keycloak/.pages
@@ -1,4 +1,5 @@
-title: Keycloak
+---
 nav:
   - deploy.md
   - delete.md
+title: Keycloak

--- a/docs/howto/marketplace/langfuse/.pages
+++ b/docs/howto/marketplace/langfuse/.pages
@@ -1,4 +1,5 @@
-title: Langfuse
+---
 nav:
   - deploy.md
   - delete.md
+title: Langfuse

--- a/docs/howto/marketplace/matomo/.pages
+++ b/docs/howto/marketplace/matomo/.pages
@@ -1,4 +1,5 @@
-title: Matomo
+---
 nav:
   - deploy.md
   - delete.md
+title: Matomo

--- a/docs/howto/marketplace/openwebui/.pages
+++ b/docs/howto/marketplace/openwebui/.pages
@@ -1,4 +1,5 @@
-title: Open WebUI
+---
 nav:
   - deploy.md
   - delete.md
+title: Open WebUI

--- a/docs/howto/marketplace/prometheus/.pages
+++ b/docs/howto/marketplace/prometheus/.pages
@@ -1,4 +1,5 @@
-title: Prometheus
+---
 nav:
   - deploy.md
   - delete.md
+title: Prometheus

--- a/docs/howto/marketplace/taiga/.pages
+++ b/docs/howto/marketplace/taiga/.pages
@@ -1,4 +1,5 @@
-title: Taiga
+---
 nav:
   - deploy.md
   - delete.md
+title: Taiga

--- a/docs/howto/object-storage/s3/.pages
+++ b/docs/howto/object-storage/s3/.pages
@@ -1,4 +1,4 @@
-title: S3 API
+---
 nav:
   - index.md
   - credentials.md
@@ -9,3 +9,4 @@ nav:
   - versioning.md
   - "Object encryption (SSE-C)": sse-c.md
   - utilization.md
+title: S3 API

--- a/docs/howto/object-storage/swift/.pages
+++ b/docs/howto/object-storage/swift/.pages
@@ -1,4 +1,4 @@
-title: Swift API
+---
 nav:
   - index.md
   - private-container.md
@@ -7,3 +7,4 @@ nav:
   - expiry.md
   - versioning.md
   - utilization.md
+title: Swift API

--- a/docs/howto/openstack/.pages
+++ b/docs/howto/openstack/.pages
@@ -1,4 +1,4 @@
-title: OpenStack
+---
 nav:
   - index.md
   - nova
@@ -9,3 +9,4 @@ nav:
   - glance
   - keystone
   - barbican
+title: OpenStack

--- a/docs/howto/openstack/barbican/.pages
+++ b/docs/howto/openstack/barbican/.pages
@@ -1,1 +1,2 @@
+---
 title: Secret storage (Barbican)

--- a/docs/howto/openstack/cinder/.pages
+++ b/docs/howto/openstack/cinder/.pages
@@ -1,7 +1,8 @@
-title: "Block storage (Cinder)"
+---
 nav:
   - index.md
   - resize-volumes.md
   - encrypted-volumes.md
   - retype-volumes.md
   - sync-volumes.md
+title: "Block storage (Cinder)"

--- a/docs/howto/openstack/designate/.pages
+++ b/docs/howto/openstack/designate/.pages
@@ -1,5 +1,6 @@
-title: "DNS (Designate)"
+---
 nav:
   - index.md
   - zones.md
   - recordsets.md
+title: "DNS (Designate)"

--- a/docs/howto/openstack/glance/.pages
+++ b/docs/howto/openstack/glance/.pages
@@ -1,6 +1,7 @@
-title: Image management (Glance)
+---
 nav:
   - index.md
   - examine.md
   - filter.md
   - custom.md
+title: Image management (Glance)

--- a/docs/howto/openstack/keystone/.pages
+++ b/docs/howto/openstack/keystone/.pages
@@ -1,5 +1,6 @@
-title: Identity (Keystone)
+---
 nav:
   - index.md
   - app-creds.md
   - api-user-passwd.md
+title: Identity (Keystone)

--- a/docs/howto/openstack/neutron/.pages
+++ b/docs/howto/openstack/neutron/.pages
@@ -1,4 +1,4 @@
-title: "Networking (Neutron)"
+---
 nav:
   - index.md
   - new-network.md
@@ -6,3 +6,4 @@ nav:
   - multiple-public-ips.md
   - vpnaas.md
   - delete-network.md
+title: "Networking (Neutron)"

--- a/docs/howto/openstack/nova/.pages
+++ b/docs/howto/openstack/nova/.pages
@@ -1,4 +1,4 @@
-title: Compute (Nova)
+---
 nav:
   - index.md
   - new-server.md
@@ -10,3 +10,4 @@ nav:
   - boot-image-volume.md
   - restore-srv-to-snap.md
   - rescue-server.md
+title: Compute (Nova)

--- a/docs/howto/openstack/octavia/.pages
+++ b/docs/howto/openstack/octavia/.pages
@@ -1,7 +1,8 @@
-title: Load balancing (Octavia)
+---
 nav:
   - index.md
   - lbaas-tcp.md
   - tls-lb.md
   - lbaas-l7pol.md
   - metrics.md
+title: Load balancing (Octavia)

--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -1,4 +1,4 @@
-title: "Reference"
+---
 nav:
   - index.md
   - features
@@ -12,3 +12,4 @@ nav:
   - versions
   - api
   - legal
+title: "Reference"

--- a/docs/reference/api/.pages
+++ b/docs/reference/api/.pages
@@ -1,1 +1,2 @@
+---
 title: API Reference

--- a/docs/reference/api/cc/.pages
+++ b/docs/reference/api/cc/.pages
@@ -1,1 +1,2 @@
+---
 title: "Cleura Cloud REST API"

--- a/docs/reference/api/openstack/.pages
+++ b/docs/reference/api/openstack/.pages
@@ -1,1 +1,2 @@
+---
 title: OpenStack API

--- a/docs/reference/features/.pages
+++ b/docs/reference/features/.pages
@@ -1,5 +1,6 @@
-title: "Feature Support"
+---
 arrange:
   - index.md
   - public.md
   - compliant.md
+title: "Feature Support"

--- a/docs/reference/quotas/.pages
+++ b/docs/reference/quotas/.pages
@@ -1,4 +1,3 @@
 ---
 nav:
   - "OpenStack": openstack.md
-

--- a/docs/reference/versions/.pages
+++ b/docs/reference/versions/.pages
@@ -1,5 +1,6 @@
-title: "Service Versions"
+---
 arrange:
   - index.md
   - public.md
   - compliant.md
+title: "Service Versions"

--- a/docs/tutorials/.pages
+++ b/docs/tutorials/.pages
@@ -1,3 +1,4 @@
+---
 nav:
   - index.md
   - Ansible: ansible.md


### PR DESCRIPTION
The `.pages` files (read by the awesome-pages plugin) are YAML files without a `.yaml` or `.yml` extension, causing them not to be caught by YAMLLint.

* Add a `yaml-files` option to `.yamllint`.
* Add `.pages` to `yaml-files`.
* Fix YAML errors.

Reference:
https://yamllint.readthedocs.io/en/stable/configuration.html#yaml-files-extensions
