### PR TITLE
build: Disable MkDocs/ProperDocs warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = yamllint,flake8,bashate,markdownlint,build
 [testenv]
 skip_install = True
 passenv = DOCS_*
+setenv =
+  DISABLE_MKDOCS_2_WARNING = true
 deps = -rrequirements.txt
 commands =
   mkdocs {posargs}


### PR DESCRIPTION
Pass `DISABLE_MKDOCS_2_WARNING=true` to the testenv, disabling the pesky ProperDocs warning.
