### PR TITLE
feat: Add the invite-only admonition to all AI-related pages

### DIFF
--- a/docs/background/ai/tokens.md
+++ b/docs/background/ai/tokens.md
@@ -1,5 +1,8 @@
 # Tokens
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 Tokens are the basic units of text that an LLM processes.
 You can think of them as the fundamental building blocks LLMs use to process input and produce output.
 

--- a/docs/howto/ai/api-keys.md
+++ b/docs/howto/ai/api-keys.md
@@ -3,6 +3,9 @@ description: How to manage Cleura AI API keys via the dashboard
 ---
 # Managing API keys
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 Whether you want to integrate a specific set of {{brand_ai}} LLMs into your application or web site, or access the models via a third party application you prefer, you first have to create an API key.
 
 ## Creating an API key

--- a/docs/howto/ai/models.md
+++ b/docs/howto/ai/models.md
@@ -3,6 +3,9 @@ description: Learn about each LLM Cleura AI supports
 ---
 # Reviewing available models
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 To see all available {{brand_ai}} LLMs, first navigate to the [{{gui}}](https://{{gui_domain}}) start page, and log into your {{brand}} account.
 Then, expand the vertical navigation bar at the left, click on _AI_ and select _On-Demand Models_.
 

--- a/docs/howto/ai/openwebui.md
+++ b/docs/howto/ai/openwebui.md
@@ -3,6 +3,9 @@ description: How to access Cleura AI LLMs via an Open WebUI instance
 ---
 # Accessing via Open WebUI
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 Open WebUI is an open source web dashboard for interacting with LLMs via an OpenAI‑compatible API.
 
 You can have an Open WebUI instance up and running in minutes, by [deploying it from the Marketplace](../marketplace/openwebui/deploy.md).

--- a/docs/howto/ai/playground.md
+++ b/docs/howto/ai/playground.md
@@ -3,6 +3,9 @@ description: How to use the Cleura AI playground
 ---
 # Using the playground
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 In the {{gui}}, expand the vertical navigation bar at the left, click on _AI_, and then choose _On-Demand Models_.
 
 ![All available on-demand LLMs](assets/on-demand-models_light.png#only-light)

--- a/docs/howto/ai/stt.md
+++ b/docs/howto/ai/stt.md
@@ -3,6 +3,9 @@ description: How to use the AI API via Python, for speech-to-text
 ---
 # Using audio transcription
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 Of the [on-demand models](../../reference/ai/llms.md) we provide, `faster-whisper-large-v3` is optimized for speech-to-text (STT) applications, also known as _audio transcription_.
 
 More specifically, you may use {{brand}}'s OpenAI-compatible API to programmatically upload audio files and get back transcribed texts.

--- a/docs/howto/ai/token-usage.md
+++ b/docs/howto/ai/token-usage.md
@@ -3,6 +3,9 @@ description: How to monitor Cleura AI token usage
 ---
 # Monitoring token usage
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 In the {{gui}}, expand the vertical pane at the left and click on _AI_.
 To monitor your token usage, select _Dashboard_.
 On the main page, also called _Dashboard_, you have a graphical view of your token usage broken down by LLM.

--- a/docs/reference/ai/llms.md
+++ b/docs/reference/ai/llms.md
@@ -3,6 +3,9 @@ description: On-demand LLMs currently offered by Cleura AI
 ---
 # On-demand models
 
+??? note "Invite-only access"
+    Access to {{brand_ai}} services is currently invite-only.
+
 {{brand_ai}} currently offers five on-demand models.
 Refer to the table below for information about each model's origin, and their relative strengths.
 


### PR DESCRIPTION
Since the admonition at the top of the page functions somewhat akin to a banner, add it to **all** AI-related pages, as opposed to just the index pages of the affected sections.
