### PR TITLE
chore: Add further "public" placeholders

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ extra:
     domain: docs.cleura.cloud
     provider: plausible
   api_domain: "citycloud.com"
-  api_region: "Public"
+  api_region: "Kna1"
   brand: "Cleura Cloud"
   brand_ai: "Cleura AI"
   brand_compliant: "Cleura Compliant Cloud"
@@ -87,7 +87,7 @@ plugins:
       on_undefined: strict
   - mike:
       alias_type: symlink
-      canonical_version: kna1
+      canonical_version: public
       version_selector: true
   - privacy
   - search

--- a/theme/main.html
+++ b/theme/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block outdated %}
-  You are viewing documentation for the <strong>Kna1</strong> region.
+  You are viewing documentation for the <strong>Public</strong> region.
 {% endblock %}


### PR DESCRIPTION
Set the placeholders/markers for the public branch to the theme reference and canonical version.
    
Reset api_domain to Kna1, so that the link check does not break on PRs.

(This PR primarily exists to test the protected branch workflow on this new branch.)