### PR TITLE
fix: Reset api_domain to Sto1HS

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ extra:
     domain: docs.cleura.cloud
     provider: plausible
   api_domain: "citycloud.com"
-  api_region: "Compliant"
+  api_region: "Sto1HS"
   brand: "Cleura Cloud"
   brand_ai: "Cleura AI"
   brand_compliant: "Cleura Compliant Cloud"


### PR DESCRIPTION
This is to avoid breaking link checks on PRs, now that the `compliant` branch is protected.

See also: 668f9dea269b3259694406a99d704a00d125da12