### PR TITLE
Structure new subcategory and indices

### DIFF
--- a/docs/howto/.nav.yml
+++ b/docs/howto/.nav.yml
@@ -8,5 +8,6 @@ nav:
   - ai
   - marketplace
   - account-billing
+  - observability
   - support
 title: "How-To Guides"

--- a/docs/howto/observability/.nav
+++ b/docs/howto/observability/.nav
@@ -1,0 +1,2 @@
+---
+title: Observability

--- a/docs/howto/observability/index.md
+++ b/docs/howto/observability/index.md
@@ -1,0 +1,22 @@
+---
+description: In Cleura Cloud, alerting and service status notifications are provided through managed status pages and monitoring integrations.
+---
+
+# Service Status
+
+{{page.meta.description}}
+
+We use iLert as our primary platform for service status pages and alerting aggregation.  
+This section of the documentation focuses on how customers interact with our **Public and Compliant status pages**, including how to subscribe to notifications and manage their alerting-related account settings.
+
+The guides in this section are written specifically for **end users**, not administrators, and intentionally avoid exposing or documenting the full iLert interface. Instead, they cover only the functionality required to:
+
+- Subscribe to service status updates
+- Configure notification channels (email, SMS, etc.)
+- Manage account security settings such as passwords and two-factor authentication
+- Maintain access to restricted or customer-specific status pages
+
+At present, this section documents **status page–related alerting only**.  
+Over time, it may be expanded to include additional alerting and monitoring topics such as metrics dashboards, heartbeat monitors, or other observability integrations, where relevant to customers.
+
+Each guide in this section provides clear, step-by-step instructions and assumes no prior knowledge of the underlying alerting platform.

--- a/docs/howto/observability/status-pages/.nav
+++ b/docs/howto/observability/status-pages/.nav
@@ -1,0 +1,4 @@
+---
+nav:
+  - index.md
+title: Status pages

--- a/docs/howto/observability/status-pages/index.md
+++ b/docs/howto/observability/status-pages/index.md
@@ -1,0 +1,47 @@
+---
+description: In Cleura Cloud, service availability and incident communication are published through public and access-restricted status pages.
+---
+
+# Status Pages
+
+{{page.meta.description}}
+
+
+We provide two types of service status pages to communicate availability, ongoing incidents, and maintenance events.
+
+## Public Status Page
+
+The [**public status page**]({{statuspage_domain.public}}) is openly accessible and intended for general visibility into the overall health of our cloud services and platforms.
+It provides high-level information about platform components, ongoing incidents, and scheduled maintenance that may impact multiple users.
+
+No account is required to view the public status page.  
+However, optional notification subscriptions may be available depending on the service.
+
+## Compliant Status Page
+
+The [**compliant status page**]({{statuspage_domain.compliant}}) is available only to invited users and is intended for customers operating in regulated or compliance-sensitive environments.
+
+This status page includes:
+
+- Customer-specific services or regions
+- Access-controlled notification subscriptions
+
+Access is granted by invitation and requires a user account.  
+Only limited account functionality is exposed, strictly for notification management and security settings.
+
+You can request access to our compliant status page via our support portal, assuming the following is true:
+
+- You are an authenticated user in our support portal.
+- Your account is subscribed to a compliant support package.
+- Your account has compliant cloud regions provisioned, or we can confirm there will be soon.
+
+## Scope of This Section
+
+The guides in this section explain how to:
+
+- Subscribe to public and restricted status pages
+- Manage user account and notification settings related to status pages
+
+Administrative configuration and internal alerting logic are intentionally out of scope.
+
+Future documentation in this section may expand to cover additional alerting or monitoring surfaces, where relevant to customers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ extra:
       url: "https://s3-kna1.citycloud.com/6a5aa55d8f094a13ae18199639aa72c2:cleura.files/Cleura-Form-Transfer-Ownership.pdf"
   rest_api: "Cleura Cloud REST API"
   rest_api_domain: "rest.cleura.cloud"
+  statuspage_domain:
+    public: "https://status.cleura.cloud"
+    compliant: "https://status.compliant.cleura.cloud"
   support: "Service Center"
   support_domain: "servicecenter.cleura.cloud"
   support_email: "support@cleura.com"


### PR DESCRIPTION
New documentation section split into three PR phases (1/3).
This PR lays the foundation for the new documentation, setting up the new subcategories and nav configs, including addition of new `extras` variable for the URLs of the public and compliant Cleura status pages.

Pushed as a draft until the other PR's with dependencies linked are created.