### PR TITLE
fix: Suggest pip-installing cleura-openstackclient

### DIFF
--- a/docs/howto/getting-started/enable-openstack-cli.md
+++ b/docs/howto/getting-started/enable-openstack-cli.md
@@ -131,7 +131,7 @@ Some examples follow.
     ```
 === "Python package"
     ```bash
-    pip install python-openstackclient
+    pip install cleura-openstackclient
     ```
 
 ### Testing access

--- a/docs/howto/object-storage/swift/index.md
+++ b/docs/howto/object-storage/swift/index.md
@@ -16,7 +16,7 @@ Use either the package manager of your operating system, or `pip`:
     install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-swiftclient
+    pip install cleura-openstackclient
     ```
 
 ## Availability

--- a/docs/howto/openstack/barbican/index.md
+++ b/docs/howto/openstack/barbican/index.md
@@ -11,7 +11,7 @@ To manage secrets with Barbican, you will need the `openstack` command line inte
 You can install them both with the following commands:
 
 ```bash
-pip install python-openstackclient python-barbicanclient
+pip install cleura-openstackclient
 ```
 
 On Debian/Ubuntu platforms, you may also install these utilities via their APT packages:

--- a/docs/howto/openstack/designate/index.md
+++ b/docs/howto/openstack/designate/index.md
@@ -22,5 +22,5 @@ For that, use either the package manager of your operating system, or `pip`:
     This particular Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-designateclient
+    pip install cleura-openstackclient
     ```

--- a/docs/howto/openstack/neutron/vpnaas.md
+++ b/docs/howto/openstack/neutron/vpnaas.md
@@ -19,7 +19,7 @@ Use either the package manager of your operating system or `pip`:
     This Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-neutronclient
+    pip install cleura-openstackclient
     ```
 
 ## Creating a VPN connection between two regions

--- a/docs/howto/openstack/octavia/lbaas-l7pol.md
+++ b/docs/howto/openstack/octavia/lbaas-l7pol.md
@@ -32,7 +32,7 @@ For that, use either the package manager of your operating system or `pip`:
     can install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-octaviaclient
+    pip install cleura-openstackclient
     ```
 
 ## Assumptions and scenario

--- a/docs/howto/openstack/octavia/lbaas-tcp.md
+++ b/docs/howto/openstack/octavia/lbaas-tcp.md
@@ -22,7 +22,7 @@ For that, use either the package manager of your operating system or `pip`:
     This particular Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-octaviaclient
+    pip install cleura-openstackclient
     ```
 
 ## Scenario and terminology

--- a/docs/howto/openstack/octavia/metrics.md
+++ b/docs/howto/openstack/octavia/metrics.md
@@ -23,7 +23,7 @@ For that, use either the package manager of your operating system, or `pip`:
     This particular Python module is unavailable via `brew`, but you can install it via `pip`.
 === "Python Package"
     ```bash
-    pip install python-octaviaclient
+    pip install cleura-openstackclient
     ```
 
 ## Assumptions and scenario


### PR DESCRIPTION
Rather than suggesting to use `pip` to install various upstream OpenStack clients as needed, suggest the `cleura-openstackclient` metapackage instead.
